### PR TITLE
fix(apps/staing/prow/post/configs/jobs): fix tekton job `codescan-security`

### DIFF
--- a/apps/staging/prow/post/configs/jobs/PingCAP-QE/ee-ops/job-tekton-pipeline-spec.yaml
+++ b/apps/staging/prow/post/configs/jobs/PingCAP-QE/ee-ops/job-tekton-pipeline-spec.yaml
@@ -16,6 +16,7 @@ presubmits:
             tasks:
               - name: codescan-security-for-prow
                 taskRef:
+                  kind: ClusterTask
                   name: codescan-security-prow
                 params:
                   - name: job-spec

--- a/apps/staging/tekton/configs/pipelines/codescan-security.yaml
+++ b/apps/staging/tekton/configs/pipelines/codescan-security.yaml
@@ -15,6 +15,7 @@ spec:
   tasks:
     - name: codescan-security
       taskRef:
+        kind: ClusterTask
         name: codescan-security
       params:
         - name: git-refs


### PR DESCRIPTION
because it using cluster task type.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>