### PR TITLE
feat(apps/prod/jenkins/release): switch first go proxy to cluster service

### DIFF
--- a/apps/prod/jenkins/release/values-JCasC.yaml
+++ b/apps/prod/jenkins/release/values-JCasC.yaml
@@ -206,7 +206,7 @@ controller:
             - envVars:
                 env:
                   - key: "GOPROXY"
-                    value: "http://goproxy.pingcap.net,https://proxy.golang.org,direct"
+                    value: "http://goproxy.apps.svc,https://proxy.golang.org,direct"
       build-failure-analyzer: |
         unclassified:
           buildFailureAnalyzer:


### PR DESCRIPTION
from goproxy.pingcap.net to goproxy.apps.svc