### PR TITLE
Revert "fix(apps/prod/tekton/configs/triggers): fix trigger for `monitoring` component (#936)"

### DIFF
--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/monitoring/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/monitoring/git-push.yaml
@@ -42,7 +42,7 @@ spec:
             body.ref.matches('^refs/heads/(main|master)$')
   bindings:
     - { name: git-url, value: https://github.com/pingcap/monitoring.git }
-    - { name: git-revision, value: origin/master }
+    - { name: git-revision, value: master }
     - { name: git-ref, value: master }
     - { name: component, value: monitoring }
     - { name: profile, value: release }

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/monitoring/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/monitoring/git-push.yaml
@@ -14,25 +14,7 @@ spec:
       params:
         - name: filter
           value: >-
-            (
-              body.repository.owner.login == 'pingcap' && 
-              body.repository.name in [
-                'monitoring',
-                'tidb',
-                'tidb-binlog',
-                'tiflash',
-                'tiflow',
-                'tiproxy',
-              ]
-            ) || (
-              body.repository.owner.login == 'tikv' && 
-              body.repository.name in [
-                'tikv',
-                'pd',
-                'migration'
-              ]
-            )
-
+            body.repository.owner.login == 'pingcap' && body.repository.name == 'monitoring'
     - name: filter on branches
       ref:
         name: cel
@@ -41,10 +23,8 @@ spec:
           value: >-
             body.ref.matches('^refs/heads/(main|master)$')
   bindings:
-    - { name: git-url, value: https://github.com/pingcap/monitoring.git }
-    - { name: git-revision, value: master }
-    - { name: git-ref, value: master }
-    - { name: component, value: monitoring }
+    - ref: github-branch-push
+    - { name: component, value: $(body.repository.name) }
     - { name: profile, value: release }
     - { name: timeout, value: 30m }
     - { name: source-ws-size, value: 8Gi }


### PR DESCRIPTION
## What
This reverts commit e446c3ad0c841b119c937bb80eac1659721e9d9e.

## Why
Lack of reproducibility, and it will cause avalanche effect of triggers.