### PR TITLE
chore(apps/gcp/prow/release): update deployment for jenkins operator to skip report

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -99,10 +99,11 @@ spec:
         tag: latest
     jenkinsOperator:
       enabled: true
+      skipReport: true
+      dryRun: false
       image:
         repository: ticommunityinfra/jenkins-operator
         tag: v20230323-3ade632
-      dryRun: false
       jenkinsUrl: ${JENKINS_BASE_URL}
       auth:
         secretName: ${JENKINS_OPERATOR_AUTH_SEC_NAME}


### PR DESCRIPTION
Reverts PingCAP-QE/ee-ops#492