### PR TITLE
fix(apps/prod/tekton/configs): fix builder images for tikv and tiflash building

### DIFF
--- a/apps/prod/tekton/configs/pipelines/push-build-package.yaml
+++ b/apps/prod/tekton/configs/pipelines/push-build-package.yaml
@@ -24,6 +24,10 @@ spec:
 
         May be it is an idea to judge it by git-url, but it maybe 
         not a generic way for forked repositories with custom names.
+    - name: builder-image
+      type: string
+      description: builder image for building binaries.
+      default: ghcr.io/pingcap-qe/ci/release-build-base:v20231107-4086b32-go1.21_linux_amd64
   workspaces:
     - name: dockerconfig
       description: Includes a docker `config.json`
@@ -152,7 +156,7 @@ spec:
           value: "true"
         - name: build-image
           # value: ghcr.io/pingcap-qe/ci/release-build-base:v20231029-b8b8d34-go1.21
-          value: ghcr.io/pingcap-qe/ci/release-build-base:v20231107-4086b32-go1.21_linux_amd64
+          value: "$(params.builder-image)"
       workspaces:
         - name: source
           workspace: source

--- a/apps/prod/tekton/configs/triggers/templates/pingcap/tiflash/push.yaml
+++ b/apps/prod/tekton/configs/triggers/templates/pingcap/tiflash/push.yaml
@@ -32,6 +32,8 @@ spec:
             value: $(tt.params.git-ref)
           - name: component
             value: tiflash
+          - name: builder-image
+            value: hub.pingcap.net/ee/ci/release-build-base-tiflash:v20230731
         workspaces:
           - name: dockerconfig
             secret:

--- a/apps/prod/tekton/configs/triggers/templates/tikv/tikv/push.yaml
+++ b/apps/prod/tekton/configs/triggers/templates/tikv/tikv/push.yaml
@@ -32,6 +32,8 @@ spec:
             value: $(tt.params.git-ref)
           - name: component
             value: tikv
+          - name: builder-image
+            value: hub.pingcap.net/ee/ci/release-build-base-tikv:v20230804
         workspaces:
           - name: dockerconfig
             secret:


### PR DESCRIPTION
The new builder images is WIP, now we use the old ones.