### PR TITLE
refactor(apps/prod/tekton/configs/pipelines): increase acquire timeout rather than retry again

### DIFF
--- a/apps/prod/tekton/configs/pipelines/pingcap-build-package-darwin.yaml
+++ b/apps/prod/tekton/configs/pipelines/pingcap-build-package-darwin.yaml
@@ -86,14 +86,13 @@ spec:
     - name: acquire-mac-machine
       runAfter:
         - checkout    
-      retries: 1
       taskRef:
         name: boskos-acquire
       params:
         - name: server-url
           value: http://boskos.apps.svc
         - name: timeout
-          value: 5m
+          value: 10m
         - name: type
           value: "mac-machine-$(params.arch)"
         - name: owner-name


### PR DESCRIPTION
Tekton will send the failure notify for every retry, so it bothers us.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>