### PR TITLE
chore(apps/dev/prow/release): bump image for hook to `v20230912-1e90cdf6eb`

### DIFF
--- a/apps/dev/prow/release/release.yaml
+++ b/apps/dev/prow/release/release.yaml
@@ -95,7 +95,7 @@ spec:
         enabled: false
       image:
         repository: ticommunityinfra/hook
-        tag: v20230912-2028ed09dd-dirty
+        tag: v20230912-1e90cdf6eb
       resources:
         requests:
           cpu: "100m"


### PR DESCRIPTION
Signed-off-by: wuhuizuo <wuhuizuo@126.com>