### PR TITLE
Revert "chore(apps/dev/prow): bump hook images to `v20230303-8e409833dd-dirty`"

### DIFF
--- a/apps/dev/prow/release/release.yaml
+++ b/apps/dev/prow/release/release.yaml
@@ -80,9 +80,6 @@ spec:
         repository: ticommunityinfra/tide
         tag: v20230112-192a3d7605
     hook:
-      image:
-        repository: ticommunityinfra/hook
-        tag: v20230303-8e409833dd-dirty
       ingress:
         enabled: false
     jenkinsOperator:


### PR DESCRIPTION
Reverts PingCAP-QE/ee-ops#412