### PR TITLE
feat: use dockerhub through internal mirror

### DIFF
--- a/apps/prod/tekton/configs/tasks/pingcap-build-images.yaml
+++ b/apps/prod/tekton/configs/tasks/pingcap-build-images.yaml
@@ -73,10 +73,10 @@ spec:
       image: gcr.io/kaniko-project/executor:debug
       workingDir: $(workspaces.source.path)/$(params.component)
       env:
-        - name: KANIKO_REGISTRY_MIRROR
-          value: registry-mirror.pingcap.net
         - name: KANIKO_EXECUTOR
           value: /kaniko/executor
+        - name: KANIKO_REGISTRY_MIRROR
+          value: registry-mirror.pingcap.net
       resources:
         requests:
           cpu: "4"

--- a/apps/prod/tekton/configs/tasks/pingcap-build-images.yaml
+++ b/apps/prod/tekton/configs/tasks/pingcap-build-images.yaml
@@ -73,6 +73,8 @@ spec:
       image: gcr.io/kaniko-project/executor:debug
       workingDir: $(workspaces.source.path)/$(params.component)
       env:
+        - name: KANIKO_REGISTRY_MIRROR
+          value: registry-mirror.pingcap.net
         - name: KANIKO_EXECUTOR
           value: /kaniko/executor
       resources:


### PR DESCRIPTION
# Why:
pull from dockerhub directly will
- use internet bandwidth
- meet 'TOOMANYREQUESTS: You have reached your pull rate limit'

# How:
- pull dockerhub image through PingCAP internal mirror