### PR TITLE
chore(apps/dev/prow): bump hook images to `v20230303-8e409833dd-dirty`

### DIFF
--- a/apps/dev/prow/release/release.yaml
+++ b/apps/dev/prow/release/release.yaml
@@ -80,6 +80,9 @@ spec:
         repository: ticommunityinfra/tide
         tag: v20230112-192a3d7605
     hook:
+      image:
+        repository: ticommunityinfra/hook
+        tag: v20230303-8e409833dd-dirty
       ingress:
         enabled: false
     jenkinsOperator:


### PR DESCRIPTION
Signed-off-by: wuhuizuo <wuhuizuo@126.com>