### PR TITLE
fix(apps/gc/prow/release): bump image of jenkins-operator to `v20230630-a19314f`

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -89,7 +89,7 @@ spec:
       enabled: true
       image:
         repository: ticommunityinfra/jenkins-operator
-        tag: v20230323-3ade632
+        tag: v20230630-a19314f
       skipReport: false
       dryRun: false
       jenkinsUrl: ${JENKINS_BASE_URL}


### PR DESCRIPTION
Ref: https://github.com/PingCAP-QE/ci/issues/2186
Signed-off-by: wuhuizuo <wuhuizuo@126.com>