### PR TITLE
chore(apps/gc/prow/release): add lgtm sticky repo `pingcap/tidb-binlog`

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -84,6 +84,7 @@ spec:
             pingcap/tiflash
             pingcap/tiflow
             pingcap/tidb
+            pingcap/tidb-binlog
             pingcap/docs
             pingcap/docs-cn
             pingcap/docs-tidb-operator


### PR DESCRIPTION
`tidb-binlog` team has not enough people on code reviewing for new commits when the PR has LGTMed.
They want make it sticked on lgtm label.