### PR TITLE
chore(apps/prod): increase cache pvc and obc size

### DIFF
--- a/apps/prod/bazel-remote/pre/obc.yaml
+++ b/apps/prod/bazel-remote/pre/obc.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: apps
 spec:
   additionalConfig:
-    maxSize: 2500Gi
+    maxSize: 5000Gi
   bucketName: ci-bazel-remote-cache
   storageClassName: ceph-bucket

--- a/apps/prod/jenkins/post/_base/cronjob-go-caches.yaml
+++ b/apps/prod/jenkins/post/_base/cronjob-go-caches.yaml
@@ -27,10 +27,10 @@ spec:
                       echo "cleaned."
                   fi
 
-                  # clean cache when usage > 80%
+                  # clean build cache when usage > 50%
                   gocache_used_percent=$(df -h | grep "$(go env GOCACHE)" | awk '{print $5}' | grep -oE "[0-9]+")
                   echo "mount of $(go env GOCACHE) usage is ${gocache_used_percent}%"
-                  if (( gocache_used_percent > 80 )); then
+                  if (( gocache_used_percent > 50 )); then
                       echo "go build cache is too large, I am cleaning it."
                       go clean -cache -x
                       echo "cleaned."

--- a/apps/prod/jenkins/post/_base/pvc.yaml
+++ b/apps/prod/jenkins/post/_base/pvc.yaml
@@ -20,7 +20,7 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: 500Gi
+      storage: 600Gi
   storageClassName: ceph-filesystem
   volumeMode: Filesystem
 ---


### PR DESCRIPTION
- s3 bucket size for bazel remote cache 2.5T to 5T
- gocache pvc from 500GB to 600GB