### PR TITLE
refactor(apps/dev,apps/staging): upgrade prow to standalone mode

### DIFF
--- a/apps/_crds/prow/kustomization.yaml
+++ b/apps/_crds/prow/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://raw.githubusercontent.com/kubernetes/test-infra/master/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml

--- a/apps/dev/kustomization.yaml
+++ b/apps/dev/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 resources:
   - ../_base
   - namespace.yaml
+  - prow-crd.yaml
   - prow

--- a/apps/dev/prow-crd.yaml
+++ b/apps/dev/prow-crd.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: prow-crd
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./apps/_crds/prow
+  prune: true
+  force: true

--- a/apps/dev/prow/release/release.yaml
+++ b/apps/dev/prow/release/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: prow
-      version: 0.7.2
+      version: 0.8.0
       sourceRef:
         kind: HelmRepository
         name: ee-ops

--- a/apps/staging/kustomization.yaml
+++ b/apps/staging/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - namespace.yaml
   - jenkins
   - tekton
+  - prow-crd.yaml
   - prow
   - mongodb
   - greenhouse

--- a/apps/staging/prow-crd.yaml
+++ b/apps/staging/prow-crd.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: prow-crd
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./apps/_crds/prow
+  prune: true
+  force: true

--- a/apps/staging/prow/release/release.yaml
+++ b/apps/staging/prow/release/release.yaml
@@ -11,7 +11,7 @@ spec:
   chart:
     spec:
       chart: prow
-      version: 0.7.5
+      version: 0.8.0
       sourceRef:
         kind: HelmRepository
         name: ee-ops


### PR DESCRIPTION
if we do not change it, it can only deploy one helm release in a cluster.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>