### PR TITLE
chore: lease timeout check to avoid too much restart

### DIFF
--- a/apps/prod/tibuild/deployment.yaml
+++ b/apps/prod/tibuild/deployment.yaml
@@ -37,8 +37,9 @@ spec:
           httpGet:
             path: /swagger/index.html
             port: 8080
-          initialDelaySeconds: 3
-          periodSeconds: 3
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - name: configs
           mountPath: "/app/configs"


### PR DESCRIPTION
Why:
- tibuild pod usually restart
- our k8s network sometimes will be slow, so just loose the timeout