### PR TITLE
Revert "Revert "Revert "chore(apps/prod/buildbarn): disable head method"""

### DIFF
--- a/apps/prod/buildbarn/release.yaml
+++ b/apps/prod/buildbarn/release.yaml
@@ -24,39 +24,6 @@ spec:
     enable: true
     ignoreFailures: false
   values:
-    frontend:
-        conf: |-
-          local common = import 'common.libsonnet';
-          {
-            global: common.global,
-            grpcServers: [{
-              listenAddresses: [':8980'],
-              authenticationPolicy: { allow: {} },
-            }],
-            schedulers: {
-              '': { 
-                endpoint: { 
-                  address: 'buildbarn-scheduler:8982',
-                  addMetadataJmespathExpression: '{
-                    "build.bazel.remote.execution.v2.requestmetadata-bin": incomingGRPCMetadata."build.bazel.remote.execution.v2.requestmetadata-bin"
-                  }',
-                } 
-              },
-            },
-            maximumMessageSizeBytes: common.maximumMessageSizeBytes,
-            contentAddressableStorage: {
-              backend: common.blobstore.contentAddressableStorage,
-              getAuthorizer: { allow: {} },
-              putAuthorizer: { allow: {} },
-              findMissingAuthorizer: { deny: {} },
-            },
-            actionCache: {
-              backend: common.blobstore.actionCache,
-              getAuthorizer: { allow: {} },
-              putAuthorizer: { allow: {} },
-            },
-            executeAuthorizer: { allow: {} },
-          }
     commonConf: |-
       {
         global: {
@@ -73,20 +40,20 @@ spec:
         },
         blobstore: {
           contentAddressableStorage: {        
-            sharding: {
-              hashInitialization: 11946695773637837490,
-              shards: [
-                {
-                  backend: { grpc: { address: 'buildbarn-storage-0.buildbarn-storage:8981' } },
-                  weight: 1,
-                },
-                {
-                  backend: { grpc: { address: 'buildbarn-storage-1.buildbarn-storage:8981' } },
-                  weight: 1,
-                },
-              ],
+                sharding: {
+                  hashInitialization: 11946695773637837490,
+                  shards: [
+                    {
+                      backend: { grpc: { address: 'buildbarn-storage-0.buildbarn-storage:8981' } },
+                      weight: 1,
+                    },
+                    {
+                      backend: { grpc: { address: 'buildbarn-storage-1.buildbarn-storage:8981' } },
+                      weight: 1,
+                    },
+                  ],
+                },          
             },
-          },
           actionCache: {
             completenessChecking: {
               backend: {


### PR DESCRIPTION
Reverts PingCAP-QE/ee-ops#570

It take no effects:

```log
2023/06/03 09:00:47 Downloading https://releases.bazel.build/5.3.2/release/bazel-5.3.2-linux-x86_64...
Extracting Bazel installation...
Starting local Bazel server and connecting to it...
INFO: Invocation ID: 1419b813-6b69-4847-b9e6-5843aebd0f09
INFO: Reading 'startup' options from /apps/tidb/.bazelrc: --host_jvm_args=-Xmx5g, --unlimit_coredumps
INFO: Options provided by the client:
  Inherited 'common' options: --isatty=1 --terminal_columns=96
INFO: Reading rc options for 'build' from /apps/tidb/.bazelrc:
  'build' options: --announce_rc --experimental_guard_against_concurrent_changes --experimental_remote_merkle_tree_cache --java_language_version=17 --java_runtime_version=17 --tool_java_language_version=17 --tool_java_runtime_version=17 --incompatible_strict_action_env --incompatible_enable_cc_toolchain_resolution
INFO: Analyzed target //tidb-server:tidb-server (1149 packages loaded, 15738 targets configured).
INFO: Found 1 target...
ERROR: /root/.cache/bazel/_bazel_root/1bd316308e353cfc3853da5b25307bbe/external/go_sdk/BUILD.bazel:47:15: GoToolchainBinaryCompile external/go_sdk/builder.a failed: (Exit 34): PERMISSION_DENIED: Authorization of instance name "remote-execution": Permission denied
ERROR: /root/.cache/bazel/_bazel_root/1bd316308e353cfc3853da5b25307bbe/external/go_sdk/BUILD.bazel:47:15: GoToolchainBinaryCompile external/go_sdk/builder.a failed: (Exit 34): PERMISSION_DENIED: Authorization of instance name "remote-execution": Permission denied
Target //tidb-server:tidb-server failed to build
Use --verbose_failures to see the command lines of failed build steps.
ERROR: /apps/tidb/tidb-server/BUILD.bazel:68:10 GoCompilePkg tidb-server/tidb-server.a failed: (Exit 34): PERMISSION_DENIED: Authorization of instance name "remote-execution": Permission denied
INFO: Elapsed time: 171.090s, Critical Path: 0.13s
INFO: 7 processes: 7 internal.
FAILED: Build did NOT complete successfully
```