### PR TITLE
feature(apps/prod/tekton/configs): git clone with git-cdn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ Chart.lock
 /charts/**/*.tgz
 
 # IDEs
-/.vscode
+.vscode

--- a/apps/prod/tekton/configs/pipelines/pingcap-build-package-darwin.yaml
+++ b/apps/prod/tekton/configs/pipelines/pingcap-build-package-darwin.yaml
@@ -39,8 +39,8 @@ spec:
       description: The workspace where the git repo will be cloned.
     - name: dockerconfig
       description: Includes a docker `config.json`
-    - name: git-credentials
-      description: secret contains ssh private key in `id_rsa` key.
+    - name: git-basic-auth
+      description: secret containing a .gitconfig and .git-credentials file.
       optional: true
     - name: mac-ssh-credentials
       description: secret contains ssh private key in `id_rsa` key for login mac
@@ -62,8 +62,8 @@ spec:
       workspaces:
         - name: output
           workspace: source
-        - name: ssh-directory
-          workspace: git-credentials
+        - name: basic-auth
+          workspace: git-basic-auth
     - name: get-release-ver
       taskSpec:
         results:

--- a/apps/prod/tekton/configs/pipelines/pingcap-build-package.yaml
+++ b/apps/prod/tekton/configs/pipelines/pingcap-build-package.yaml
@@ -41,8 +41,8 @@ spec:
       description: The workspace where the git repo will be cloned.
     - name: dockerconfig
       description: Includes a docker `config.json`
-    - name: git-credentials
-      description: secret contains ssh private key in `id_rsa` key.
+    - name: git-basic-auth
+      description: secret containing a .gitconfig and .git-credentials file.
       optional: true
     - name: mac-ssh-credentials
       description: secret contains ssh private key in `id_rsa` key for login mac
@@ -64,8 +64,8 @@ spec:
       workspaces:
         - name: output
           workspace: source
-        - name: ssh-directory
-          workspace: git-credentials
+        - name: basic-auth
+          workspace: git-basic-auth
     - name: get-release-ver
       taskSpec:
         results:

--- a/apps/prod/tekton/configs/triggers/templates/pingcap/tidb/build.yaml
+++ b/apps/prod/tekton/configs/triggers/templates/pingcap/tidb/build.yaml
@@ -62,9 +62,9 @@ spec:
                 resources:
                   requests:
                     storage: 10Gi
-          - name: git-credentials # need to fetch some private repositories.
+          - name: git-basic-auth # need to fetch some private repositories.
             secret:
-              secretName: git-credentials
+              secretName: git-credentials-basic
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
       metadata:
@@ -116,9 +116,9 @@ spec:
                 resources:
                   requests:
                     storage: 10Gi
-          - name: git-credentials # need to fetch some private repositories.
+          - name: git-basic-auth # need to fetch some private repositories.
             secret:
-              secretName: git-credentials
+              secretName: git-credentials-basic
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
       metadata:
@@ -162,9 +162,9 @@ spec:
           - name: mac-ssh-credentials
             secret:
               secretName: mac-ssh-credentials
-          - name: git-credentials # need to fetch some private repositories.
+          - name: git-basic-auth # need to fetch some private repositories.
             secret:
-              secretName: git-credentials
+              secretName: git-credentials-basic
           - name: source
             volumeClaimTemplate:
               spec:
@@ -215,9 +215,9 @@ spec:
                 resources:
                   requests:
                     storage: 10Gi
-          - name: git-credentials # need to fetch some private repositories.
+          - name: git-basic-auth # need to fetch some private repositories.
             secret:
-              secretName: git-credentials
+              secretName: git-credentials-basic
         timeouts:
           pipeline: 1h
         taskRunSpecs:


### PR DESCRIPTION
git url instead is configurated in `.gitconfig` file of the secret.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>