### PR TITLE
Revert "fix(apps/gcp/prow/release): bump hook image to `v20230719-dcd9b36`"

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: prow
-      version: 0.9.8
+      version: 0.9.7
       sourceRef:
         kind: HelmRepository
         name: ee-ops
@@ -74,7 +74,7 @@ spec:
         enabled: false
       image:
         repository: ticommunityinfra/hook
-        tag: v20230719-dcd9b36
+        tag: v20230629-a95a424
       kubeconfigSecret: prow-kubeconfig
       additionalArgs:
         - --kubeconfig=/etc/kubeconfig/config

--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -74,7 +74,7 @@ spec:
         enabled: false
       image:
         repository: ticommunityinfra/hook
-        tag: v20230629-a95a424
+        tag: v20230719-dcd9b36
       kubeconfigSecret: prow-kubeconfig
       additionalArgs:
         - --kubeconfig=/etc/kubeconfig/config


### PR DESCRIPTION
Reverts PingCAP-QE/ee-ops#646