### PR TITLE
feat(apps/prod/tekton/setup): enable cloudevent emit and add sink url

### DIFF
--- a/apps/prod/tekton/setup/operator-config.yaml
+++ b/apps/prod/tekton/setup/operator-config.yaml
@@ -40,7 +40,7 @@ spec:
           key: dedicated
           operator: Equal
           value: test-infra
-    default-cloud-events-sink: https://cloudevents-server.apps.svc/events
+    default-cloud-events-sink: http://cloudevents-server.apps.svc/events
 
   trigger:
     default-service-account: "default"

--- a/apps/prod/tekton/setup/operator-config.yaml
+++ b/apps/prod/tekton/setup/operator-config.yaml
@@ -18,6 +18,7 @@ spec:
     enable-tekton-oci-bundles: true
     require-git-ssh-secret-known-hosts: false
     running-in-environment-with-injected-sidecars: false # set it to `true` when Istio installed and enabled auto sidecar injecting.
+    send-cloudevents-for-runs: true
 
     ###### metrics items ########
     metrics.pipelinerun.duration-type: histogram
@@ -39,6 +40,8 @@ spec:
           key: dedicated
           operator: Equal
           value: test-infra
+    default-cloud-events-sink: https://cloudevents-server.apps.svc/events
+
   trigger:
     default-service-account: "default"
     enable-api-fields: alpha # stable | alpha


### PR DESCRIPTION
Notice: currently we need update the config map `tekton-pipelines/feature-flags` manually because of the operator not support the congfiguration before v0.63.0.
Signed-off-by: wuhuizuo <wuhuizuo@126.com>