### PR TITLE
opt(apps/prod/tekton/configs/tasks): add env var in build step to avoid cargo fetch error

### DIFF
--- a/apps/prod/tekton/configs/tasks/pingcap-build-binaries.yaml
+++ b/apps/prod/tekton/configs/tasks/pingcap-build-binaries.yaml
@@ -80,6 +80,9 @@ spec:
     - name: build
       image: "$(params.builder-image)"
       workingDir: $(workspaces.source.path)
+      env:
+        - name: CARGO_NET_GIT_FETCH_WITH_CLI
+          value: 'true'
       # TODO: get the user and host by better way. 
       script: |
         script="/workspace/build-package-artifacts.sh"


### PR DESCRIPTION
Example error:
```
[build]     Updating git repository `https://github.com/tabokie/fs2-rs`
[build]     Updating git repository `https://github.com/pingcap/rust-protobuf`
[build]     Updating git submodule `https://github.com/google/protobuf`
[build] error: failed to load source for dependency `protobuf`
[build]
[build] Caused by:
[build]   Unable to update https://github.com/pingcap/rust-protobuf?branch=v2.8#6642ebaa
[build]
[build] Caused by:
[build]   failed to update submodule `google-protobuf`
[build]
[build] Caused by:
[build]   failed to fetch submodule `google-protobuf` from https://github.com/google/protobuf
[build]
[build] Caused by:
[build]   network failure seems to have happened
[build]   if a proxy or similar is necessary `net.git-fetch-with-cli` may help here
[build]   https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
[build]
[build] Caused by:
[build]   SSL error: unknown error; class=Ssl (16)
[build] + r=101
[build] + set +x
```

Signed-off-by: wuhuizuo <wuhuizuo@126.com>