### PR TITLE
fix(apps/prod/tekton/configs/pipeline): fix task order for `pingcap-build-package-darwin`

### DIFF
--- a/apps/prod/tekton/configs/pipelines/pingcap-build-package-darwin.yaml
+++ b/apps/prod/tekton/configs/pipelines/pingcap-build-package-darwin.yaml
@@ -65,6 +65,8 @@ spec:
         - name: basic-auth
           workspace: git-basic-auth
     - name: get-release-ver
+      runAfter:
+        - checkout    
       taskSpec:
         results:
           - name: version
@@ -78,12 +80,12 @@ spec:
             script: |
               RESULT_VERSION="$(git describe --tags --always --dirty)"
               printf "%s" "${RESULT_VERSION}" > $(results.version.path)
-      runAfter:
-        - checkout
       workspaces:
         - name: source
           workspace: source
     - name: acquire-mac-machine
+      runAfter:
+        - checkout    
       retries: 5
       taskRef:
         name: boskos-acquire


### PR DESCRIPTION
let it acquire resource after checkouted source codes to reduce the resource leasing time.