### PR TITLE
feat(apps/staging/jenkins): perfer to git url to avoid github api rate limit

### DIFF
--- a/apps/staging/jenkins/release/values-JCasC.yaml
+++ b/apps/staging/jenkins/release/values-JCasC.yaml
@@ -249,12 +249,8 @@ controller:
                 modernSCM:
                   libraryPath: libraries/tipipeline
                   scm:
-                    github:
-                      configuredByUrl: true
-                      repositoryUrl: "https://github.com/PingCAP-QE/ci"
-                      # useless but required.
-                      repoOwner: "PingCAP-QE"
-                      repository: "ci"
+                    git:
+                      remote: "https://github.com/PingCAP-QE/ci"
               cachingConfiguration:
                 refreshTimeMinutes: 60
                 excludedVersionsStr: 'feature/ fix/ bugfix/'


### PR DESCRIPTION
unauthenticated will be limit to 60/hour.