### PR TITLE
chore(apps/staging/buildfarm): increase cpu and memory resource for shard workers

### DIFF
--- a/apps/staging/buildfarm/configs/config.yaml
+++ b/apps/staging/buildfarm/configs/config.yaml
@@ -46,7 +46,7 @@ server:
     secretName: test
 backplane:
   type: SHARD
-  redisUri: "redis://buildfarm-redis-cluster-service:6379"
+  redisUri: "redis://buildfarm-redis-cluster:6379"
   redisPassword:
   redisNodes:
   jedisPoolMaxTotal: 4000

--- a/apps/staging/buildfarm/redis-cluster.yaml
+++ b/apps/staging/buildfarm/redis-cluster.yaml
@@ -30,7 +30,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: buildfarm-redis-cluster-service
+  name: buildfarm-redis-cluster
 spec:
   selector:
     name: buildfarm-redis-cluster

--- a/apps/staging/buildfarm/server.yaml
+++ b/apps/staging/buildfarm/server.yaml
@@ -26,7 +26,7 @@ spec:
               name: metr
           env:
             - name: REDIS_URI
-              value: "redis://buildfarm-redis-cluster-service:6379"
+              value: "redis://buildfarm-redis-cluster:6379"
           volumeMounts:
             - mountPath: /etc/buildfarm
               name: config

--- a/apps/staging/buildfarm/shard-worker.yaml
+++ b/apps/staging/buildfarm/shard-worker.yaml
@@ -33,7 +33,7 @@ spec:
               name: metr
           env:
             - name: REDIS_URI
-              value: "redis://buildfarm-redis-cluster-service:6379"
+              value: "redis://buildfarm-redis-cluster:6379"
       volumes:
         - name: config
           configMap:

--- a/apps/staging/buildfarm/shard-worker.yaml
+++ b/apps/staging/buildfarm/shard-worker.yaml
@@ -24,8 +24,8 @@ spec:
               name: config
           resources:
             limits:
-              cpu: "2"
-              memory: 4Gi
+              cpu: "8"
+              memory: 16Gi
           ports:
             - containerPort: 8980
               name: comm


### PR DESCRIPTION
## Changes

1. rename redis service name
2. increase resource for shard workers

## Why
1. no need to add `service` suffix to service name since it's type is `Service`.
2. it will failed with OOM killing when build heavy targets.
