### PR TITLE
feat(apps/prod/greenhouse): increase block pvc size to 4T

### DIFF
--- a/apps/prod/greenhouse/release.yaml
+++ b/apps/prod/greenhouse/release.yaml
@@ -42,11 +42,7 @@ spec:
       enabled: true
       storageClass: ceph-block
       accessMode: ReadWriteOnce
-      size: 3Ti
-      volumes:
-      - name: cache
-        hostPath:
-          path: /data/brc
+      size: 4Ti
     serviceMonitor:
       enabled: true
       additionalLabels:


### PR DESCRIPTION
migrate from disk to pvc to avoid size limit in single host.