### PR TITLE
fix: tiflow-operator only for linux

### DIFF
--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tiflow-operator/fake-git-create-tag.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tiflow-operator/fake-git-create-tag.yaml
@@ -21,7 +21,7 @@ spec:
       params:
         - name: filter
           value: >-
-            body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+')
+            body.ref.matches('^v.+')
   bindings:
     - ref: github-tag-create
     - ref: ce-context

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tiflow-operator/git-create-tag.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tiflow-operator/git-create-tag.yaml
@@ -21,7 +21,7 @@ spec:
       params:
         - name: filter
           value: >-
-            body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+')
+            body.ref.matches('^v.+')
   bindings:
     - ref: github-tag-create
     - { name: component, value: $(body.repository.name) }

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tiflow-operator/git-create-tag.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tiflow-operator/git-create-tag.yaml
@@ -25,10 +25,11 @@ spec:
   bindings:
     - ref: github-tag-create
     - { name: component, value: $(body.repository.name) }
+    - { name: os, value: linux }
     - { name: profile, value: release }
     - { name: timeout, value: 30m }
     - { name: source-ws-size, value: 5Gi }
     - { name: builder-resources-memory, value: 4Gi }
     - { name: builder-resources-cpu, value: "2" }
   template:
-    ref: build-component-all-platforms
+    ref: build-component

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tiflow-operator/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tiflow-operator/git-push.yaml
@@ -26,10 +26,11 @@ spec:
   bindings:
     - ref: github-branch-push
     - { name: component, value: $(body.repository.name) }
+    - { name: os, value: linux }
     - { name: profile, value: release }
     - { name: timeout, value: 30m }
     - { name: source-ws-size, value: 5Gi }
     - { name: builder-resources-memory, value: 4Gi }
     - { name: builder-resources-cpu, value: "2" }
   template:
-    ref: build-component-all-platforms
+    ref: build-component


### PR DESCRIPTION
# Why:
- operator only live for k8s, so only linux docker image is needed