### PR TITLE
chore: upgrade tibuild

### DIFF
--- a/apps/prod/tibuild/deployment.yaml
+++ b/apps/prod/tibuild/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app: tibuild
     spec:
       containers:
-      - image: ghcr.io/pingcap-qe/ee-apps/tibuild:594e266
+      - image: ghcr.io/pingcap-qe/ee-apps/tibuild:0f07b00
         imagePullPolicy: Always
         name: tibuild
         ports:


### PR DESCRIPTION
Why:
- upgrade tibuild to trigger tekton