### PR TITLE
fix(apps/prod/bazel-remote): add label to service monitor resource

### DIFF
--- a/apps/prod/bazel-remote/config.yaml
+++ b/apps/prod/bazel-remote/config.yaml
@@ -11,7 +11,7 @@ spec:
     name: flux-system
     namespace: flux-system
   path: ./apps/staging/bazel-remote/config
-  prune: true
+  prune: false
   postBuild:
     substituteFrom:
       - kind: Secret

--- a/apps/prod/bazel-remote/release.yaml
+++ b/apps/prod/bazel-remote/release.yaml
@@ -13,4 +13,4 @@ spec:
     name: flux-system
     namespace: flux-system
   path: ./apps/staging/bazel-remote/release
-  prune: true
+  prune: false

--- a/apps/prod/bazel-remote/release/release.yaml
+++ b/apps/prod/bazel-remote/release/release.yaml
@@ -35,6 +35,8 @@ spec:
         emptyDir: {}
     serviceMonitor:
       enabled: true
+      additionalLabels:
+        release: kps
     volumeMounts:
       - name: brc-cache
         mountPath: /cache


### PR DESCRIPTION
before rename or move, we should disable garbage collection.

Ref: fluxcd [faq](https://fluxcd.io/flux/faq/#how-can-i-safely-move-resources-from-one-dir-to-another)