### PR TITLE
feat(apps/prod/tekton/setup): bump tekton-operator to v0.60.0

### DIFF
--- a/apps/prod/tekton/setup/kustomization.yaml
+++ b/apps/prod/tekton/setup/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   # renovate: datasource=github-releases depName=tektoncd/operator versioning=semver
-  # - https://github.com/tektoncd/operator/releases/download/v0.59.0/release.yaml
+  # - https://github.com/tektoncd/operator/releases/download/v0.60.0/release.yaml
   # we fixed the image tag to make it runable on arm64 nodes:
   #   gcr.io/tekton-releases/dogfooding/tkn
   - operator-release.yaml 

--- a/apps/prod/tekton/setup/operator-release.yaml
+++ b/apps/prod/tekton/setup/operator-release.yaml
@@ -7,8 +7,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.59.0
-    version: v0.59.0
+    operator.tekton.dev/release: v0.60.0
+    version: v0.60.0
   name: tektonchains.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -45,8 +45,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.59.0
-    version: v0.59.0
+    operator.tekton.dev/release: v0.60.0
+    version: v0.60.0
   name: tektonconfigs.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -83,8 +83,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.59.0
-    version: v0.59.0
+    operator.tekton.dev/release: v0.60.0
+    version: v0.60.0
   name: tektondashboards.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -121,8 +121,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.59.0
-    version: v0.59.0
+    operator.tekton.dev/release: v0.60.0
+    version: v0.60.0
   name: tektonhubs.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -165,8 +165,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.59.0
-    version: v0.59.0
+    operator.tekton.dev/release: v0.60.0
+    version: v0.60.0
   name: tektoninstallersets.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -200,8 +200,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.59.0
-    version: v0.59.0
+    operator.tekton.dev/release: v0.60.0
+    version: v0.60.0
   name: tektonpipelines.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -238,8 +238,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.59.0
-    version: v0.59.0
+    operator.tekton.dev/release: v0.60.0
+    version: v0.60.0
   name: tektonresults.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -333,8 +333,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.59.0
-    version: v0.59.0
+    operator.tekton.dev/release: v0.60.0
+    version: v0.60.0
   name: tektontriggers.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -957,7 +957,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  version: v0.59.0
+  version: v0.60.0
 kind: ConfigMap
 metadata:
   labels:
@@ -979,7 +979,7 @@ kind: Service
 metadata:
   labels:
     app: tekton-pipelines-controller
-    version: v0.59.0
+    version: v0.60.0
   name: tekton-operator
   namespace: tekton-operator
 spec:
@@ -998,8 +998,8 @@ metadata:
   labels:
     app: tekton-operator
     name: tekton-operator-webhook
-    operator.tekton.dev/release: v0.59.0
-    version: v0.59.0
+    operator.tekton.dev/release: v0.60.0
+    version: v0.60.0
   name: tekton-operator-webhook
   namespace: tekton-operator
 spec:
@@ -1015,8 +1015,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    operator.tekton.dev/release: v0.59.0
-    version: v0.59.0
+    operator.tekton.dev/release: v0.60.0
+    version: v0.60.0
   name: tekton-operator
   namespace: tekton-operator
 spec:
@@ -1031,7 +1031,12 @@ spec:
         name: tekton-operator
     spec:
       containers:
-        - env:
+        - args:
+            - -controllers
+            - tektonconfig,tektonpipeline,tektontrigger,tektonhub,tektonchain,tektonresults,tektondashboard
+            - -unique-process-name
+            - tekton-operator-lifecycle
+          env:
             - name: SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -1043,13 +1048,13 @@ spec:
             - name: OPERATOR_NAME
               value: tekton-operator
             - name: IMAGE_PIPELINES_PROXY
-              value: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/proxy-webhook:v0.59.0@sha256:c2c3a38c2d26fc05d336e0e47c24a488a26cc6df8d72cd55e00ac05668d090d4
+              value: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/proxy-webhook:v0.60.0@sha256:09fb2b1a97bcd4cb3f0278cec0ece101aeacb59b2253045a4b971e3ac880a6c0
             - name: IMAGE_JOB_PRUNER_TKN
               value: gcr.io/tekton-releases/dogfooding/tkn:v20221201-ed0196540a
             - name: METRICS_DOMAIN
               value: tekton.dev/operator
             - name: VERSION
-              value: v0.59.0
+              value: v0.60.0
             - name: CONFIG_OBSERVABILITY_NAME
               value: tekton-config-observability
             - name: AUTOINSTALL_COMPONENTS
@@ -1062,17 +1067,40 @@ spec:
                 configMapKeyRef:
                   key: DEFAULT_TARGET_NAMESPACE
                   name: tekton-config-defaults
-          image: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/operator:v0.59.0@sha256:e5e6cbf5c56a3c62136ac71e478a26fa93067ced6334929f99a82cfd2d726674
+          image: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/operator:v0.60.0@sha256:22ca40497d6f820d6b2034905f30d9c13fc46cc3e113dadbe332d00656648a70
           imagePullPolicy: Always
-          name: tekton-operator
+          name: tekton-operator-lifecycle
+        - args:
+            - -controllers
+            - tektoninstallerset
+            - -unique-process-name
+            - tekton-operator-cluster-operations
+          env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: tekton-operator
+            - name: PROFILING_PORT
+              value: "9009"
+            - name: VERSION
+              value: v0.60.0
+          image: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/operator:v0.60.0@sha256:22ca40497d6f820d6b2034905f30d9c13fc46cc3e113dadbe332d00656648a70
+          imagePullPolicy: Always
+          name: tekton-operator-cluster-operations
       serviceAccountName: tekton-operator
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    operator.tekton.dev/release: v0.59.0
-    version: v0.59.0
+    operator.tekton.dev/release: v0.60.0
+    version: v0.60.0
   name: tekton-operator-webhook
   namespace: tekton-operator
 spec:
@@ -1100,7 +1128,7 @@ spec:
               value: tekton-operator-webhook-certs
             - name: METRICS_DOMAIN
               value: tekton.dev/operator
-          image: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/webhook:v0.59.0@sha256:24b94e84b9edecd6f98581f4921832a2a1deae13ed9b2308f985eb86f29149b8
+          image: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/webhook:v0.60.0@sha256:aa13f702ea1b0fa8bf6ccd7c2b99eeebe15f8df26ad2b80ea2f24a9f5b35b211
           name: tekton-operator-webhook
           ports:
             - containerPort: 8443


### PR DESCRIPTION
It bump these components:
- hub: [v1.8.0](https://github.com/tektoncd/hub/releases/tag/v1.8.0)
- dashboard: [v0.27.0](https://github.com/tektoncd/dashboard/releases/tag/v0.27.0)
- pipeline: [v0.37.0](https://github.com/tektoncd/pipeline/releases/tag/v0.37.0)
- chains: [v0.9.0](https://github.com/tektoncd/chains/releases/tag/v0.9.0)