### PR TITLE
fix(apps/staging/tekton/setup): fix tekton config field `spec.pipeline.default-timeout-minutes`

### DIFF
--- a/apps/staging/tekton/setup/operator-config.yaml
+++ b/apps/staging/tekton/setup/operator-config.yaml
@@ -26,7 +26,7 @@ spec:
     metrics.taskrun.level: taskrun
 
     ###### optional items #######
-    default-timeout-minutes: "60" # unit is minutes, default timeout for TaskRun and PipelineRun.
+    default-timeout-minutes: 60 # unit is minutes, default timeout for TaskRun and PipelineRun.
     default-service-account: "default"
     # default empty dir, can not be shared between tasks.
     default-task-run-workspace-binding: >


### PR DESCRIPTION
It should be a `int` type.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>