### PR TITLE
feat(apps/prod): add git-cdn instance

### DIFF
--- a/apps/prod/git-cdn/kustomization.yaml
+++ b/apps/prod/git-cdn/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: apps
+resources:
+  - release.yaml

--- a/apps/prod/git-cdn/release.yaml
+++ b/apps/prod/git-cdn/release.yaml
@@ -1,16 +1,16 @@
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
-  name: cloudevents-server
+  name: git-cdn
 spec:
-  releaseName: cloudevents-server
+  releaseName: git-cdn
   chart:
     spec:
-      chart: cloudevents-server
+      chart: git-cdn
       version: 0.1.0
       sourceRef:
         kind: HelmRepository
-        name: ee-apps
+        name: ee-ops
         namespace: flux-system
   interval: 5m
   timeout: 5m
@@ -31,19 +31,18 @@ spec:
     replicaCount: 1
     resources:
       limits:
-        cpu: "500m"
-        memory: 512Mi
+        cpu: "4"
+        memory: 4Gi
     nodeSelector:
       kubernetes.io/arch: amd64
-    image:
-      repository: hub.pingcap.net/ee/apps/cloudevents-server
-      tag: v0.1.0-1-ga3d0cd3
-    server:
-      args: [--config=/config/config.yaml]
-      volumeMounts:
-        - name: config
-          mountPath: /config
-      volumes:
-        - name: config
-          secret:
-            secretName: cloudevents-server-config
+    volumeMounts:
+      - name: data
+        mountPath: /data
+    volumes:
+      - name: data
+        emptyDir: {}
+    configuration:
+      GITSERVER_UPSTREAM: https://github.com
+      PACK_CACHE_SIZE_GB: 20
+      # directory where to put cache files
+      WORKING_DIRECTORY: /data

--- a/apps/prod/kustomization.yaml
+++ b/apps/prod/kustomization.yaml
@@ -17,3 +17,4 @@ resources:
   - jenkins-beta
   - cloudevents-server
   - boskos
+  - git-cdn


### PR DESCRIPTION
We can use it in CI/CD flows:

```bash
git config --global url."http://git-cdn.apps.svc:8080/".insteadOf https://github.com/


git clone https://github.com/pingcap/tidb.git

```