### PR TITLE
feat(apps/prod): add boskos to support acquire and release mac builder resources

### DIFF
--- a/apps/prod/boskos/README.md
+++ b/apps/prod/boskos/README.md
@@ -1,0 +1,23 @@
+This overlay creates a fairly simple Boskos deployment in the namespace `apps`.
+
+It manages the following ficticious resources:
+- `mac-machine` (cleaned by the mac-machine janitor)
+
+Beyond the core Boskos server, the following components are installed:
+- The `cleaner`, to clean up automatic resources.
+- The `janitor`, to clean up `mac-machine` projects.
+- The `reaper`, to clean up orphaned leases
+
+To try out this example, you will need to [install Kustomize](https://kubernetes-sigs.github.io/kustomize/installation/). (The version of Kustomize included in Kubectl is too old at time of writing.)
+Additionally, to play with this example locally, you can first create a [kind cluster](https://kind.sigs.k8s.io/).
+
+Build the manifests:
+```console
+# From within this directory
+$ kustomize build deployments/overlays/example/
+```
+
+Apply to a cluster:
+```console
+$ kustomize build . | kubectl apply -f-
+```

--- a/apps/prod/boskos/base/cleaner/deployment.yaml
+++ b/apps/prod/boskos/base/cleaner/deployment.yaml
@@ -1,0 +1,45 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: boskos-cleaner
+  labels:
+    app: boskos-cleaner
+  namespace: boskos
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: boskos-cleaner
+  template:
+    metadata:
+      labels:
+        app: boskos-cleaner
+    spec:
+      serviceAccountName: boskos-cleaner
+      terminationGracePeriodSeconds: 300
+      containers:
+        - name: boskos-cleaner
+          image: gcr.io/k8s-staging-boskos/cleaner:v20211015-2401f5c
+          args:
+            - --boskos-url=http://boskos
+            - --namespace=$(NAMESPACE)
+            - --use-v2-implementation
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace

--- a/apps/prod/boskos/base/cleaner/kustomization.yaml
+++ b/apps/prod/boskos/base/cleaner/kustomization.yaml
@@ -1,0 +1,23 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  app: boskos-cleaner
+
+resources:
+  - deployment.yaml
+  - rbac.yaml

--- a/apps/prod/boskos/base/cleaner/rbac.yaml
+++ b/apps/prod/boskos/base/cleaner/rbac.yaml
@@ -1,0 +1,72 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: boskos-cleaner
+  namespace: boskos
+---
+# Give the cleaner access to update Boskos resources directly
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: boskos-cleaner-crd-updater
+  namespace: boskos
+subjects:
+  - kind: ServiceAccount
+    name: boskos-cleaner
+    namespace: boskos
+roleRef:
+  kind: Role
+  name: boskos-crd-updater
+  apiGroup: rbac.authorization.k8s.io
+---
+# Give the cleaner access to its leaderlock
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: boskos-cleaner-leaderlock
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - boskos-cleaner-leaderlock
+    verbs:
+      - get
+      - update
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - events
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: boskos-cleaner-leaderlock
+  namespace: boskos
+subjects:
+  - kind: ServiceAccount
+    name: boskos-cleaner
+    namespace: boskos
+roleRef:
+  kind: Role
+  name: boskos-cleaner-leaderlock
+  apiGroup: rbac.authorization.k8s.io

--- a/apps/prod/boskos/base/crd.yaml
+++ b/apps/prod/boskos/base/crd.yaml
@@ -1,0 +1,152 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: dynamicresourcelifecycles.boskos.k8s.io
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/boskos/pull/105
+spec:
+  group: boskos.k8s.io
+  names:
+    kind: DRLCObject
+    listKind: DRLCObjectList
+    plural: dynamicresourcelifecycles
+    singular: dynamicresourcelifecycle
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Type
+          type: string
+          description: The dynamic resource type.
+          jsonPath: .spec.config.type
+        - name: Min-Count
+          type: integer
+          description: The minimum count requested.
+          jsonPath: .spec.min-count
+        - name: Max-Count
+          type: integer
+          description: The maximum count requested.
+          jsonPath: .spec.max-count
+      schema:
+        openAPIV3Schema:
+          description: Defines the lifecycle of a dynamic resource. All
+            Resource of a given type will be constructed using the same
+            configuration
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                state:
+                  type: string
+                max-count:
+                  description: Maxiumum number of resources expected. This
+                    maximum may be temporarily exceeded while resources are in
+                    the process of being deleted, though this is only expected
+                    when MaxCount is lowered.
+                  type: integer
+                  format: int32
+                min-count:
+                  description: Minimum number of resources to be used as a
+                    buffer. Resources in the process of being deleted and
+                    cleaned up are included in this count.
+                  type: integer
+                  format: int32
+                lifespan:
+                  description: Lifespan of a resource, time after which the
+                    resource should be reset
+                  type: integer
+                  format: int64
+                config:
+                  description: Config information about how to create the
+                    object
+                  type: object
+                  properties:
+                    type:
+                      description: The dynamic resource type
+                      type: string
+                    content:
+                      type: string
+                needs:
+                  description: Define the resource needs to create the object
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: resources.boskos.k8s.io
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/boskos/pull/105
+spec:
+  group: boskos.k8s.io
+  names:
+    kind: ResourceObject
+    listKind: ResourceObjectList
+    plural: resources
+    singular: resource
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Type
+          type: string
+          description: The resource type.
+          jsonPath: .spec.type
+        - name: State
+          type: string
+          description: The current state of the resource.
+          jsonPath: .status.state
+        - name: Owner
+          type: string
+          description: The current owner of the resource.
+          jsonPath: .status.owner
+        - name: Last-Updated
+          type: date
+          jsonPath: .status.lastUpdate
+      schema:
+        openAPIV3Schema:
+          description: Abstracts any resource type that can be tracked by boskos
+          type: object
+          properties:
+            spec:
+              description: Holds information that are not likely to change
+              type: object
+              properties:
+                type:
+                  type: string
+            status:
+              description: Holds information that are likely to change
+              type: object
+              properties:
+                state:
+                  type: string
+                owner:
+                  type: string
+                lastUpdate:
+                  type: string
+                  format: date-time
+                userData:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                expirationDate:
+                  type: string
+                  format: date-time

--- a/apps/prod/boskos/base/deployment.yaml
+++ b/apps/prod/boskos/base/deployment.yaml
@@ -1,0 +1,64 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: boskos
+  namespace: boskos
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: boskos
+  template:
+    metadata:
+      labels:
+        app: boskos
+    spec:
+      serviceAccountName: boskos
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: boskos
+          image: gcr.io/k8s-staging-boskos/boskos:v20211015-2401f5c
+          args:
+            - --config=/etc/config/boskos-resources.yaml
+            - --namespace=$(NAMESPACE)
+            - --pod-name=$(POD_NAME)
+            - --boskos-label-selector=app=boskos
+            - --enable-leader-election=true
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /healthz/ready
+              port: 8081
+          volumeMounts:
+            - name: boskos-config
+              mountPath: /etc/config
+              readOnly: true
+      volumes:
+        - name: boskos-config
+          configMap:
+            name: boskos-resources

--- a/apps/prod/boskos/base/janitor/README.md
+++ b/apps/prod/boskos/base/janitor/README.md
@@ -1,0 +1,9 @@
+The Janitor requires a bit of overriding in overlays.
+
+At the very least:
+1. You must override the `JANITOR_RESOURCE_TYPES` environment variable in the Deployment to contain the list of resource types this Janitor should manage.
+2. You must ensure the Service Account has necessary credentials to clean up the resources.
+
+You will likely also want to increase the number of replicas.
+
+If you want to have multiple kinds of Janitors (perhaps servicing different resource types), you can create separate overlays for each Janitor. Consult the example overlay for details.

--- a/apps/prod/boskos/base/janitor/deployment.yaml
+++ b/apps/prod/boskos/base/janitor/deployment.yaml
@@ -1,0 +1,47 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: boskos-janitor
+  labels:
+    app: boskos-janitor
+  namespace: boskos
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: boskos-janitor
+  template:
+    metadata:
+      labels:
+        app: boskos-janitor
+    spec:
+      terminationGracePeriodSeconds: 300
+      serviceAccountName: boskos-janitor
+      containers:
+        - name: boskos-janitor
+          image: gcr.io/k8s-staging-boskos/janitor:v20211015-2401f5c
+          args:
+            - --boskos-url=http://boskos
+            - --resource-type=$(JANITOR_RESOURCE_TYPES)
+            - --janitor-path=$(JANITOR_BINARY)
+            - --
+            - --hours=0
+          env:
+            - name: JANITOR_RESOURCE_TYPES
+              value:
+            - name: JANITOR_BINARY
+              value: /bin/gcp_janitor.py

--- a/apps/prod/boskos/base/janitor/kustomization.yaml
+++ b/apps/prod/boskos/base/janitor/kustomization.yaml
@@ -1,0 +1,23 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  app: boskos-janitor
+
+resources:
+  - deployment.yaml
+  - serviceaccount.yaml

--- a/apps/prod/boskos/base/janitor/serviceaccount.yaml
+++ b/apps/prod/boskos/base/janitor/serviceaccount.yaml
@@ -1,0 +1,19 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: boskos-janitor
+  namespace: boskos

--- a/apps/prod/boskos/base/kustomization.yaml
+++ b/apps/prod/boskos/base/kustomization.yaml
@@ -1,0 +1,25 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  app: boskos
+
+resources:
+  - crd.yaml
+  - deployment.yaml
+  - rbac.yaml
+  - service.yaml

--- a/apps/prod/boskos/base/rbac.yaml
+++ b/apps/prod/boskos/base/rbac.yaml
@@ -1,0 +1,87 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: boskos
+  namespace: boskos
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: boskos-server
+  namespace: boskos
+rules:
+  - apiGroups: ["boskos.k8s.io"]
+    resources: ["*"]
+    verbs: ["*"]
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    verbs:
+    - get
+    - list
+    - watch
+    - update
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    resourceNames:
+    - boskos-server
+    verbs:
+    - get
+    - update
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    verbs:
+    - create
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: boskos-server
+  namespace: boskos
+subjects:
+  - kind: ServiceAccount
+    name: boskos
+    namespace: boskos
+roleRef:
+  kind: Role
+  name: boskos-server
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: boskos-crd-reader
+  namespace: boskos
+rules:
+  - apiGroups: ["boskos.k8s.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: boskos-crd-updater
+  namespace: boskos
+rules:
+  - apiGroups: ["boskos.k8s.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch", "update"]

--- a/apps/prod/boskos/base/reaper/README.md
+++ b/apps/prod/boskos/base/reaper/README.md
@@ -1,0 +1,1 @@
+For the Reaper to be functional, you must override the `REAPER_RESOURCE_TYPES` environment variable in overlays.

--- a/apps/prod/boskos/base/reaper/deployment.yaml
+++ b/apps/prod/boskos/base/reaper/deployment.yaml
@@ -1,0 +1,41 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: boskos-reaper
+  labels:
+    app: boskos-reaper
+  namespace: boskos
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: boskos-reaper
+  template:
+    metadata:
+      labels:
+        app: boskos-reaper
+    spec:
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: boskos-reaper
+          image: gcr.io/k8s-staging-boskos/reaper:v20211015-2401f5c
+          args:
+            - --boskos-url=http://boskos
+            - --resource-type=$(REAPER_RESOURCE_TYPES)
+          env:
+            - name: REAPER_RESOURCE_TYPES
+              value:

--- a/apps/prod/boskos/base/reaper/kustomization.yaml
+++ b/apps/prod/boskos/base/reaper/kustomization.yaml
@@ -1,0 +1,22 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  app: boskos-reaper
+
+resources:
+  - deployment.yaml

--- a/apps/prod/boskos/base/service.yaml
+++ b/apps/prod/boskos/base/service.yaml
@@ -1,0 +1,44 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expose a cluster-internal service for the Boskos API
+apiVersion: v1
+kind: Service
+metadata:
+  name: boskos
+  namespace: boskos
+spec:
+  selector:
+    boskos-leader: "true"
+  ports:
+    - name: default
+      protocol: TCP
+      port: 80
+      targetPort: 8080
+---
+# Expose a cluster-external service for Prometheus-style metrics
+apiVersion: v1
+kind: Service
+metadata:
+  name: boskos-metrics
+  namespace: boskos
+spec:
+  selector:
+    app: boskos
+  ports:
+    - name: metrics
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
+  type: LoadBalancer

--- a/apps/prod/boskos/boskos-resources.yaml
+++ b/apps/prod/boskos/boskos-resources.yaml
@@ -1,0 +1,10 @@
+resources:
+  - names:
+      - darwin-amd64-1
+      - darwin-arm64-1
+    state: free
+    type: mac-machine
+    config:
+      type: MacMachineConfig
+      content: |
+        {"TODO": "yes"}

--- a/apps/prod/boskos/kustomization.yaml
+++ b/apps/prod/boskos/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: apps
+resources:
+  - base
+  - base/cleaner
+  - overlays/mac-machine-janitor
+  - overlays/mac-machine-reaper
+
+configMapGenerator:
+  - name: boskos-resources
+    files:
+      - boskos-resources.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true

--- a/apps/prod/boskos/overlays/mac-machine-janitor/kustomization.yaml
+++ b/apps/prod/boskos/overlays/mac-machine-janitor/kustomization.yaml
@@ -1,0 +1,36 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+nameSuffix: -mac-machine
+commonLabels:
+  app: boskos-janitor-mac-machine
+resources:
+  - ../../base/janitor
+patchesJson6902:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: boskos-janitor
+      namespace: boskos
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/env
+        value:
+          - name: JANITOR_RESOURCE_TYPES
+            value: mac-machine
+          - name: JANITOR_BINARY
+            value: /bin/echo

--- a/apps/prod/boskos/overlays/mac-machine-reaper/kustomization.yaml
+++ b/apps/prod/boskos/overlays/mac-machine-reaper/kustomization.yaml
@@ -1,0 +1,34 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+nameSuffix: -mac-machine
+commonLabels:
+  app: boskos-reaper-mac-machine
+resources:
+  - ../../base/reaper
+patchesJson6902:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: boskos-reaper
+      namespace: boskos
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/env
+        value:
+          - name: REAPER_RESOURCE_TYPES
+            value: mac-machine

--- a/apps/prod/kustomization.yaml
+++ b/apps/prod/kustomization.yaml
@@ -16,3 +16,4 @@ resources:
   - ccache-pvc
   - jenkins-beta
   - cloudevents-server
+  - boskos


### PR DESCRIPTION
New deployments
===

## Adds

1. Deploy k8s-sig's boskos to setup the resource manager for mac machines resoures, in future, it can manage more types.


## Some future tasks

- [ ] add the acquire and release tekton tasks.
- [ ] implement the beaper and janitor for the `mac-machine` types, and support config the resource type.

## Tests

- [x] Tested manually in local kind cluster.