### PR TITLE
fix(apps/staging/prow/release): bump chatgpt plugin's image tag to `v20230511-0058871`

### DIFF
--- a/apps/staging/prow/release/release.yaml
+++ b/apps/staging/prow/release/release.yaml
@@ -90,7 +90,7 @@ spec:
         replicaCount: 1
         image:
           repository: ticommunityinfra/chatgpt
-          tag: v20230511-d5656f4
+          tag: v20230511-0058871
         ports:
           http: 8888
         args:


### PR DESCRIPTION
Signed-off-by: wuhuizuo <wuhuizuo@126.com>