### PR TITLE
feat: enable release-x.x image sync to qa repo

### DIFF
--- a/apps/prod/tekton/configs/triggers/triggers/_/image-push-on-harbor.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/image-push-on-harbor.yaml
@@ -71,7 +71,7 @@ spec:
               && !
               body.event_data.repository.repo_full_name.matches('/package(s)?')
             ) &&
-            body.event_data.resources[0].tag.matches('^(master|main|release-[0-9]+\\.[0-9]+)(-[0-9a-f]+)?$')
+            body.event_data.resources[0].tag.matches('^(master|main|release-[0-9]+[.][0-9]+)(-[0-9a-f]+)?$')
 
   bindings:
     - ref: harbor-image-push

--- a/apps/prod/tekton/configs/triggers/triggers/_/image-push-on-harbor.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/image-push-on-harbor.yaml
@@ -71,7 +71,7 @@ spec:
               && !
               body.event_data.repository.repo_full_name.matches('/package(s)?')
             ) &&
-            body.event_data.resources[0].tag.matches('^(master|main)(-[0-9a-f]+)?$')
+            body.event_data.resources[0].tag.matches('^(master|main|release-[0-9]+\\.[0-9]+)(-[0-9a-f]+)?$')
 
   bindings:
     - ref: harbor-image-push


### PR DESCRIPTION
# Why:
- enale sync rc image to qa. 
- eg. hub.pingcap.net/tikv/pd/image:release-x.x -> hub.pingcap.net/qa/pd:release-x.x