### PR TITLE
feat(staging/apps/jenkins): add jenkins plugin timestamper

### DIFF
--- a/apps/prod/jenkins/release/values-controller-plugins.yaml
+++ b/apps/prod/jenkins/release/values-controller-plugins.yaml
@@ -86,10 +86,6 @@ controller:
       source:
         # renovate: datasource=jenkins-plugins depName=generic-webhook-trigger
         version: 1.85.2
-    - artifactId: timestamper
-      source:
-        # renovate: datasource=jenkins-plugins depName=timestamper
-        version: 1.21
   # for plugin build-failure-analyzer
   #   Exporting to prometheus
   #   Ref: https://github.com/jenkinsci/build-failure-analyzer-plugin/blob/master/docs/metrics.md

--- a/apps/prod/jenkins/release/values-controller-plugins.yaml
+++ b/apps/prod/jenkins/release/values-controller-plugins.yaml
@@ -86,6 +86,10 @@ controller:
       source:
         # renovate: datasource=jenkins-plugins depName=generic-webhook-trigger
         version: 1.85.2
+    - artifactId: timestamper
+      source:
+        # renovate: datasource=jenkins-plugins depName=timestamper
+        version: 1.21
   # for plugin build-failure-analyzer
   #   Exporting to prometheus
   #   Ref: https://github.com/jenkinsci/build-failure-analyzer-plugin/blob/master/docs/metrics.md

--- a/apps/staging/jenkins/release/values-controller-plugins.yaml
+++ b/apps/staging/jenkins/release/values-controller-plugins.yaml
@@ -88,7 +88,7 @@ controller:
         version: 1.85.2
     - artifactId: timestamper
       source:
-        # renovate: datasource=jenkins-plugins depName=generic-webhook-trigger
+        # renovate: datasource=jenkins-plugins depName=timestamper
         version: 1.21
   # for plugin build-failure-analyzer
   #   Exporting to prometheus

--- a/apps/staging/jenkins/release/values-controller-plugins.yaml
+++ b/apps/staging/jenkins/release/values-controller-plugins.yaml
@@ -86,6 +86,10 @@ controller:
       source:
         # renovate: datasource=jenkins-plugins depName=generic-webhook-trigger
         version: 1.85.2
+    - artifactId: timestamper
+      source:
+        # renovate: datasource=jenkins-plugins depName=generic-webhook-trigger
+        version: 1.21
   # for plugin build-failure-analyzer
   #   Exporting to prometheus
   #   Ref: https://github.com/jenkinsci/build-failure-analyzer-plugin/blob/master/docs/metrics.md


### PR DESCRIPTION
Add plugin timestamper to adds timestamps to the console output of Jenkins jobs for more user-friendly issue targeting.

Example
```shell
21:51:15  Started by user anonymous
21:51:15  Building on master
21:51:17  Finished: SUCCESS
```