### PR TITLE
fix(charts/jenkins/templates/test): bump image `bats/bats` to `v1.10.0`

### DIFF
--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -40,4 +40,4 @@ sources:
   - https://github.com/jenkinsci/docker-inbound-agent
   - https://github.com/maorfr/kube-tasks
   - https://github.com/jenkinsci/configuration-as-code-plugin
-version: 4.1.21
+version: 4.1.22

--- a/charts/jenkins/templates/tests/jenkins-test.yaml
+++ b/charts/jenkins/templates/tests/jenkins-test.yaml
@@ -17,7 +17,7 @@ spec:
   {{- end }}
   initContainers:
     - name: "test-framework"
-      image: "bats/bats:1.2.1"
+      image: "bats/bats:1.10.0"
       command:
         - "bash"
         - "-c"

--- a/charts/jenkins/templates/tests/jenkins-test.yaml
+++ b/charts/jenkins/templates/tests/jenkins-test.yaml
@@ -17,7 +17,7 @@ spec:
   {{- end }}
   initContainers:
     - name: "test-framework"
-      image: "bats/bats:1.10.0"
+      image: "bats/bats:v1.10.0"
       command:
         - "bash"
         - "-c"


### PR DESCRIPTION
The `1.2.0` has no arm64 container image published, and the `1.10.0` has multi-arch image published.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>