### PR TITLE
chore: deploy tidb image to use new enterprise-plugin branch for hotfix

### DIFF
--- a/apps/prod/tibuild/deployment.yaml
+++ b/apps/prod/tibuild/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app: tibuild
     spec:
       containers:
-      - image: ghcr.io/pingcap-qe/ee-apps/tibuild:d987e3c
+      - image: ghcr.io/pingcap-qe/ee-apps/tibuild:594e266
         imagePullPolicy: Always
         name: tibuild
         ports:


### PR DESCRIPTION
# Why:
- deploy new tidb image to use release-x.y.z enterprise plugin branch for hotfix