### PR TITLE
fix(apps/gcp/prow/release): bump hook image to `v20230719-dcd9b36`

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: prow
-      version: 0.9.7
+      version: 0.9.8
       sourceRef:
         kind: HelmRepository
         name: ee-ops
@@ -74,7 +74,7 @@ spec:
         enabled: false
       image:
         repository: ticommunityinfra/hook
-        tag: v20230629-a95a424
+        tag: v20230719-dcd9b36
       kubeconfigSecret: prow-kubeconfig
       additionalArgs:
         - --kubeconfig=/etc/kubeconfig/config


### PR DESCRIPTION
Signed-off-by: wuhuizuo <wuhuizuo@126.com>