### PR TITLE
feat(apps/prod/tekton/ingress): add internal ingress

### DIFF
--- a/apps/prod/tekton/ingress/ingress-dashboard.yaml
+++ b/apps/prod/tekton/ingress/ingress-dashboard.yaml
@@ -25,4 +25,30 @@ spec:
                 name: tekton-dashboard
                 port:
                   name: http
-
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tekton-dashboard-internal
+  namespace: tekton-pipelines
+  labels:
+    app: tekton-dashboard
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/name: dashboard
+    app.kubernetes.io/part-of: tekton-dashboard
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: "${domain_internal}"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "${path_for_dashboard}(/|$)(.*)"
+            backend:
+              service:
+                name: tekton-dashboard
+                port:
+                  name: http

--- a/apps/prod/tekton/ingress/ingress-event-listener.yaml
+++ b/apps/prod/tekton/ingress/ingress-event-listener.yaml
@@ -19,3 +19,24 @@ spec:
                 name: el-public
                 port:
                   name: http-listener
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: el-internal
+  namespace: ee-cd
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: "${domain_internal}"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "${path_for_hook}(/|$)(.*)"
+            backend:
+              service:
+                name: el-internal
+                port:
+                  name: http-listener


### PR DESCRIPTION
- the internal hook listen on the internal ingress endpoint.
- add internal dashboard ingress to fast access the pages.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>