### PR TITLE
chore(apps/prod/prow/release): bump hook image to `ticommunityinfra/hook:v20230608-bd4b41b`

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -92,7 +92,7 @@ spec:
         enabled: false
       image:
         repository: ticommunityinfra/hook
-        tag: latest
+        tag: v20230608-bd4b41b
     pipeline:
       image:
         repository: ticommunityinfra/pipeline


### PR DESCRIPTION
update lgtm plugin.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>