### PR TITLE
feat(apps/prod/tekton/setup): bump tekton-operator to v0.58.0

### DIFF
--- a/apps/prod/tekton/setup/operator-release.yaml
+++ b/apps/prod/tekton/setup/operator-release.yaml
@@ -7,8 +7,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.57.0
-    version: v0.57.0
+    operator.tekton.dev/release: v0.58.0
+    version: v0.58.0
   name: tektonchains.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -45,8 +45,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.57.0
-    version: v0.57.0
+    operator.tekton.dev/release: v0.58.0
+    version: v0.58.0
   name: tektonconfigs.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -83,8 +83,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.57.0
-    version: v0.57.0
+    operator.tekton.dev/release: v0.58.0
+    version: v0.58.0
   name: tektondashboards.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -121,8 +121,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.57.0
-    version: v0.57.0
+    operator.tekton.dev/release: v0.58.0
+    version: v0.58.0
   name: tektonhubs.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -165,8 +165,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.57.0
-    version: v0.57.0
+    operator.tekton.dev/release: v0.58.0
+    version: v0.58.0
   name: tektoninstallersets.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -200,8 +200,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.57.0
-    version: v0.57.0
+    operator.tekton.dev/release: v0.58.0
+    version: v0.58.0
   name: tektonpipelines.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -238,8 +238,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.57.0
-    version: v0.57.0
+    operator.tekton.dev/release: v0.58.0
+    version: v0.58.0
   name: tektonresults.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -333,8 +333,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.57.0
-    version: v0.57.0
+    operator.tekton.dev/release: v0.58.0
+    version: v0.58.0
   name: tektontriggers.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -912,7 +912,6 @@ data:
   DEFAULT_TARGET_NAMESPACE: tekton-pipelines
 kind: ConfigMap
 metadata:
-  annotations: {}
   labels:
     operator.tekton.dev/release: devel
   name: tekton-config-defaults
@@ -958,7 +957,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  version: v0.57.0
+  version: v0.58.0
 kind: ConfigMap
 metadata:
   labels:
@@ -980,7 +979,7 @@ kind: Service
 metadata:
   labels:
     app: tekton-pipelines-controller
-    version: v0.57.0
+    version: v0.58.0
   name: tekton-operator
   namespace: tekton-operator
 spec:
@@ -999,8 +998,8 @@ metadata:
   labels:
     app: tekton-operator
     name: tekton-operator-webhook
-    operator.tekton.dev/release: v0.57.0
-    version: v0.57.0
+    operator.tekton.dev/release: v0.58.0
+    version: v0.58.0
   name: tekton-operator-webhook
   namespace: tekton-operator
 spec:
@@ -1016,8 +1015,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    operator.tekton.dev/release: v0.57.0
-    version: v0.57.0
+    operator.tekton.dev/release: v0.58.0
+    version: v0.58.0
   name: tekton-operator
   namespace: tekton-operator
 spec:
@@ -1044,13 +1043,13 @@ spec:
             - name: OPERATOR_NAME
               value: tekton-operator
             - name: IMAGE_PIPELINES_PROXY
-              value: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/proxy-webhook:v0.57.0@sha256:3e131ff228274d4500763cfe1c03a34aa3431780054fd6562e6ff44ebb723ba0
+              value: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/proxy-webhook:0.58.0@sha256:394f35e6392e602f1a90e2649ee0138ae5de96466bb5b6f6b6ef9e2afe1999f9
             - name: IMAGE_JOB_PRUNER_TKN
               value: gcr.io/tekton-releases/dogfooding/tkn:v20221201-ed0196540a
             - name: METRICS_DOMAIN
               value: tekton.dev/operator
             - name: VERSION
-              value: v0.57.0
+              value: v0.58.0
             - name: CONFIG_OBSERVABILITY_NAME
               value: tekton-config-observability
             - name: AUTOINSTALL_COMPONENTS
@@ -1063,7 +1062,7 @@ spec:
                 configMapKeyRef:
                   key: DEFAULT_TARGET_NAMESPACE
                   name: tekton-config-defaults
-          image: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/operator:v0.57.0@sha256:ef1ac656d315e8608f5a0de6047a3a18f93f7c9b603a31ad603e599c608a7bc7
+          image: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/operator:0.58.0@sha256:7555cb76311f4ba6bb41437750364e97a819f277de991e3765bcd13e00721fdd
           imagePullPolicy: Always
           name: tekton-operator
       serviceAccountName: tekton-operator
@@ -1072,8 +1071,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    operator.tekton.dev/release: v0.57.0
-    version: v0.57.0
+    operator.tekton.dev/release: v0.58.0
+    version: v0.58.0
   name: tekton-operator-webhook
   namespace: tekton-operator
 spec:
@@ -1101,7 +1100,7 @@ spec:
               value: tekton-operator-webhook-certs
             - name: METRICS_DOMAIN
               value: tekton.dev/operator
-          image: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/webhook:v0.57.0@sha256:54b97b512ae083ed1979700817724a370a4ab9266f5ff2463a8c069deace4124
+          image: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/webhook:0.58.0@sha256:9ce9c680430bcc7288bb6f920c7a969201fd0d9673df01b90e13a8de11cd5c02
           name: tekton-operator-webhook
           ports:
             - containerPort: 8443


### PR DESCRIPTION
it bump the dashboard component from `v0.25.0` to `v0.26.0`.