### PR TITLE
chore(apps/gcp/prow/release): bump image for hook to `v20230922-c60c561dfe`

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -74,7 +74,7 @@ spec:
         enabled: false
       image:
         repository: ticommunityinfra/hook
-        tag: v20230912-1e90cdf6eb
+        tag: v20230922-c60c561dfe
       kubeconfigSecret: prow-kubeconfig
       additionalArgs:
         - --kubeconfig=/etc/kubeconfig/config


### PR DESCRIPTION
tested in dev env.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>