### PR TITLE
feat: add ccache pvc

### DIFF
--- a/apps/prod/ccache-pvc/base/kustomization.yaml
+++ b/apps/prod/ccache-pvc/base/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- pvc.yaml

--- a/apps/prod/ccache-pvc/base/pvc.yaml
+++ b/apps/prod/ccache-pvc/base/pvc.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cargo-home
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 32Gi
+  storageClassName: ceph-filesystem
+  volumeMode: Filesystem
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ccache-dir
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 64Gi
+  storageClassName: ceph-filesystem
+  volumeMode: Filesystem
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rustup-home
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 32Gi
+  storageClassName: ceph-filesystem
+  volumeMode: Filesystem

--- a/apps/prod/ccache-pvc/kustomization.yaml
+++ b/apps/prod/ccache-pvc/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- platforms/linux-amd64
+- platforms/linux-arm64
+namespace: jenkins-cd

--- a/apps/prod/ccache-pvc/platforms/linux-amd64/kustomization.yaml
+++ b/apps/prod/ccache-pvc/platforms/linux-amd64/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- ../../base
+namesuffix: "-linux-amd64"

--- a/apps/prod/ccache-pvc/platforms/linux-arm64/kustomization.yaml
+++ b/apps/prod/ccache-pvc/platforms/linux-arm64/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- ../../base
+namesuffix: "-linux-arm64"

--- a/apps/prod/kustomization.yaml
+++ b/apps/prod/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
   - brc
   - buildbarn
   - prow-worker
+  - ccache-pvc


### PR DESCRIPTION
# Why:
- tiflash ccache need pvc to share cache
- rust-toolchain and cargo can be cached

# How:
- add kustomization

# Testing:
- tested in https://cd.pingcap.net/blue/organizations/jenkins/debug%2Fbuild-tiflash/detail/build-tiflash/79/pipeline/241