### PR TITLE
chore(apps/prod/tekton/configs/triggers): add trigger for release branches

### DIFF
--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/monitoring/fake-git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/monitoring/fake-git-push.yaml
@@ -8,20 +8,16 @@ metadata:
     github-repo: monitoring
 spec:
   interceptors:
-    - name: filter on repo owner and name
-      ref:
-        name: cel
+    - name: filter on repo owner and name and branches
+      ref: { name: cel }
       params:
         - name: filter
           value: >-
-            body.repository.owner.login == 'pingcap' && body.repository.name == 'monitoring'
-    - name: filter on branches
-      ref:
-        name: cel
-      params:
-        - name: filter
-          value: >-
-            body.ref.matches('^refs/heads/(main|master)$')
+            body.repository.owner.login == 'pingcap'
+              &&
+            body.repository.name == 'monitoring'
+              &&
+            body.ref.matches('^refs/heads/(master|release-(7[.]5|7[.]1|6[.]5|6[.]1))$')
 
   bindings:
     - ref: github-branch-push
@@ -33,5 +29,6 @@ spec:
     - { name: source-ws-size, value: 8Gi }
     - { name: builder-resources-memory, value: 4Gi }
     - { name: builder-resources-cpu, value: "2" }
+
   template:
     ref: build-component

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/monitoring/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/monitoring/git-push.yaml
@@ -8,20 +8,20 @@ metadata:
     github-repo: monitoring
 spec:
   interceptors:
-    - name: filter on repo owner and name
-      ref:
-        name: cel
+    - name: filter on repo owner and name and branches
+      ref: { name: cel }
       params:
         - name: filter
+          # support branches:
+          # - master
+          # - release-6.1, release-6.5, release-7.1, release-7.5        
           value: >-
-            body.repository.owner.login == 'pingcap' && body.repository.name == 'monitoring'
-    - name: filter on branches
-      ref:
-        name: cel
-      params:
-        - name: filter
-          value: >-
-            body.ref.matches('^refs/heads/(main|master)$')
+            body.repository.owner.login == 'pingcap'
+              &&
+            body.repository.name == 'monitoring'
+              &&
+            body.ref.matches('^refs/heads/(master|release-(7[.]5|7[.]1|6[.]5|6[.]1))$')
+
   bindings:
     - ref: github-branch-push
     - { name: component, value: $(body.repository.name) }
@@ -30,5 +30,6 @@ spec:
     - { name: source-ws-size, value: 8Gi }
     - { name: builder-resources-memory, value: 4Gi }
     - { name: builder-resources-cpu, value: "2" }
+
   template:
     ref: build-component-all-platforms

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/ng-monitoring/fake-git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/ng-monitoring/fake-git-push.yaml
@@ -8,20 +8,16 @@ metadata:
     github-repo: ng-monitoring
 spec:
   interceptors:
-    - name: filter on repo owner and name
-      ref:
-        name: cel
+    - name: filter on repo owner and name and branches
+      ref: { name: cel }
       params:
         - name: filter
           value: >-
-            body.repository.owner.login == 'pingcap' && body.repository.name == 'ng-monitoring'
-    - name: filter on branches
-      ref:
-        name: cel
-      params:
-        - name: filter
-          value: >-
-            body.ref.matches('^refs/heads/(main|master)$')
+            body.repository.owner.login == 'pingcap'
+              &&
+            body.repository.name == 'ng-monitoring'
+              &&
+            body.ref.matches('^refs/heads/(main|master|release-(7[.]5|7[.]1|6[.]5|6[.]1))$')
 
   bindings:
     - ref: github-branch-push
@@ -33,5 +29,6 @@ spec:
     - { name: source-ws-size, value: 8Gi }
     - { name: builder-resources-memory, value: 4Gi }
     - { name: builder-resources-cpu, value: "2" }
+
   template:
     ref: build-component

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/ng-monitoring/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/ng-monitoring/git-push.yaml
@@ -8,20 +8,19 @@ metadata:
     github-repo: ng-monitoring
 spec:
   interceptors:
-    - name: filter on repo owner and name
-      ref:
-        name: cel
+    - name: filter on repo owner and name and branches
+      ref: { name: cel }
       params:
         - name: filter
+          # support branches:
+          # - master
+          # - release-6.1, release-6.5, release-7.1, release-7.5
           value: >-
