### PR TITLE
fix(charts/jenkins): correct ui-test pod image tag

### DIFF
--- a/charts/jenkins/templates/tests/jenkins-test.yaml
+++ b/charts/jenkins/templates/tests/jenkins-test.yaml
@@ -31,7 +31,7 @@ spec:
         name: tools
   containers:
     - name: {{ .Release.Name }}-ui-test
-      image: {{ .Values.controller.image }}:{{ .Chart.AppVersion }}-{{ .Values.controller.tagLabel }}
+      image: {{ .Values.controller.image }}:{{ .Values.controller.tag }}
       command: ["/tools/bats/bin/bats", "-t", "/tests/run.sh"]
       volumeMounts:
       - mountPath: /tests


### PR DESCRIPTION
Use the value `Values.controller.tag` as the correct pod image tag.