### PR TITLE
fix(apps/prod/tekton/configs/tasks): fix task `multi-arch-image-collect`

### DIFF
--- a/apps/prod/tekton/configs/tasks/multi-arch-image-collect.yaml
+++ b/apps/prod/tekton/configs/tasks/multi-arch-image-collect.yaml
@@ -40,7 +40,7 @@ spec:
 
         # steps:
         # 1. check the pushed tag, if not existed, step will fail.
-        oras repo tags $(params.image_url)
+        oras discover --distribution-spec v1.1-referrers-tag $(params.image_url)
 
         # 2. compute the mult-arch tags and digests
         pushed_repo="$(echo $(params.image_url) | cut -d ':' -f 1)"


### PR DESCRIPTION
oras repo tags image:tag will hang when the tag list is too long.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>