### PR TITLE
chore(apps/gcp/prow/release): bump image for hook to `v20230927-01102e9c12`

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -74,7 +74,7 @@ spec:
         enabled: false
       image:
         repository: ticommunityinfra/hook
-        tag: v20230922-c60c561dfe
+        tag: v20230927-01102e9c12
       kubeconfigSecret: prow-kubeconfig
       additionalArgs:
         - --kubeconfig=/etc/kubeconfig/config


### PR DESCRIPTION
- [x] tested in dev env.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>