### PR TITLE
fix(apps/staging/prow/release): bump chatgpt plugin's image tag to `v20230511-97a0d53`

### DIFF
--- a/apps/staging/prow/release/release.yaml
+++ b/apps/staging/prow/release/release.yaml
@@ -90,7 +90,7 @@ spec:
         replicaCount: 1
         image:
           repository: ticommunityinfra/chatgpt
-          tag: v20230505-46ce180
+          tag: v20230511-97a0d53
         ports:
           http: 8888
         args:


### PR DESCRIPTION
The new image solved the large message limits of open AI server.