-            body.repository.owner.login == 'pingcap' && body.repository.name == 'ng-monitoring'
-    - name: filter on branches
-      ref:
-        name: cel
-      params:
-        - name: filter
-          value: >-
-            body.ref.matches('^refs/heads/(main|master)$')
+            body.repository.owner.login == 'pingcap'
+              &&
+            body.repository.name == 'ng-monitoring'
+              &&
+            body.ref.matches('^refs/heads/(main|master|release-(7[.]5|7[.]1|6[.]5|6[.]1))$')
   bindings:
     - ref: github-branch-push
     - { name: component, value: $(body.repository.name) }

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb-binlog/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb-binlog/git-push.yaml
@@ -8,20 +8,20 @@ metadata:
     github-repo: tidb-binlog
 spec:
   interceptors:
-    - name: filter on repo owner and name
-      ref:
-        name: cel
+    - name: filter on repo owner and name and branches
+      ref: { name: cel }
       params:
         - name: filter
+          # support branches:
+          # - master
+          # - release-6.1, release-6.5, release-7.1, release-7.5        
           value: >-
-            body.repository.owner.login == 'pingcap' && body.repository.name == 'tidb-binlog'
-    - name: filter on branches
-      ref:
-        name: cel
-      params:
-        - name: filter
-          value: >-
-            body.ref.matches('^refs/heads/(master)$')
+            body.repository.owner.login == 'pingcap'
+              &&
+            body.repository.name == 'tidb-binlog'
+              &&
+            body.ref.matches('^refs/heads/(master|release-(7[.]5|7[.]1|6[.]5|6[.]1))$')
+
   bindings:
     - ref: github-branch-push
     - { name: component, value: $(body.repository.name) }

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb-dashboard/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb-dashboard/git-push.yaml
@@ -8,19 +8,18 @@ metadata:
     github-repo: tidb-dashboard
 spec:
   interceptors:
-    - name: filter on repo owner and name
-      ref:
-        name: cel
+    - name: filter on repo owner and name and branches
+      ref: { name: cel }
       params:
         - name: filter
+          # support branches:
+          # - master
+          # - release-6.1, release-6.5, release-7.1, release-7.5        
           value: >-
-            body.repository.owner.login == 'pingcap' && body.repository.name == 'tidb-dashboard'
-    - name: filter on branches
-      ref:
-        name: cel
-      params:
-        - name: filter
-          value: >-
+            body.repository.owner.login == 'pingcap'
+              &&
+            body.repository.name == 'tidb-dashboard'
+              &&
             body.ref.matches('^refs/heads/(main|master)$')
   bindings:
     - ref: github-branch-push

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb-tools/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb-tools/git-push.yaml
@@ -8,20 +8,20 @@ metadata:
     github-repo: tidb-tools
 spec:
   interceptors:
-    - name: filter on repo owner and name
-      ref:
-        name: cel
+    - name: filter on repo owner and name and branches
+      ref: { name: cel }
       params:
         - name: filter
+          # support branches:
+          # - master
+          # - release-6.1, release-6.5, release-7.1, release-7.5        
           value: >-
-            body.repository.owner.login == 'pingcap' && body.repository.name == 'tidb-tools'
-    - name: filter on branches
-      ref:
-        name: cel
-      params:
-        - name: filter
-          value: >-
-            body.ref.matches('^refs/heads/(master)$')
+            body.repository.owner.login == 'pingcap'
+              &&
+            body.repository.name == 'tidb-tools'
+              &&
+            body.ref.matches('^refs/heads/(master)$')            
+
   bindings:
     - ref: github-branch-push
     - { name: component, value: $(body.repository.name) }

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb/fake-git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb/fake-git-push.yaml
@@ -8,20 +8,19 @@ metadata:
     github-repo: tidb
 spec:
   interceptors:
-    - name: filter on repo owner and name
-      ref:
-        name: cel
+    - name: filter on repo owner and name and branches
+      ref: { name: cel }
       params:
         - name: filter
+          # support branches:
+          # - master
+          # - release-6.1, release-6.5, release-7.1, release-7.5
           value: >-
-            body.repository.owner.login == 'pingcap' && body.repository.name == 'tidb'
-    - name: filter on branches
-      ref:
-        name: cel
-      params:
-        - name: filter
-          value: >-
-            body.ref.matches('^refs/heads/(master)$')
+            body.repository.owner.login == 'pingcap'
+              &&
+            body.repository.name == 'tidb'
+              &&
+            body.ref.matches('^refs/heads/(master|release-(7[.]5|7[.]1|6[.]5|6[.]1))$')
 
   bindings:
     - ref: github-branch-push

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb/git-push.yaml
@@ -50,7 +50,7 @@ spec:
       params:
         - name: filter
           # support branches:
