### PR TITLE
feat(apps/prod/tibuild): bump image tag to `2f9d4cd`

### DIFF
--- a/apps/prod/tibuild/deployment.yaml
+++ b/apps/prod/tibuild/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app: tibuild
     spec:
       containers:
-      - image: hub.pingcap.net/tibuild/tibuild:2e11af5
+      - image: ghcr.io/pingcap-qe/ee-apps/tibuild:2f9d4cd
         imagePullPolicy: Always
         name: tibuild
         ports:


### PR DESCRIPTION
and change repo to `ghcr.io/pingcap-qe/ee-apps/tibuild`.

It's built automatically.