### PR TITLE
fix(apps/prod/goproxy): adjust upstream goproxy

### DIFF
--- a/apps/prod/goproxy/deployment.yaml
+++ b/apps/prod/goproxy/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         args:
           - "-listen=0.0.0.0:8080"
           - "-cacheDir=/opt/cache"
-          - "-proxy=https://proxy.golang.org"
+          - "-proxy=https://goproxy.io"
         readinessProbe:
           tcpSocket:
             port: 8080


### PR DESCRIPTION
use https://goproxy.io instead of https://proxy.golang.org