### PR TITLE
fix(apps/prod/tekton/configs/pipelines): decrease wait time and retry times for require mac resource

### DIFF
--- a/apps/prod/tekton/configs/pipelines/pingcap-build-package-darwin.yaml
+++ b/apps/prod/tekton/configs/pipelines/pingcap-build-package-darwin.yaml
@@ -86,14 +86,14 @@ spec:
     - name: acquire-mac-machine
       runAfter:
         - checkout    
-      retries: 5
+      retries: 1
       taskRef:
         name: boskos-acquire
       params:
         - name: server-url
           value: http://boskos.apps.svc
         - name: timeout
-          value: 15m
+          value: 5m
         - name: type
           value: "mac-machine-$(params.arch)"
         - name: owner-name


### PR DESCRIPTION
We put the release step in the final tasks, but currently when pipelinerun timeout, the final task will not run. It will cause the resource not be released and blocking the future runs.