### PR TITLE
Revert " feature(apps/dev/prow/prow/release): bump hook's image tag to `v20230627-6810132`"

### DIFF
--- a/apps/dev/prow/release/release.yaml
+++ b/apps/dev/prow/release/release.yaml
@@ -67,7 +67,7 @@ spec:
         enabled: false
       image:
         repository: ticommunityinfra/hook
-        tag: v20230627-6810132
+        tag: v20230627-6c92121
       additionalEnv:
         - name: STICKY_REPOS
           value: >-


### PR DESCRIPTION
Reverts PingCAP-QE/ee-ops#623