### PR TITLE
fix(gcp/prow/release): bump image ticommunityinfra/tichi-issue-triage-plugin to `v2.4.3`

### DIFF
--- a/apps/dev/prow/release/release.yaml
+++ b/apps/dev/prow/release/release.yaml
@@ -285,7 +285,7 @@ spec:
           name: prow-hook
         image:
           repository: ticommunityinfra/tichi-issue-triage-plugin
-          tag: v2.4.2
+          tag: v2.4.3
         args:
           - --dry-run=false
           - --github-app-id=$(GITHUB_APP_ID)

--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -336,7 +336,7 @@ spec:
           name: prow-hook
         image:
           repository: ticommunityinfra/tichi-issue-triage-plugin
-          tag: v2.4.2
+          tag: v2.4.3
         args:
           - --dry-run=false
           - --github-app-id=$(GITHUB_APP_ID)


### PR DESCRIPTION
It will fix the issue of triage plugin: add `need-cherry-pick-to-*` label on PR for version not in maintain list when affect-x.y label exists.

