### PR TITLE
fix(apps): bump chatgpt plugin's image tag to `v20230511-83c30cb`

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -116,7 +116,7 @@ spec:
         replicaCount: 1
         image:
           repository: ticommunityinfra/chatgpt
-          tag: v20230505-46ce180
+          tag: v20230511-83c30cb
         ports:
           http: 8888
         args:

--- a/apps/staging/prow/release/release.yaml
+++ b/apps/staging/prow/release/release.yaml
@@ -90,7 +90,7 @@ spec:
         replicaCount: 1
         image:
           repository: ticommunityinfra/chatgpt
-          tag: v20230511-565d3ec
+          tag: v20230511-83c30cb
         ports:
           http: 8888
         args:


### PR DESCRIPTION
changes make to `gcp` and `staging` environments.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>