### PR TITLE
fix(apps/gc/prow/release): bump hook image tag to `v20230629-a95a424`

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -71,7 +71,7 @@ spec:
         enabled: false
       image:
         repository: ticommunityinfra/hook
-        tag: v20230608-bd4b41b
+        tag: v20230629-a95a424
       additionalEnv:
         - name: STICKY_REPOS
           value: >-


### PR DESCRIPTION
Changes:
- https://github.com/kubernetes/test-infra/pull/29762
- https://github.com/kubernetes/test-infra/pull/29970
- other changes from upstream.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>