### PR TITLE
fix(apps/gcp/prow/release): bump tide image to `v20230706-5546ede`

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -68,7 +68,7 @@ spec:
     tide:
       image:
         repository: ticommunityinfra/tide
-        tag: v20230323-3ade632
+        tag: v20230706-5546ede
     hook:
       ingress:
         enabled: false


### PR DESCRIPTION
Ref https://github.com/ti-community-infra/test-infra/pull/35

Signed-off-by: wuhuizuo <wuhuizuo@126.com>