-          # - feature/release-X.Y-*        
+          # - feature/release-X.Y-*
           value: >-
             body.repository.owner.login == 'pingcap'
               &&

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb/git-push.yaml
@@ -9,22 +9,18 @@ metadata:
     edition: community
 spec:
   interceptors:
-    - name: filter on repo owner and name
-      ref:
-        name: cel
-      params:
-        - name: filter
-          value: >-
-            body.repository.owner.login == 'pingcap' && body.repository.name == 'tidb'
-    - name: filter on branches
-      ref:
-        name: cel
+    - name: filter on repo owner and name and branches
+      ref: { name: cel }
       params:
         - name: filter
           # support branches:
           # - master
           # - release-6.1, release-6.5, release-7.1, release-7.5
           value: >-
+            body.repository.owner.login == 'pingcap'
+              &&
+            body.repository.name == 'tidb'
+              &&
             body.ref.matches('^refs/heads/(master|release-(7[.]5|7[.]1|6[.]5|6[.]1))$')
   bindings:
     - ref: github-branch-push
@@ -48,22 +44,20 @@ metadata:
     edition: enterprise
 spec:
   interceptors:
-    - name: filter on repo owner and name
-      ref:
-        name: cel
-      params:
-        - name: filter
-          value: >-
-            body.repository.owner.login == 'pingcap' && body.repository.name == 'tidb'
-    - name: filter on branches
+    - name: filter on repo owner and name and branches
       ref:
         name: cel
       params:
         - name: filter
           # support branches:
-          # - feature/release-X.Y-*
+          # - feature/release-X.Y-*        
           value: >-
+            body.repository.owner.login == 'pingcap'
+              &&
+            body.repository.name == 'tidb'
+              &&
             body.ref.matches('^refs/heads/(feature/release-[0-9]+[.][0-9]+-.*)$')
+
   bindings:
     - ref: github-branch-push
     - { name: component, value: $(body.repository.name) }

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tiflash/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tiflash/git-push.yaml
@@ -8,20 +8,20 @@ metadata:
     github-repo: tiflash
 spec:
   interceptors:
-    - name: filter on repo owner and name
-      ref:
-        name: cel
+    - name: filter on repo owner and name and branches
+      ref: { name: cel }
       params:
         - name: filter
+          # support branches:
+          # - master
+          # - release-6.1, release-6.5, release-7.1, release-7.5        
           value: >-
-            body.repository.owner.login == 'pingcap' && body.repository.name == 'tiflash'
-    - name: filter on branches
-      ref:
-        name: cel
-      params:
-        - name: filter
-          value: >-
-            body.ref.matches('^refs/heads/(master)$')
+            body.repository.owner.login == 'pingcap'
+              &&
+            body.repository.name == 'tiflash'
+              &&
+            body.ref.matches('^refs/heads/(master|release-(7[.]5|7[.]1|6[.]5|6[.]1))$')            
+
   bindings:
     - ref: github-branch-push
     - { name: component, value: $(body.repository.name) }

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tiflow-operator/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tiflow-operator/git-push.yaml
@@ -8,19 +8,15 @@ metadata:
     github-repo: tiflow-operator
 spec:
   interceptors:
-    - name: filter on repo owner and name
-      ref:
-        name: cel
+    - name: filter on repo owner and name and branches
+      ref: { name: cel }
       params:
         - name: filter
           value: >-
-            body.repository.owner.login == 'pingcap' && body.repository.name == 'tiflow-operator'
-    - name: filter on branches
-      ref:
-        name: cel
-      params:
-        - name: filter
-          value: >-
+            body.repository.owner.login == 'pingcap'
+              &&
+            body.repository.name == 'tiflow-operator'
+              &&
             body.ref.matches('^refs/heads/(master)$')
 
   bindings:

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tiflow/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tiflow/git-push.yaml
@@ -8,20 +8,19 @@ metadata:
     github-repo: tiflow
 spec:
   interceptors:
-    - name: filter on repo owner and name
-      ref:
-        name: cel
+    - name: filter on repo owner and name and branches
+      ref: { name: cel }
       params:
         - name: filter
+          # support branches:
+          # - master
+          # - release-6.1, release-6.5, release-7.1, release-7.5        
           value: >-
