### PR TITLE
fix(staging/apps/jenkins): upgrade plugin kubernetes version to fix client error

### DIFF
--- a/apps/staging/jenkins/release/values-controller-plugins.yaml
+++ b/apps/staging/jenkins/release/values-controller-plugins.yaml
@@ -18,7 +18,7 @@ controller:
     - artifactId: kubernetes
       source:
         # renovate: datasource=jenkins-plugins depName=kubernetes
-        version: 3734.v562b_b_a_627ea_c
+        version: 3802.vb_b_600831fcb_3
     - artifactId: configuration-as-code
       source:
         # renovate: datasource=jenkins-plugins depName=configuration-as-code


### PR DESCRIPTION
Related to https://github.com/jenkinsci/kubernetes-plugin/pull/1291.
Upgrade plugin kubernetes version to fix compatibility with Kubernetes client 6.x.
Error message
```shell
2023-01-10 15:49:01 |  hudson.remoting.ProxyException: io.fabric8.kubernetes.client.KubernetesClientException: No httpclient implementations found on the context classloader, please ensure your classpath includes an implementation jar
2023-01-10 15:49:01 |  	at io.fabric8.kubernetes.client.utils.HttpClientUtils.getHttpClientFactory(HttpClientUtils.java:164)
2023-01-10 15:49:01 |  	at io.fabric8.kubernetes.client.utils.HttpClientUtils.createHttpClient(HttpClientUtils.java:145)
2023-01-10 15:49:01 |  	at io.fabric8.kubernetes.client.DefaultKubernetesClient.<init>(DefaultKubernetesClient.java:56)
2023-01-10 15:49:01 |  	at io.fabric8.kubernetes.client.DefaultKubernetesClient.<init>(DefaultKubernetesClient.java:48)
2023-01-10 15:49:01 |  	at org.csanchez.jenkins.plugins.kubernetes.PodTemplateUtils.parseFromYaml(PodTemplateUtils.java:602)
2023-01-10 15:49:01 |  	at org.csanchez.jenkins.plugins.kubernetes.PodTemplateUtils.validateYamlContainerNames(PodTemplateUtils.java:639)
2023-01-10 15:49:01 |  	at org.csanchez.jenkins.plugins.kubernetes.PodTemplateUtils.validateYamlContainerNames(PodTemplateUtils.java:629)
2023-01-10 15:49:01 |  	at org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.start(PodTemplateStepExecution.java:145)
```