### PR TITLE
chore(apps/prod/tekton/setup): bump tekton operator to v0.61.0

### DIFF
--- a/apps/prod/tekton/setup/operator-release.yaml
+++ b/apps/prod/tekton/setup/operator-release.yaml
@@ -7,8 +7,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.60.1
-    version: v0.60.1
+    operator.tekton.dev/release: v0.61.0
+    version: v0.61.0
   name: tektonchains.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -45,8 +45,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.60.1
-    version: v0.60.1
+    operator.tekton.dev/release: v0.61.0
+    version: v0.61.0
   name: tektonconfigs.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -83,8 +83,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.60.1
-    version: v0.60.1
+    operator.tekton.dev/release: v0.61.0
+    version: v0.61.0
   name: tektondashboards.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -121,8 +121,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.60.1
-    version: v0.60.1
+    operator.tekton.dev/release: v0.61.0
+    version: v0.61.0
   name: tektonhubs.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -165,8 +165,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.60.1
-    version: v0.60.1
+    operator.tekton.dev/release: v0.61.0
+    version: v0.61.0
   name: tektoninstallersets.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -200,8 +200,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.60.1
-    version: v0.60.1
+    operator.tekton.dev/release: v0.61.0
+    version: v0.61.0
   name: tektonpipelines.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -238,8 +238,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.60.1
-    version: v0.60.1
+    operator.tekton.dev/release: v0.61.0
+    version: v0.61.0
   name: tektonresults.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -333,8 +333,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.60.1
-    version: v0.60.1
+    operator.tekton.dev/release: v0.61.0
+    version: v0.61.0
   name: tektontriggers.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -957,7 +957,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  version: v0.60.1
+  version: v0.61.0
 kind: ConfigMap
 metadata:
   labels:
@@ -979,7 +979,7 @@ kind: Service
 metadata:
   labels:
     app: tekton-pipelines-controller
-    version: v0.60.1
+    version: v0.61.0
   name: tekton-operator
   namespace: tekton-operator
 spec:
@@ -998,8 +998,8 @@ metadata:
   labels:
     app: tekton-operator
     name: tekton-operator-webhook
-    operator.tekton.dev/release: v0.60.1
-    version: v0.60.1
+    operator.tekton.dev/release: v0.61.0
+    version: v0.61.0
   name: tekton-operator-webhook
   namespace: tekton-operator
 spec:
@@ -1015,8 +1015,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    operator.tekton.dev/release: v0.60.1
-    version: v0.60.1
+    operator.tekton.dev/release: v0.61.0
+    version: v0.61.0
   name: tekton-operator
   namespace: tekton-operator
 spec:
@@ -1048,13 +1048,13 @@ spec:
             - name: OPERATOR_NAME
               value: tekton-operator
             - name: IMAGE_PIPELINES_PROXY
-              value: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/proxy-webhook:v0.60.1@sha256:1f16df4e514c3a2a2d7a1e8aa2f8742147c32f240a8828a4b0512f3e06ecf68e
+              value: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/proxy-webhook:v0.61.0@sha256:143e0f1e22ca6dee89b29d99626a9badc8d4e08d6707aebfec93ac89a117845d
             - name: IMAGE_JOB_PRUNER_TKN
               value: gcr.io/tekton-releases/dogfooding/tkn:v20221201-ed0196540a
             - name: METRICS_DOMAIN
               value: tekton.dev/operator
             - name: VERSION
-              value: v0.60.1
+              value: v0.61.0
             - name: CONFIG_OBSERVABILITY_NAME
               value: tekton-config-observability
             - name: AUTOINSTALL_COMPONENTS
@@ -1067,7 +1067,7 @@ spec:
                 configMapKeyRef:
                   key: DEFAULT_TARGET_NAMESPACE
                   name: tekton-config-defaults
-          image: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/operator:v0.60.1@sha256:ae99d26f4812b4666378ca9fe52426d4c9988c535a15b6b71c4b80fbf78d2f21
+          image: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/operator:v0.61.0@sha256:c91ed327f06ad60b3a43a2838eee6b833b78b00ffb482a9de531f452fb90c6fa
           imagePullPolicy: Always
           name: tekton-operator-lifecycle
         - args:
@@ -1089,10 +1089,10 @@ spec:
             - name: PROFILING_PORT
               value: "9009"
             - name: VERSION
-              value: v0.60.1
+              value: v0.61.0
             - name: METRICS_DOMAIN
               value: tekton.dev/operator
-          image: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/operator:v0.60.1@sha256:ae99d26f4812b4666378ca9fe52426d4c9988c535a15b6b71c4b80fbf78d2f21
+          image: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/operator:v0.61.0@sha256:c91ed327f06ad60b3a43a2838eee6b833b78b00ffb482a9de531f452fb90c6fa
           imagePullPolicy: Always
           name: tekton-operator-cluster-operations
       serviceAccountName: tekton-operator
@@ -1101,8 +1101,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    operator.tekton.dev/release: v0.60.1
-    version: v0.60.1
+    operator.tekton.dev/release: v0.61.0
+    version: v0.61.0
   name: tekton-operator-webhook
   namespace: tekton-operator
 spec:
@@ -1130,7 +1130,7 @@ spec:
               value: tekton-operator-webhook-certs
             - name: METRICS_DOMAIN
               value: tekton.dev/operator
-          image: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/webhook:v0.60.1@sha256:ad1cf36844e548931a88bb9e0030aea6f72ff23af221c2ce434629d939a82304
+          image: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/webhook:v0.61.0@sha256:38698adafe8317c6846e967c92c20db205f9a5152b255a92b8190fe0f78a272f
           name: tekton-operator-webhook
           ports:
             - containerPort: 8443


### PR DESCRIPTION
With components updated:
- hub "v1.9.0"
- dashboard "v0.28.0"
- pipeline "v0.39.0"
- chains "v0.11.0"

Signed-off-by: wuhuizuo <wuhuizuo@126.com>