### PR TITLE
feat(apps/staging): add buildfarm app to research dev-test

### DIFF
--- a/apps/staging/buildfarm/configs/config.yaml
+++ b/apps/staging/buildfarm/configs/config.yaml
@@ -1,0 +1,144 @@
+digestFunction: SHA256
+defaultActionTimeout: 600
+maximumActionTimeout: 3600
+maxEntrySizeBytes: 2147483648 # 2 * 1024 * 1024 * 1024
+prometheusPort: 9090
+server:
+  instanceType: SHARD
+  name: shard
+  actionCacheReadOnly: false
+  port: 8980
+  grpcMetrics:
+    enabled: false
+    provideLatencyHistograms: false
+  maxInboundMessageSizeBytes: 0
+  maxInboundMetadataSize: 0
+  casWriteTimeout: 3600
+  bytestreamTimeout: 3600
+  sslCertificatePath:
+  sslPrivateKeyPath:
+  runDispatchedMonitor: true
+  dispatchedMonitorIntervalSeconds: 1
+  runOperationQueuer: true
+  ensureOutputsPresent: false
+  maxCpu: 0
+  maxRequeueAttempts: 100
+  useDenyList: true
+  grpcTimeout: 3600
+  executeKeepaliveAfterSeconds: 60
+  recordBesEvents: false
+  clusterId: local
+  cloudRegion: us-east-1
+  caches:
+    directoryCacheMaxEntries: 10000
+    commandCacheMaxEntries: 10000
+    digestToActionCacheMaxEntries: 10000
+    recentServedExecutionsCacheMaxEntries: 10000
+  admin:
+    deploymentEnvironment: AWS
+    clusterEndpoint: "grpc://buildfarm-server-service:8980"
+    enableGracefulShutdown: false
+  metrics:
+    publisher: LOG
+    logLevel: FINEST
+    topic: test
+    topicMaxConnections: 1000
+    secretName: test
+backplane:
+  type: SHARD
+  redisUri: "redis://buildfarm-redis-cluster-service:6379"
+  redisPassword:
+  redisNodes:
+  jedisPoolMaxTotal: 4000
+  workersHashName: "Workers"
+  workerChannel: "WorkerChannel"
+  actionCachePrefix: "ActionCache"
+  actionCacheExpire: 2419200 # 4 weeks
+  actionBlacklistPrefix: "ActionBlacklist"
+  actionBlacklistExpire: 3600 # 1 hour
+  invocationBlacklistPrefix: "InvocationBlacklist"
+  operationPrefix: "Operation"
+  operationExpire: 604800 # 1 week
+  preQueuedOperationsListName: "{Arrival}:PreQueuedOperations"
+  processingListName: "{Arrival}:ProcessingOperations"
+  processingPrefix: "Processing"
+  processingTimeoutMillis: 20000
+  queuedOperationsListName: "{Execution}:QueuedOperations"
+  dispatchingPrefix: "Dispatching"
+  dispatchingTimeoutMillis: 10000
+  dispatchedOperationsHashName: "DispatchedOperations"
+  operationChannelPrefix: "OperationChannel"
+  casPrefix: "ContentAddressableStorage"
+  casExpire: 604800 # 1 week
+  subscribeToBackplane: true
+  runFailsafeOperation: true
+  maxQueueDepth: 100000
+  maxPreQueueDepth: 1000000
+  priorityQueue: false
+  priorityPollIntervalMillis: 100
+  timeout: 10000
+  maxAttempts: 20
+  cacheCas: false
+  queues:
+    - name: "cpu"
+      allowUnmatched: true
+      properties:
+        - name: "min-cores"
+          value: "*"
+        - name: "max-cores"
+          value: "*"
+worker:
+  port: 8980
+  publicName: "buildfarm-shard-worker-service:8980"
+  grpcMetrics:
+    enabled: false
+    provideLatencyHistograms: false
+  capabilities:
+    cas: true
+    execution: true
+  root: "/tmp/worker"
+  inlineContentLimit: 1048567 # 1024 * 1024
+  operationPollPeriod: 1
+  dequeueMatchSettings:
+    acceptEverything: true
+    allowUnmatched: false
+  storages:
+    - type: FILESYSTEM
+      path: "cache"
+      maxSizeBytes: 21474836480 # 2 * 1024 * 1024 * 1024
+      fileDirectoriesIndexInMemory: false
+      skipLoad: false
+      hexBucketLevels: 0
+      execRootCopyFallback: false
+      target:
+      publishTtlMetric: false
+  executeStageWidth: 10
+  inputFetchStageWidth: 10
+  inputFetchDeadline: 60
+  linkInputDirectories: true
+  realInputDirectories:
+    - "external"
+  execOwner:
+  defaultMaxCores: 0
+  limitGlobalExecution: false
+  onlyMulticoreTests: false
+  allowBringYourOwnContainer: false
+  errorOperationRemainingResources: false
+  sandboxSettings:
+    alwaysUse: false
+    selectForBlockNetwork: false
+    selectForTmpFs: false
+  executionPolicies:
+    - name: test
+      executionWrapper:
+        path: "/"
+        arguments:
+executionWrappers:
+  cgroups: /usr/bin/cgexec
+  unshare: /usr/bin/unshare
+  linuxSandbox: /app/build_buildfarm/linux-sandbox
+  asNobody: /app/build_buildfarm/as-nobody
+  processWrapper: /app/build_buildfarm/process-wrapper
+  skipSleep: /app/build_buildfarm/skip_sleep
+  skipSleepPreload: /app/build_buildfarm/skip_sleep_preload.so
+  delay: /app/build_buildfarm/delay.sh

