### PR TITLE
feat(apps/prod/greenhouse): use local path volume

### DIFF
--- a/apps/prod/greenhouse/release.yaml
+++ b/apps/prod/greenhouse/release.yaml
@@ -40,12 +40,9 @@ spec:
       accessMode: ReadWriteOnce
       size: 3Ti
       volumes:
-      - name: new-cache
+      - name: cache
         hostPath:
           path: /data/brc
-      mounts:
-       - mountPath: /new-data
-         name: new-cache
     serviceMonitor:
       enabled: true
       additionalLabels:


### PR DESCRIPTION
before: using ceph-block, read speed is 120MB/s tested with rsync