### PR TITLE
fix(apps/staging/tekton/setup): rollback tekton operator to `v0.65.1`

### DIFF
--- a/apps/staging/tekton/setup/kustomization.yaml
+++ b/apps/staging/tekton/setup/kustomization.yaml
@@ -3,6 +3,6 @@ kind: Kustomization
 resources:
   - namespace.yaml
   # renovate: datasource=github-releases depName=tektoncd/operator versioning=semver
-  - https://github.com/tektoncd/operator/releases/download/v0.66.0/release.yaml
+  - https://github.com/tektoncd/operator/releases/download/v0.65.1/release.yaml
   - operator-config.yaml
   - ingress-dashboard.yaml


### PR DESCRIPTION
current min kubernetes version need `1.24.0`

Signed-off-by: wuhuizuo <wuhuizuo@126.com>