### PR TITLE
fix(apps/prod/greenhouse): fix evicting args for local path device mount

### DIFF
--- a/apps/prod/greenhouse/release.yaml
+++ b/apps/prod/greenhouse/release.yaml
@@ -30,6 +30,10 @@ spec:
     ignoreFailures: false
   values:
     replicaCount: 2
+    run:
+      minPercentBlocksFree: 10 # %10
+      evictUntilPercentBlocksFree: 20 # %20
+      diskCheckInterval: 30s
     resources:
       limits:
         cpu: "8"


### PR DESCRIPTION
Why:
when device usage got by `df` was 99%, but cap - used was greater than 5%, greenhouse will not evict the contents.