### PR TITLE
feat(apps/prod/tekton/setup): bump tekton-operator to v0.57.0

### DIFF
--- a/apps/prod/tekton/setup/kustomization.yaml
+++ b/apps/prod/tekton/setup/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   # renovate: datasource=github-releases depName=tektoncd/operator versioning=semver
-  # - https://github.com/tektoncd/operator/releases/download/v0.55.1/release.yaml
+  # - https://github.com/tektoncd/operator/releases/download/v0.57.0/release.yaml
   # we fixed the image tag to make it runable on arm64 nodes:
   #   gcr.io/tekton-releases/dogfooding/tkn
   - operator-release.yaml 

--- a/apps/prod/tekton/setup/operator-release.yaml
+++ b/apps/prod/tekton/setup/operator-release.yaml
@@ -7,8 +7,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.56.0
-    version: v0.56.0
+    operator.tekton.dev/release: v0.57.0
+    version: v0.57.0
   name: tektonchains.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -45,8 +45,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.56.0
-    version: v0.56.0
+    operator.tekton.dev/release: v0.57.0
+    version: v0.57.0
   name: tektonconfigs.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -83,8 +83,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.56.0
-    version: v0.56.0
+    operator.tekton.dev/release: v0.57.0
+    version: v0.57.0
   name: tektondashboards.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -121,8 +121,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.56.0
-    version: v0.56.0
+    operator.tekton.dev/release: v0.57.0
+    version: v0.57.0
   name: tektonhubs.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -165,8 +165,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.56.0
-    version: v0.56.0
+    operator.tekton.dev/release: v0.57.0
+    version: v0.57.0
   name: tektoninstallersets.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -200,8 +200,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.56.0
-    version: v0.56.0
+    operator.tekton.dev/release: v0.57.0
+    version: v0.57.0
   name: tektonpipelines.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -238,8 +238,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.56.0
-    version: v0.56.0
+    operator.tekton.dev/release: v0.57.0
+    version: v0.57.0
   name: tektonresults.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -333,8 +333,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.56.0
-    version: v0.56.0
+    operator.tekton.dev/release: v0.57.0
+    version: v0.57.0
   name: tektontriggers.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -779,6 +779,16 @@ rules:
       - list
       - update
       - watch
+  - apiGroups:
+      - resolution.tekton.dev
+    resources:
+      - resolutionrequests
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -948,7 +958,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  version: v0.56.0
+  version: v0.57.0
 kind: ConfigMap
 metadata:
   labels:
@@ -970,7 +980,7 @@ kind: Service
 metadata:
   labels:
     app: tekton-pipelines-controller
-    version: v0.56.0
+    version: v0.57.0
   name: tekton-operator
   namespace: tekton-operator
 spec:
@@ -989,8 +999,8 @@ metadata:
   labels:
     app: tekton-operator
     name: tekton-operator-webhook
-    operator.tekton.dev/release: v0.56.0
-    version: v0.56.0
+    operator.tekton.dev/release: v0.57.0
+    version: v0.57.0
   name: tekton-operator-webhook
   namespace: tekton-operator
 spec:
@@ -1006,8 +1016,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    operator.tekton.dev/release: v0.56.0
-    version: v0.56.0
+    operator.tekton.dev/release: v0.57.0
+    version: v0.57.0
   name: tekton-operator
   namespace: tekton-operator
 spec:
@@ -1034,13 +1044,13 @@ spec:
             - name: OPERATOR_NAME
               value: tekton-operator
             - name: IMAGE_PIPELINES_PROXY
-              value: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/proxy-webhook:0.56.0@sha256:552d6d0af395582cf484b5d8eb59b5b45a580578e54147762b27ab47de37308d
+              value: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/proxy-webhook:v0.57.0@sha256:3e131ff228274d4500763cfe1c03a34aa3431780054fd6562e6ff44ebb723ba0
             - name: IMAGE_JOB_PRUNER_TKN
               value: gcr.io/tekton-releases/dogfooding/tkn:v20221201-ed0196540a
             - name: METRICS_DOMAIN
               value: tekton.dev/operator
             - name: VERSION
-              value: v0.56.0
+              value: v0.57.0
             - name: CONFIG_OBSERVABILITY_NAME
               value: tekton-config-observability
             - name: AUTOINSTALL_COMPONENTS
@@ -1053,7 +1063,7 @@ spec:
                 configMapKeyRef:
                   key: DEFAULT_TARGET_NAMESPACE
                   name: tekton-config-defaults
-          image: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/operator:0.56.0@sha256:060cc281db4918bb80a0e149df637f732ac7eeb2dd08ba3364f33e8a3c3cf846
+          image: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/operator:v0.57.0@sha256:ef1ac656d315e8608f5a0de6047a3a18f93f7c9b603a31ad603e599c608a7bc7
           imagePullPolicy: Always
           name: tekton-operator
       serviceAccountName: tekton-operator
@@ -1062,8 +1072,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    operator.tekton.dev/release: v0.56.0
-    version: v0.56.0
+    operator.tekton.dev/release: v0.57.0
+    version: v0.57.0
   name: tekton-operator-webhook
   namespace: tekton-operator
 spec:
@@ -1091,7 +1101,7 @@ spec:
               value: tekton-operator-webhook-certs
             - name: METRICS_DOMAIN
               value: tekton.dev/operator
-          image: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/webhook:0.56.0@sha256:9cbcffecda4b66572e0db5b9ba1fa75d7047aa37aab6f5720f726f2b95f7df63
+          image: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/webhook:v0.57.0@sha256:54b97b512ae083ed1979700817724a370a4ab9266f5ff2463a8c069deace4124
           name: tekton-operator-webhook
           ports:
             - containerPort: 8443


### PR DESCRIPTION
it bump the pipeline component from `v0.34.1` to `v0.35.0`.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>