### PR TITLE
chore(apps/dev/prow/release): bump image for hook to `v20230927-01102e9c12`

### DIFF
--- a/apps/dev/prow/release/release.yaml
+++ b/apps/dev/prow/release/release.yaml
@@ -95,7 +95,7 @@ spec:
         enabled: false
       image:
         repository: ticommunityinfra/hook
-        tag: v20230922-c60c561dfe
+        tag: v20230927-01102e9c12
       resources:
         requests:
           cpu: "100m"


### PR DESCRIPTION
lazy match default regex for full config type OWNERS files

Signed-off-by: wuhuizuo <wuhuizuo@126.com>