### PR TITLE
feat(apps/prod/cloudevents-server): bump image tag to `e652158`

### DIFF
--- a/apps/prod/cloudevents-server/release.yaml
+++ b/apps/prod/cloudevents-server/release.yaml
@@ -37,7 +37,8 @@ spec:
       kubernetes.io/arch: amd64
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/cloudevents-server
-      tag: f4f2f4c
+      # datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/cloudevents-server
+      tag: e652158
     server:
       args: [--config=/config/config.yaml]
       volumeMounts:


### PR DESCRIPTION
The updating will introduce the tekton event sinker feature:

sinks the cloud events of task run and pipeline run: send the state by Lark bot app.