### PR TITLE
fix(apps/gcp): fix prowjob crd

### DIFF
--- a/apps/gcp/prow-crd.yaml
+++ b/apps/gcp/prow-crd.yaml
@@ -10,6 +10,6 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  path: ./apps/_crds/prow
+  path: ./apps/_crds/prow/hacked
   prune: true
   force: true


### PR DESCRIPTION
## Why

The validation of tekton pipeline spec is wrong, and is not fixed in prow upstream.

but here has a fixed version: https://github.com/kyma-project/test-infra/raw/main/prow/cluster/components/prowjob_customresourcedefinition.yaml

## Tests

- [x] We have tested it in `prow-dev.tidb.net` instance