### PR TITLE
feat(apps/prod/tekton/configs/triggers): add triggers for `tidb-binlog` and `tidb-tools`

### DIFF
--- a/apps/prod/tekton/configs/triggers/tests/test.http
+++ b/apps/prod/tekton/configs/triggers/tests/test.http
@@ -180,3 +180,23 @@ X-GitHub-Event: push
         }
     }
 }
+
+### pingcap/tidb-tools push on master branch
+POST http://127.0.0.1:8080 HTTP/1.1
+Accept: */*
+content-type: application/json
+X-GitHub-Event: push
+
+{
+    "ref": "refs/heads/master",
+    "before": "00000000000000000000000000000000000000000",
+    "after": "c4bdf178b3d6ae0242332aa7ef8448b74eb5b45c",
+    "ref_type": "branch",
+    "repository": {
+        "name": "tidb-tools",
+        "clone_url": "https://github.com/pingcap/tidb-tools",
+        "owner": {
+            "login": "pingcap"
+        }
+    }
+}

--- a/apps/prod/tekton/configs/triggers/tests/test.http
+++ b/apps/prod/tekton/configs/triggers/tests/test.http
@@ -160,3 +160,23 @@ X-GitHub-Event: push
         }
     }
 }
+
+### pingcap/tidb-binlog push on master branch
+POST http://127.0.0.1:8080 HTTP/1.1
+Accept: */*
+content-type: application/json
+X-GitHub-Event: push
+
+{
+    "ref": "refs/heads/master",
+    "before": "00000000000000000000000000000000000000000",
+    "after": "154d6d99d8bda586e10723c3aacc6c4d8ff6a1c6",
+    "ref_type": "branch",
+    "repository": {
+        "name": "tidb-binlog",
+        "clone_url": "https://github.com/pingcap/tidb-binlog",
+        "owner": {
+            "login": "pingcap"
+        }
+    }
+}

--- a/apps/prod/tekton/configs/triggers/triggers/_/artifact-push-on-harbor.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/artifact-push-on-harbor.yaml
@@ -53,7 +53,7 @@ spec:
       params:
         - name: filter
           value: >-
-            body.event_data.resources[0].tag.matches('^release-\d+\.\d+-.*[-_](amd64|arm64)$')
+            body.event_data.resources[0].tag.matches('^release-[0-9]+[.][0-9]+-.*[-_](amd64|arm64)$')
   bindings:
     - ref: harbor-image-push
   template:
@@ -83,7 +83,7 @@ spec:
       params:
         - name: filter
           value: >-
-            body.event_data.resources[0].tag.matches('^v\d+\.\d+.*[-_](amd64|arm64)$')
+            body.event_data.resources[0].tag.matches('^v[0-9]+[.][0-9]+.*[-_](amd64|arm64)$')
   bindings:
     - ref: harbor-image-push
   template:

--- a/apps/prod/tekton/configs/triggers/triggers/kustomization.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/kustomization.yaml
@@ -14,6 +14,10 @@ resources:
   - pingcap/tidb/git-create-branch.yaml
   - pingcap/tidb/git-create-tag.yaml
   - pingcap/tidb/git-push.yaml
