### PR TITLE
fix: tibuild support dot in branch name

### DIFF
--- a/apps/prod/tibuild/deployment.yaml
+++ b/apps/prod/tibuild/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app: tibuild
     spec:
       containers:
-      - image: hub.pingcap.net/tibuild/tibuild:afb7bba
+      - image: hub.pingcap.net/tibuild/tibuild:ba975d9
         imagePullPolicy: Always
         name: tibuild
         ports:
@@ -43,6 +43,8 @@ spec:
         - name: configs
           mountPath: "/app/configs"
           readOnly: true
+      nodeSelector:
+        kubernetes.io/arch: "amd64"
       volumes:
       - name: configs
         secret:


### PR DESCRIPTION
Why:
- update tibuild to fix gitRef regex