### PR TITLE
fix(apps/dev/prow/release): bump hook image to `v20230808-5546ede`

### DIFF
--- a/apps/dev/prow/release/release.yaml
+++ b/apps/dev/prow/release/release.yaml
@@ -78,7 +78,7 @@ spec:
         enabled: false
       image:
         repository: ticommunityinfra/hook
-        tag: v20230719-dcd9b36
+        tag: v20230808-5546ede
       additionalEnv:
         - name: STICKY_REPOS
           value: >-


### PR DESCRIPTION
Signed-off-by: wuhuizuo <wuhuizuo@126.com>