### PR TITLE
fix(apps/prod/goproxy): adjust upstream to proxy.golang.org

### DIFF
--- a/apps/prod/goproxy/deployment.yaml
+++ b/apps/prod/goproxy/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         args:
           - "-listen=0.0.0.0:8080"
           - "-cacheDir=/opt/cache"
-          - "-proxy=https://goproxy.io"
+          - "-proxy=https://proxy.golang.org"
         readinessProbe:
           tcpSocket:
             port: 8080


### PR DESCRIPTION
Upsteam goproxy.io causes a checksum error, adjust to use proxy.golang.org