### PR TITLE
chore(apps/prod/tekton/configs/triggers): add trigger for `ctl` building

### DIFF
--- a/apps/prod/tekton/configs/triggers/templates/_/build-component-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/templates/_/build-component-single-platform.yaml
@@ -1,0 +1,99 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: build-component-single-platform
+spec:
+  params:
+    - name: git-url
+      description: The git repository full url
+    - name: git-revision
+      description: The git revision
+    - name: git-ref
+      description: The git branch
+    - name: component
+      description: component name, tidb|tikv|pd|tiflow|tiflash, etc...
+    - name: os
+      default: linux
+    - name: arch
+      default: amd64
+    - name: profile
+      description: build target profile
+      default: release
+    - name: timeout
+      description: pipeline run timeout
+      default: 2h
+    - name: source-ws-size
+      description: workspace size for source.
+      default: 10Gi
+    - name: builder-resources-memory
+      default: 16Gi
+    - name: builder-resources-cpu
+      default: "4"
+    - name: ce-context
+      description: cloud event context.
+      default: '{}'
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: build-package-$(tt.params.component)-$(tt.params.os)-$(tt.params.arch)-
+        annotations:
+          "tekton.dev/ce-context": $(tt.params.ce-context)
+          "tekton.dev/git-status": "true"
+          "tekton.dev/status-target-url": "https://do.pingcap.net/tekton/#/namespaces/{{ .Namespace }}/pipelineruns/{{ .Name }}"
+          "tekton.dev/git-repo": $(tt.params.git-url)
+          "tekton.dev/git-revision": $(tt.params.git-revision)
+      spec:
+        pipelineRef:
+          name: pingcap-build-package
+        params:
+          - name: git-url
+            value: $(tt.params.git-url)
+          - name: git-revision
+            value: $(tt.params.git-revision)
+          - name: git-ref
+            value: $(tt.params.git-ref)
+          - name: component
+            value: $(tt.params.component)
+          - name: profile
+            value: $(tt.params.profile)
+          - name: os
+            value: $(tt.params.os)
+          - name: arch
+            value: $(tt.params.arch)
+        taskRunSpecs:
+          - pipelineTaskName: build-binaries
+            taskPodTemplate:
+              nodeSelector:
+                kubernetes.io/arch: $(tt.params.arch)
+            stepOverrides:
+              - name: build
+                resources:
+                  requests:
+                    memory: $(tt.params.builder-resources-memory)
+                    cpu: $(tt.params.builder-resources-cpu)
+          - pipelineTaskName: build-images
+            taskPodTemplate:
+              nodeSelector:
+                kubernetes.io/arch: $(tt.params.arch)
+        timeouts:
+          pipeline: $(tt.params.timeout)
+        workspaces:
+          - name: dockerconfig
+            secret:
+              secretName: hub-pingcap-net-ee
+          - name: source
+            volumeClaimTemplate:
+              spec:
+                storageClassName: ceph-block
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: $(tt.params.source-ws-size)
+          - name: git-basic-auth # fetch with git-cdn.
+            secret:
+              secretName: git-credentials-basic
+          - name: cargo-home
+            persistentVolumeClaim:
+              claimName: cargo-home

--- a/apps/prod/tekton/configs/triggers/templates/kustomization.yaml
+++ b/apps/prod/tekton/configs/triggers/templates/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - _/build-component-all-platforms.yaml
+  - _/build-component-single-platform.yaml
   - _/build-component.yaml
   - _/image-push.yaml
   - _/push-oci-artifact-to-tiup.yaml