+  - pingcap/tidb-binlog/git-create-tag.yaml
+  - pingcap/tidb-binlog/git-push.yaml
+  - pingcap/tidb-tools/git-create-tag.yaml
+  - pingcap/tidb-tools/git-push.yaml
   - pingcap/tiflash/fake-git-create-tag.yaml
   - pingcap/tiflash/fake-git-push.yaml
   - pingcap/tiflash/git-create-tag.yaml

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb-binlog/git-create-tag.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb-binlog/git-create-tag.yaml
@@ -1,0 +1,34 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: tag-create-pingcap-tidb-binlog
+  labels:
+    type: github-tag-create
+    github-owner: pingcap
+    github-repo: tidb-binlog
+spec:
+  interceptors:
+    - name: filter on repo owner and name
+      ref:
+        name: cel
+      params:
+        - name: filter
+          value: >-
+            body.repository.owner.login == 'pingcap' && body.repository.name == 'tidb-binlog'
+    - name: filter on version tags
+      ref:
+        name: cel
+      params:
+        - name: filter
+          value: >-
+            body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+')
+  bindings:
+    - ref: github-tag-create
+    - { name: component, value: $(body.repository.name) }
+    - { name: profile, value: release }
+    - { name: timeout, value: 2h }
+    - { name: source-ws-size, value: 100Gi }
+    - { name: builder-resources-memory, value: 64Gi }
+    - { name: builder-resources-cpu, value: "16" }
+  template:
+    ref: build-component-all-platforms

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb-binlog/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb-binlog/git-push.yaml
@@ -1,0 +1,34 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: git-push-pingcap-tidb-binlog
+  labels:
+    type: github-branch-push
+    github-owner: pingcap
+    github-repo: tidb-binlog
+spec:
+  interceptors:
+    - name: filter on repo owner and name
+      ref:
+        name: cel
+      params:
+        - name: filter
+          value: >-
+            body.repository.owner.login == 'pingcap' && body.repository.name == 'tidb-binlog'
+    - name: filter on branches
+      ref:
+        name: cel
+      params:
+        - name: filter
+          value: >-
+            body.ref.matches('^refs/heads/(master)$')
+  bindings:
+    - ref: github-branch-push
+    - { name: component, value: $(body.repository.name) }
+    - { name: profile, value: release }
+    - { name: timeout, value: 2h }
+    - { name: source-ws-size, value: 100Gi }
+    - { name: builder-resources-memory, value: 64Gi }
+    - { name: builder-resources-cpu, value: "16" }
+  template:
+    ref: build-component-all-platforms

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb-tools/git-create-tag.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb-tools/git-create-tag.yaml
@@ -1,0 +1,34 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: tag-create-pingcap-tidb-tools
+  labels:
+    type: github-tag-create
+    github-owner: pingcap
+    github-repo: tidb-tools
+spec:
+  interceptors:
+    - name: filter on repo owner and name
+      ref:
+        name: cel
+      params:
+        - name: filter
+          value: >-
+            body.repository.owner.login == 'pingcap' && body.repository.name == 'tidb-tools'
+    - name: filter on version tags
+      ref:
+        name: cel
+      params:
+        - name: filter
+          value: >-
+            body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+')
+  bindings:
+    - ref: github-tag-create
+    - { name: component, value: $(body.repository.name) }
+    - { name: profile, value: release }
+    - { name: timeout, value: 1h }
+    - { name: source-ws-size, value: 10Gi }
+    - { name: builder-resources-memory, value: 16Gi }
+    - { name: builder-resources-cpu, value: "4" }
+  template:
+    ref: build-component-all-platforms

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb-tools/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb-tools/git-push.yaml
@@ -1,0 +1,34 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: git-push-pingcap-tidb-tools
+  labels:
+    type: github-branch-push
+    github-owner: pingcap
+    github-repo: tidb-tools
+spec:
+  interceptors:
+    - name: filter on repo owner and name
+      ref:
+        name: cel
+      params:
+        - name: filter
+          value: >-
+            body.repository.owner.login == 'pingcap' && body.repository.name == 'tidb-tools'
+    - name: filter on branches
+      ref:
+        name: cel
+      params:
+        - name: filter
+          value: >-
+            body.ref.matches('^refs/heads/(master)$')
+  bindings:
+    - ref: github-branch-push
+    - { name: component, value: $(body.repository.name) }
+    - { name: profile, value: release }
+    - { name: timeout, value: 1h }
+    - { name: source-ws-size, value: 10Gi }
+    - { name: builder-resources-memory, value: 16Gi }
+    - { name: builder-resources-cpu, value: "4" }
+  template:
+    ref: build-component-all-platforms


### PR DESCRIPTION
- tidb-tools will not release from release-x.y branches.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>