--- a/apps/staging/buildfarm/kustomization.yaml
+++ b/apps/staging/buildfarm/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- redis-cluster.yaml
+- server.yaml
+- shard-worker.yaml
+configMapGenerator:
+  - name: buildfarm
+    options:
+      disableNameSuffixHash: true
+    files:
+      - configs/config.yaml

--- a/apps/staging/buildfarm/redis-cluster.yaml
+++ b/apps/staging/buildfarm/redis-cluster.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: buildfarm-redis-cluster
+  labels:
+    name: buildfarm-redis-cluster
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: buildfarm-redis-cluster
+  template:
+    metadata:
+      labels:
+        name: buildfarm-redis-cluster
+    spec:
+      containers:
+      - name: redis-cluster
+        image: redis:5.0.4
+        ports:
+        - containerPort: 6379
+        resources:
+          limits:
+            cpu: '1'
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: buildfarm-redis-cluster-service
+spec:
+  selector:
+    name: buildfarm-redis-cluster
+  ports:
+    - protocol: TCP
+      port: 6379
+      targetPort: 6379

--- a/apps/staging/buildfarm/server.yaml
+++ b/apps/staging/buildfarm/server.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: buildfarm-server
+  labels:
+    name: buildfarm-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: buildfarm-server
+  template:
+    metadata:
+      labels:
+        name: buildfarm-server
+    spec:
+      containers:
+        - name: server
+          image: bazelbuild/buildfarm-server:latest
+          args:
+            - /etc/buildfarm/config.yaml
+          ports:
+            - containerPort: 8980
+              name: comm
+            - containerPort: 9090
+              name: metrics
+          env:
+            - name: REDIS_URI
+              value: "redis://buildfarm-redis-cluster-service:6379"
+          volumeMounts:
+            - mountPath: /etc/buildfarm
+              name: config
+          resources:
+            limits:
+              cpu: "8"
+              memory: 8Gi
+      volumes:
+        - name: config
+          configMap:
+            name: buildfarm
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: buildfarm-server-service
+spec:
+  selector:
+    name: buildfarm-server
+  ports:
+    - name: "communication"
+      protocol: TCP
+      port: 8980
+      targetPort: comm
+    - name: "metrics"
+      protocol: TCP
+      port: 9090
+      targetPort: metrics

--- a/apps/staging/buildfarm/shard-worker.yaml
+++ b/apps/staging/buildfarm/shard-worker.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: buildfarm-shard-worker
+  labels:
+    name: buildfarm-shard-worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: buildfarm-shard-worker
+  template:
+    metadata:
+      labels:
+        name: buildfarm-shard-worker
+    spec:
+      containers:
+        - name: shard-worker
+          image: bazelbuild/buildfarm-worker:latest
+          args:
+            - /etc/buildfarm/config.yaml
+          volumeMounts:
+            - mountPath: /etc/buildfarm
+              name: config
+          resources:
+            limits:
+              cpu: "2"
+              memory: 4Gi
+          ports:
+            - containerPort: 8980
+              name: comm
+            - containerPort: 9090
+              name: metrics
+          env:
+            - name: REDIS_URI
+              value: "redis://buildfarm-redis-cluster-service:6379"
+      volumes:
+        - name: config
+          configMap:
+            name: buildfarm
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: buildfarm-shard-worker-service
+spec:
+  selector:
+    name: buildfarm-shard-worker
+  ports:
+    - name: communication
+      protocol: TCP
+      port: 8980
+      targetPort: comm
+    - name: metrics
+      protocol: TCP
+      port: 9090
+      targetPort: metrics

--- a/apps/staging/kustomization.yaml
+++ b/apps/staging/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - goproxy
   - harbor
   - sec-service.yaml
+  - buildfarm


### PR DESCRIPTION
May be we should call it "local test", currently we foucs on tidb with bazel toolchain.
usage: bazel build --remote_executor=grpc://buildfarm-server.apps.svc:8980 //pkg

Signed-off-by: wuhuizuo <wuhuizuo@126.com>