### PR TITLE
fix(apps/prod/cloudevents-server): bump image tag to `v20240228-8-g6a29275`

### DIFF
--- a/apps/prod/cloudevents-server/release.yaml
+++ b/apps/prod/cloudevents-server/release.yaml
@@ -38,7 +38,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/cloudevents-server
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/cloudevents-server versioning=docker
-      tag: v20240228-3-g051c1fd
+      tag: v20240228-8-g6a29275
     server:
       args: [--config=/config/config.yaml]
       volumeMounts:


### PR DESCRIPTION
Ref: https://github.com/PingCAP-QE/ee-apps/pull/94