### PR TITLE
fix(apps/staing/prow/post/configs/jobs): fix tekton job `codescan-security`

### DIFF
--- a/apps/staging/prow/post/configs/jobs/PingCAP-QE/ee-ops/job-prowjob.yaml
+++ b/apps/staging/prow/post/configs/jobs/PingCAP-QE/ee-ops/job-prowjob.yaml
@@ -6,4 +6,4 @@ presubmits:
       spec:
         containers:
           - image: alpine
-            command: ["/bin/date"]      
+            command: ["/bin/date"]

--- a/apps/staging/prow/post/configs/jobs/PingCAP-QE/ee-ops/job-tekton-pipeline-spec.yaml
+++ b/apps/staging/prow/post/configs/jobs/PingCAP-QE/ee-ops/job-tekton-pipeline-spec.yaml
@@ -14,7 +14,7 @@ presubmits:
                   name: codescan-security-prow
                 params:
                   - name: job-spec
-                    value: $(params.JOB_SPEC)
+                    value: '$(params.JOB_SPEC)'
                   - name: server-base-url
                     value: http://sec-server.apps-sec.svc
                 


### PR DESCRIPTION
should using quato to wrap the param subtitue

Signed-off-by: wuhuizuo <wuhuizuo@126.com>