### PR TITLE
fix: do not build for older release version

### DIFF
--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/monitoring/fake-git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/monitoring/fake-git-push.yaml
@@ -17,7 +17,7 @@ spec:
               &&
             body.repository.name == 'monitoring'
               &&
-            body.ref.matches('^refs/heads/(master|release-(7[.]5|7[.]1|6[.]5|6[.]1))$')
+            body.ref.matches('^refs/heads/(master|release-(7[.]5|7[.]1))$')
 
   bindings:
     - ref: github-branch-push

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/monitoring/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/monitoring/git-push.yaml
@@ -20,7 +20,7 @@ spec:
               &&
             body.repository.name == 'monitoring'
               &&
-            body.ref.matches('^refs/heads/(master|release-(7[.]5|7[.]1|6[.]5|6[.]1))$')
+            body.ref.matches('^refs/heads/(master|release-(7[.]5|7[.]1))$')
 
   bindings:
     - ref: github-branch-push

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/ng-monitoring/fake-git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/ng-monitoring/fake-git-push.yaml
@@ -17,7 +17,7 @@ spec:
               &&
             body.repository.name == 'ng-monitoring'
               &&
-            body.ref.matches('^refs/heads/(main|master|release-(7[.]5|7[.]1|6[.]5|6[.]1))$')
+            body.ref.matches('^refs/heads/(main|master|release-(7[.]5|7[.]1))$')
 
   bindings:
     - ref: github-branch-push

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/ng-monitoring/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/ng-monitoring/git-push.yaml
@@ -20,7 +20,7 @@ spec:
               &&
             body.repository.name == 'ng-monitoring'
               &&
-            body.ref.matches('^refs/heads/(main|master|release-(7[.]5|7[.]1|6[.]5|6[.]1))$')
+            body.ref.matches('^refs/heads/(main|master|release-(7[.]5|7[.]1))$')
   bindings:
     - ref: github-branch-push
     - { name: component, value: $(body.repository.name) }

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb-binlog/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb-binlog/git-push.yaml
@@ -20,7 +20,7 @@ spec:
               &&
             body.repository.name == 'tidb-binlog'
               &&
-            body.ref.matches('^refs/heads/(master|release-(7[.]5|7[.]1|6[.]5|6[.]1))$')
+            body.ref.matches('^refs/heads/(master|release-(7[.]5|7[.]1))$')
 
   bindings:
     - ref: github-branch-push

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb/fake-git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb/fake-git-push.yaml
@@ -20,7 +20,7 @@ spec:
               &&
             body.repository.name == 'tidb'
               &&
-            body.ref.matches('^refs/heads/(master|release-(7[.]5|7[.]1|6[.]5|6[.]1))$')
+            body.ref.matches('^refs/heads/(master|release-(7[.]5|7[.]1))$')
 
   bindings:
     - ref: github-branch-push

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb/git-push.yaml
@@ -21,7 +21,7 @@ spec:
               &&
             body.repository.name == 'tidb'
               &&
-            body.ref.matches('^refs/heads/(master|release-(7[.]5|7[.]1|6[.]5|6[.]1))$')
+            body.ref.matches('^refs/heads/(master|release-(7[.]5|7[.]1))$')
   bindings:
     - ref: github-branch-push
     - { name: component, value: $(body.repository.name) }

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tiflash/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tiflash/git-push.yaml
@@ -20,7 +20,7 @@ spec:
               &&
             body.repository.name == 'tiflash'
               &&
-            body.ref.matches('^refs/heads/(master|release-(7[.]5|7[.]1|6[.]5|6[.]1))$')            
+            body.ref.matches('^refs/heads/(master|release-(7[.]5|7[.]1))$')            
 
   bindings:
     - ref: github-branch-push

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tiflow/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tiflow/git-push.yaml
@@ -20,7 +20,7 @@ spec:
               &&
             body.repository.name == 'tiflow'
               &&
-            body.ref.matches('^refs/heads/(master|release-(7[.]5|7[.]1|6[.]5|6[.]1))$')            
+            body.ref.matches('^refs/heads/(master|release-(7[.]5|7[.]1))$')            
 
   bindings:
     - ref: github-branch-push

--- a/apps/prod/tekton/configs/triggers/triggers/tikv/pd/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/tikv/pd/git-push.yaml
@@ -20,7 +20,7 @@ spec:
               &&
             body.repository.name == 'pd'
               &&
-            body.ref.matches('^refs/heads/(master|release-(7[.]5|7[.]1|6[.]5|6[.]1))$')
+            body.ref.matches('^refs/heads/(master|release-(7[.]5|7[.]1))$')
 
   bindings:
     - ref: github-branch-push

--- a/apps/prod/tekton/configs/triggers/triggers/tikv/tikv/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/tikv/tikv/git-push.yaml
@@ -20,7 +20,7 @@ spec:
               &&
             body.repository.name == 'tikv'
               &&
-            body.ref.matches('^refs/heads/(master|release-(7[.]5|7[.]1|6[.]5|6[.]1))$')
+            body.ref.matches('^refs/heads/(master|release-(7[.]5|7[.]1))$')
 
   bindings:
     - ref: github-branch-push


### PR DESCRIPTION
# Why:
- new pipeline is not ready for older version yet

# How:
- disable trigger for release-6.5 and release-6.1