### PR TITLE
fix(apps/prod/jenkins): fix jenkins-tidb namespace's annotations

### DIFF
--- a/apps/prod/jenkins/post/tidb/namespace.yaml
+++ b/apps/prod/jenkins/post/tidb/namespace.yaml
@@ -6,4 +6,4 @@ metadata:
     scheduler.alpha.kubernetes.io/defaultTolerations:
       '[{"operator": "Equal", "effect": "NoSchedule", "key": "dedicated",
       "value": "test-infra"}]'
-    scheduler.alpha.kubernetes.io/node-selector: enable-ci=true
+    scheduler.alpha.kubernetes.io/node-selector: resourcepool=ksyun-ci


### PR DESCRIPTION
why: current rook-ceph fs plugin daemonset not automatic deploy pod on nodes which owned label `enable-ci=true`