--- a/apps/prod/tekton/configs/triggers/triggers/_/ctl/artifact-push-on-harbor.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/ctl/artifact-push-on-harbor.yaml
@@ -1,0 +1,113 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: artifact-push-on-harbor-with-trunk-branch-tags-tidb
+  labels:
+    type: image-push
+spec:
+  interceptors:
+    - name: filter on image repo names and tags
+      ref:
+        name: cel
+      params:
+        - name: filter
+          value: >-
+            body.event_data.repository.repo_full_name.matches('^pingcap/tidb/package$')
+             &&
+            body.event_data.resources[0].tag.matches('^(master|main)(-[0-9a-f]{7-10})(-release)?[-_](darwin|linux)[-_](amd64|arm64)$')
+        - name: overlays
+          value:
+          - key: arch
+            expression: body.event_data.resources[0].tag.split('_')[-1]
+          - key: os
+            expression: body.event_data.resources[0].tag.split('_')[-2]
+          - key: git-ref
+            expression: body.event_data.resources[0].tag.split('_')[-3].spint('-')[:-1].join('_')
+          - key: git-revision
+            expression: body.event_data.resources[0].tag.split('_')[-3].spint('-')[-1]
+  bindings:
+    - { name: component, value: ctl }
+    - { name: profile, value: release }
+    - { name: git-url, value: https://github.com/pingcap/tidb.git }
+    - { name: git-ref, value: $(extensions.git-ref) }
+    - { name: git-revision, value: $(extensions.git-revision) }
+    - { name: os, value: $(extensions.os) }
+    - { name: arch, value: $(extensions.arch) }
+  template:
+    ref: build-component-single-platform
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: artifact-push-on-harbor-with-release-branch-tags-tidb
+  labels:
+    type: image-push
+spec:
+  interceptors:
+    - name: filter on image repo names and tags
+      ref:
+        name: cel
+      params:
+        - name: filter
+          value: >-
+            body.event_data.repository.repo_full_name.matches('^pingcap/tidb/package$')
+             &&
+            body.event_data.resources[0].tag.matches('^release-[0-9]+[.][0-9]+(-[0-9a-f]{7-10})-.*[-_](amd64|arm64)$')
+        - name: overlays
+          value:
+          - key: arch
+            expression: body.event_data.resources[0].tag.split('_')[-1]
+          - key: os
+            expression: body.event_data.resources[0].tag.split('_')[-2]
+          - key: git-ref
+            expression: body.event_data.resources[0].tag.split('_')[-3].spint('-')[:-1].join('_')
+          - key: git-revision
+            expression: body.event_data.resources[0].tag.split('_')[-3].spint('-')[-1]
+  bindings:
+    - { name: component, value: ctl }
+    - { name: profile, value: release }
+    - { name: git-url, value: https://github.com/pingcap/tidb.git }
+    - { name: git-ref, value: $(extensions.git-ref) }
+    - { name: git-revision, value: $(extensions.git-revision) }
+    - { name: os, value: $(extensions.os) }
+    - { name: arch, value: $(extensions.arch) }
+  template:
+    ref: build-component-single-platform
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: artifact-push-on-harbor-with-git-tags-tidb
+  labels:
+    type: image-push
+spec:
+  interceptors:
+    - name: filter on image repo names and tags
+      ref:
+        name: cel
+      params:
+        - name: filter
+          value: >-
+            body.event_data.repository.repo_full_name.matches('^pingcap/tidb/package$')
+             &&
+            body.event_data.resources[0].tag.matches('^v[0-9]+[.][0-9]+[.][0-9]+(-[0-9a-f]{7-10})[-_](linux|darwin)[-_](amd64|arm64)$')
+        - name: overlays
+          value:
+          - key: arch
+            expression: body.event_data.resources[0].tag.split('_')[-1]
+          - key: os
+            expression: body.event_data.resources[0].tag.split('_')[-2]
+          - key: git-ref
+            expression: body.event_data.resources[0].tag.split('_')[-3]
+          - key: git-revision
+            expression: body.event_data.resources[0].tag.split('_')[-3]
+  bindings:
+    - { name: component, value: ctl }
+    - { name: profile, value: release }
+    - { name: git-url, value: https://github.com/pingcap/tidb.git }
+    - { name: git-ref, value: $(extensions.git-ref) }
+    - { name: git-revision, value: $(extensions.git-revision) }
+    - { name: os, value: $(extensions.os) }
+    - { name: arch, value: $(extensions.arch) }
+  template:
+    ref: build-component-single-platform

--- a/apps/prod/tekton/configs/triggers/triggers/_/ctl/harbor.http
+++ b/apps/prod/tekton/configs/triggers/triggers/_/ctl/harbor.http
@@ -1,0 +1,26 @@
+## You should run it firstly:
+## kubectl port-forward -n ee-cd svc/el-internal 8080
+
+########################
+### push tidb oci artifacts
+POST http://127.0.0.1:8080 HTTP/1.1
+Content-Type: application/json
+
+{
+    "type": "PUSH_ARTIFACT",
+    "event_data": {
+        "resources": [
+            {
+                "digest": "sha256:6efdf19e78f53389153a1b7351168ee81a15ca2aa25a157fd47a714b5dcf14e4",
+                "tag": "master-1fc92b3_linux_amd64",
+                "resource_url": "hub.pingcap.net/pingcap/tidb/package:master-1fc92b3_linux_amd64"
+            }
+        ],
+        "repository": {
+            "name": "tidb/package",
+            "namespace": "pingcap",
+            "repo_full_name": "pingcap/tidb/package",
+            "repo_type": "public"
+        }
+    }
+}

--- a/apps/prod/tekton/configs/triggers/triggers/kustomization.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - _/artifact-push-on-harbor.yaml
+  - _/ctl/artifact-push-on-harbor.yaml
   - _/git-push-on-fips-branches.yaml
   - _/image-push-on-harbor.yaml
   - pingcap/_/git-create-branch-gomod-update.yaml

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb-binlog/test.http
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb-binlog/test.http
@@ -10,7 +10,7 @@ X-GitHub-Event: push
 {
     "ref": "refs/heads/master",
     "before": "00000000000000000000000000000000000000000",
-    "after": "154d6d99d8bda586e10723c3aacc6c4d8ff6a1c6",
+    "after": "a7fae77dc59418da9d8971ffae3a7399e34e290f",
     "ref_type": "branch",
     "repository": {
         "name": "tidb-binlog",


### PR DESCRIPTION
- The pushing of tidb OCI artifacts will trigger the building for `ctl` component.
- When building it, it juge version with tidb.git repo.