### PR TITLE
fix(apps/prod/jenkins): add node affinity on clean cache cronjob

### DIFF
--- a/apps/prod/jenkins/pre/cronjobs.yaml
+++ b/apps/prod/jenkins/pre/cronjobs.yaml
@@ -10,6 +10,15 @@ spec:
       template:
         spec:
           restartPolicy: OnFailure
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: kubernetes.io/arch
+                        operator: In
+                        values:
+                          - amd64
           containers:
             - name: deno
               image: "denoland/deno:1.25.1"

--- a/apps/staging/jenkins/pre/obc/cronjobs.yaml
+++ b/apps/staging/jenkins/pre/obc/cronjobs.yaml
@@ -10,6 +10,15 @@ spec:
       template:
         spec:
           restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: kubernetes.io/arch
+                        operator: In
+                        values:
+                          - amd64
           containers:
             - name: deno
               image: "denoland/deno:1.26.1"


### PR DESCRIPTION
Add node affinity on clean cache cronjob to void scheduling to arm64 nodes that may cause task failures.