### PR TITLE
fix(apps/staging/buildfarm): fix services ports and increase replicas for workers

### DIFF
--- a/apps/staging/buildfarm/server.yaml
+++ b/apps/staging/buildfarm/server.yaml
@@ -23,7 +23,7 @@ spec:
             - containerPort: 8980
               name: comm
             - containerPort: 9090
-              name: metrics
+              name: metr
           env:
             - name: REDIS_URI
               value: "redis://buildfarm-redis-cluster-service:6379"
@@ -47,11 +47,11 @@ spec:
   selector:
     name: buildfarm-server
   ports:
-    - name: "communication"
+    - name: communication
       protocol: TCP
       port: 8980
       targetPort: comm
-    - name: "metrics"
+    - name: metrics
       protocol: TCP
       port: 9090
-      targetPort: metrics
+      targetPort: metr

--- a/apps/staging/buildfarm/shard-worker.yaml
+++ b/apps/staging/buildfarm/shard-worker.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     name: buildfarm-shard-worker
 spec:
-  replicas: 1
+  replicas: 4
   selector:
     matchLabels:
       name: buildfarm-shard-worker

--- a/apps/staging/buildfarm/shard-worker.yaml
+++ b/apps/staging/buildfarm/shard-worker.yaml
@@ -30,7 +30,7 @@ spec:
             - containerPort: 8980
               name: comm
             - containerPort: 9090
-              name: metrics
+              name: metr
           env:
             - name: REDIS_URI
               value: "redis://buildfarm-redis-cluster-service:6379"
@@ -54,4 +54,4 @@ spec:
     - name: metrics
       protocol: TCP
       port: 9090
-      targetPort: metrics
+      targetPort: metr


### PR DESCRIPTION
Changes: 
- fix service ports about dup name issues.
- scale for workers to make the deployment as shard mode.