### PR TITLE
fix(apps/prod/tekton/configs/triggers): fix trigger for `monitoring` component

### DIFF
--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/monitoring/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/monitoring/git-push.yaml
@@ -42,7 +42,7 @@ spec:
             body.ref.matches('^refs/heads/(main|master)$')
   bindings:
     - { name: git-url, value: https://github.com/pingcap/monitoring.git }
-    - { name: git-revision, value: master }
+    - { name: git-revision, value: origin/master }
     - { name: git-ref, value: master }
     - { name: component, value: monitoring }
     - { name: profile, value: release }


### PR DESCRIPTION
the branch reversion should use `origin/master` rather than `master`

Signed-off-by: wuhuizuo <wuhuizuo@126.com>