### PR TITLE
Revert "fix(apps/prod/tekton/configs/pipelines): use checkout result as commit sha to downstream tasks"

### DIFF
--- a/apps/prod/tekton/configs/pipelines/pingcap-build-package-darwin.yaml
+++ b/apps/prod/tekton/configs/pipelines/pingcap-build-package-darwin.yaml
@@ -140,7 +140,7 @@ spec:
         - name: git-ref
           value: $(params.git-ref)
         - name: git-sha
-          value: $(tasks.checkout.commit)
+          value: $(params.git-revision)
         - name: builder-image
           value: "$(tasks.get-binaries-builder.results.image-url)"
         - name: release-dir

--- a/apps/prod/tekton/configs/pipelines/pingcap-build-package.yaml
+++ b/apps/prod/tekton/configs/pipelines/pingcap-build-package.yaml
@@ -132,7 +132,7 @@ spec:
         - name: git-ref
           value: $(params.git-ref)
         - name: git-sha
-          value: $(tasks.checkout.commit)
+          value: $(params.git-revision)
         - name: builder-image
           value: "$(tasks.get-binaries-builder.results.image-url)"
         - name: release-dir
@@ -170,7 +170,7 @@ spec:
         - name: git-ref
           value: $(params.git-ref)
         - name: git-sha
-          value: $(tasks.checkout.commit)
+          value: $(params.git-revision)
         - name: release-dir
           value: build
         - name: build


### PR DESCRIPTION
Reverts PingCAP-QE/ee-ops#1052