### PR TITLE
feat(staging/apps/jenkins): add plugin timestamper v1.21

### DIFF
--- a/apps/staging/jenkins/release/values-controller-plugins.yaml
+++ b/apps/staging/jenkins/release/values-controller-plugins.yaml
@@ -70,6 +70,10 @@ controller:
       source:
         # renovate: datasource=jenkins-plugins depName=generic-webhook-trigger
         version: 1.85.2
+    - artifactId: timestamper
+      source:
+        # renovate: datasource=jenkins-plugins depName=timestamper
+        version: 1.21
   # for plugin build-failure-analyzer
   #   Exporting to prometheus
   #   Ref: https://github.com/jenkinsci/build-failure-analyzer-plugin/blob/master/docs/metrics.md


### PR DESCRIPTION
Add plugin timestamper to adds timestamps to the console output of Jenkins jobs for more user-friendly issue targeting.

Example
```shell
21:51:15  Started by user anonymous
21:51:15  Building on master
21:51:17  Finished: SUCCESS
```