### PR TITLE
chore(apps/prod/tekton/setup): bump tekton operator to v0.63.0

### DIFF
--- a/apps/prod/tekton/setup/operator-release.yaml
+++ b/apps/prod/tekton/setup/operator-release.yaml
@@ -7,8 +7,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.62.0
-    version: v0.62.0
+    operator.tekton.dev/release: v0.63.0
+    version: v0.63.0
   name: tektonchains.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -27,7 +27,7 @@ spec:
         - jsonPath: .status.conditions[?(@.type=="Ready")].status
           name: Ready
           type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
           name: Reason
           type: string
       name: v1alpha1
@@ -45,8 +45,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.62.0
-    version: v0.62.0
+    operator.tekton.dev/release: v0.63.0
+    version: v0.63.0
   name: tektonconfigs.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -65,7 +65,7 @@ spec:
         - jsonPath: .status.conditions[?(@.type=="Ready")].status
           name: Ready
           type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
           name: Reason
           type: string
       name: v1alpha1
@@ -83,8 +83,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.62.0
-    version: v0.62.0
+    operator.tekton.dev/release: v0.63.0
+    version: v0.63.0
   name: tektondashboards.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -103,7 +103,7 @@ spec:
         - jsonPath: .status.conditions[?(@.type=="Ready")].status
           name: Ready
           type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
           name: Reason
           type: string
       name: v1alpha1
@@ -121,8 +121,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.62.0
-    version: v0.62.0
+    operator.tekton.dev/release: v0.63.0
+    version: v0.63.0
   name: tektonhubs.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -141,7 +141,7 @@ spec:
         - jsonPath: .status.conditions[?(@.type=="Ready")].status
           name: Ready
           type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
           name: Reason
           type: string
         - jsonPath: .status.apiUrl
@@ -165,8 +165,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.62.0
-    version: v0.62.0
+    operator.tekton.dev/release: v0.63.0
+    version: v0.63.0
   name: tektoninstallersets.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -182,7 +182,7 @@ spec:
         - jsonPath: .status.conditions[?(@.type=="Ready")].status
           name: Ready
           type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
           name: Reason
           type: string
       name: v1alpha1
@@ -200,8 +200,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.62.0
-    version: v0.62.0
+    operator.tekton.dev/release: v0.63.0
+    version: v0.63.0
   name: tektonpipelines.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -220,7 +220,7 @@ spec:
         - jsonPath: .status.conditions[?(@.type=="Ready")].status
           name: Ready
           type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
           name: Reason
           type: string
       name: v1alpha1
@@ -238,8 +238,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.62.0
-    version: v0.62.0
+    operator.tekton.dev/release: v0.63.0
+    version: v0.63.0
   name: tektonresults.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -258,7 +258,7 @@ spec:
         - jsonPath: .status.conditions[?(@.type=="Ready")].status
           name: Ready
           type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
           name: Reason
           type: string
       name: v1alpha1
@@ -333,8 +333,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.62.0
-    version: v0.62.0
+    operator.tekton.dev/release: v0.63.0
+    version: v0.63.0
   name: tektontriggers.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -353,7 +353,7 @@ spec:
         - jsonPath: .status.conditions[?(@.type=="Ready")].status
           name: Ready
           type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
           name: Reason
           type: string
       name: v1alpha1
@@ -960,7 +960,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  version: v0.62.0
+  version: v0.63.0
 kind: ConfigMap
 metadata:
   labels:
@@ -982,7 +982,7 @@ kind: Service
 metadata:
   labels:
     app: tekton-pipelines-controller
-    version: v0.62.0
+    version: v0.63.0
   name: tekton-operator
   namespace: tekton-operator
 spec:
@@ -1018,8 +1018,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    operator.tekton.dev/release: v0.62.0
-    version: v0.62.0
+    operator.tekton.dev/release: v0.63.0
+    version: v0.63.0
   name: tekton-operator
   namespace: tekton-operator
 spec:
@@ -1051,7 +1051,7 @@ spec:
             - name: OPERATOR_NAME
               value: tekton-operator
             - name: IMAGE_PIPELINES_PROXY
-              value: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/proxy-webhook:v0.62.0@sha256:3c079de954e7a8c56fea86ba064b436d4a668da68f034b26d498d4197b4448f7
+              value: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/proxy-webhook:v0.63.0@sha256:f1e65851bda568c7780c142a02e472a9a97f74d72216c3e2f777b9bb16a77b0c
             - name: IMAGE_JOB_PRUNER_TKN
               value: gcr.io/tekton-releases/dogfooding/tkn:v20221201-ed0196540a
             - name: METRICS_DOMAIN
@@ -1070,7 +1070,7 @@ spec:
                 configMapKeyRef:
                   key: DEFAULT_TARGET_NAMESPACE
                   name: tekton-config-defaults
-          image: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/operator:v0.62.0@sha256:7f9071864b49439de21eb0413ef4fe5773116b00db34b73214920c21e26fd640
+          image: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/operator:v0.63.0@sha256:e9c5e39df92da6f0a3d58ea03006c62375cb7602d22734ebc414aded62bb6d91
           imagePullPolicy: Always
           name: tekton-operator-lifecycle
         - args:
@@ -1095,7 +1095,7 @@ spec:
               value: devel
             - name: METRICS_DOMAIN
               value: tekton.dev/operator
-          image: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/operator:v0.62.0@sha256:7f9071864b49439de21eb0413ef4fe5773116b00db34b73214920c21e26fd640
+          image: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/operator:v0.63.0@sha256:e9c5e39df92da6f0a3d58ea03006c62375cb7602d22734ebc414aded62bb6d91
           imagePullPolicy: Always
           name: tekton-operator-cluster-operations
       serviceAccountName: tekton-operator
@@ -1104,8 +1104,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    operator.tekton.dev/release: v0.62.0
-    version: v0.62.0
+    operator.tekton.dev/release: v0.63.0
+    version: v0.63.0
   name: tekton-operator-webhook
   namespace: tekton-operator
 spec:
@@ -1133,7 +1133,7 @@ spec:
               value: tekton-operator-webhook-certs
             - name: METRICS_DOMAIN
               value: tekton.dev/operator
-          image: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/webhook:v0.62.0@sha256:af242fc4ca25235e64db10fb478031cb55d882cc1f783d4a5392d048605e5b35
+          image: gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/webhook:v0.63.0@sha256:1ffd57928fc3328a89cf8213cf3bbd26e7f4e28431413e0be11865478688e056
           name: tekton-operator-webhook
           ports:
             - containerPort: 8443


### PR DESCRIPTION
With components updated:
- hub "v1.11.1"
- dashboard "v0.30.0"
- pipeline "v0.41.0"
- chains "v0.13.0"
- triggers "v0.22.0"