### PR TITLE
Revert "chore(apps/prod/prow/release): bump hook image to `ticommunityinfra/hook:v20230608-bd4b41b`"

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -71,7 +71,7 @@ spec:
         enabled: false
       image:
         repository: ticommunityinfra/hook
-        tag: v20230608-bd4b41b
+        tag: latest
     pipeline:
       image:
         repository: ticommunityinfra/pipeline


### PR DESCRIPTION
Reverts PingCAP-QE/ee-ops#596