-            body.repository.owner.login == 'pingcap' && body.repository.name == 'tiflow'
-    - name: filter on branches
-      ref:
-        name: cel
-      params:
-        - name: filter
-          value: >-
-            body.ref.matches('^refs/heads/(master)$')
+            body.repository.owner.login == 'pingcap'
+              &&
+            body.repository.name == 'tiflow'
+              &&
+            body.ref.matches('^refs/heads/(master|release-(7[.]5|7[.]1|6[.]5|6[.]1))$')            
 
   bindings:
     - ref: github-branch-push

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tiproxy/fake-git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tiproxy/fake-git-push.yaml
@@ -8,19 +8,15 @@ metadata:
     github-repo: tiproxy
 spec:
   interceptors:
-    - name: filter on repo owner and name
-      ref:
-        name: cel
+    - name: filter on repo owner and name and branches
+      ref: { name: cel }
       params:
         - name: filter
           value: >-
-            body.repository.owner.login == 'pingcap' && body.repository.name == 'tiproxy'
-    - name: filter on branches
-      ref:
-        name: cel
-      params:
-        - name: filter
-          value: >-
+            body.repository.owner.login == 'pingcap'
+              &&
+            body.repository.name == 'tiproxy'
+              &&
             body.ref.matches('^refs/heads/(main|master)$')
 
   bindings:

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tiproxy/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tiproxy/git-push.yaml
@@ -8,19 +8,15 @@ metadata:
     github-repo: tiproxy
 spec:
   interceptors:
-    - name: filter on repo owner and name
-      ref:
-        name: cel
+    - name: filter on repo owner and name and branches
+      ref: { name: cel }
       params:
         - name: filter
           value: >-
-            body.repository.owner.login == 'pingcap' && body.repository.name == 'tiproxy'
-    - name: filter on branches
-      ref:
-        name: cel
-      params:
-        - name: filter
-          value: >-
+            body.repository.owner.login == 'pingcap'
+              &&
+            body.repository.name == 'tiproxy'
+              &&
             body.ref.matches('^refs/heads/(main|master)$')
   bindings:
     - ref: github-branch-push

--- a/apps/prod/tekton/configs/triggers/triggers/tikv/pd/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/tikv/pd/git-push.yaml
@@ -8,20 +8,19 @@ metadata:
     github-repo: pd
 spec:
   interceptors:
-    - name: filter on repo owner and name
-      ref:
-        name: cel
+    - name: filter on repo owner and name and branches
+      ref: { name: cel }
       params:
         - name: filter
+          # support branches:
+          # - master
+          # - release-6.1, release-6.5, release-7.1, release-7.5
           value: >-
-            body.repository.owner.login == 'tikv' && body.repository.name == 'pd'
-    - name: filter on branches
-      ref:
-        name: cel
-      params:
-        - name: filter
-          value: >-
-            body.ref.matches('^refs/heads/(master)$')
+            body.repository.owner.login == 'tikv'
+              &&
+            body.repository.name == 'pd'
+              &&
+            body.ref.matches('^refs/heads/(master|release-(7[.]5|7[.]1|6[.]5|6[.]1))$')
 
   bindings:
     - ref: github-branch-push

--- a/apps/prod/tekton/configs/triggers/triggers/tikv/tikv/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/tikv/tikv/git-push.yaml
@@ -8,20 +8,19 @@ metadata:
     github-repo: tikv
 spec:
   interceptors:
-    - name: filter on repo owner and name
-      ref:
-        name: cel
+    - name: filter on repo owner and name and branches
+      ref: { name: cel }
       params:
         - name: filter
+          # support branches:
+          # - master
+          # - release-6.1, release-6.5, release-7.1, release-7.5
           value: >-
-            body.repository.owner.login == 'tikv' && body.repository.name == 'tikv'
-    - name: filter on branches
-      ref:
-        name: cel
-      params:
-        - name: filter
-          value: >-
-            body.ref.matches('^refs/heads/(master)$')
+            body.repository.owner.login == 'tikv'
+              &&
+            body.repository.name == 'tikv'
+              &&
+            body.ref.matches('^refs/heads/(master|release-(7[.]5|7[.]1|6[.]5|6[.]1))$')
 
   bindings:
     - ref: github-branch-push


### PR DESCRIPTION
Add trigger for LTS release branches:

- release-6.1
- release-6.5
- release-7.1
- release-7.5

Also combine the CEL interceptors to save api calls to CEL service.

In feature we can set it for all release branches.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>