### PR TITLE
chore(apps/gcp/prow/release): bump prow release to v0.8.1

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: prow
-      version: 0.8.0
+      version: 0.8.1
       sourceRef:
         kind: HelmRepository
         name: ee-ops


### PR DESCRIPTION
It will only update configmap, will not affect the pods.