### PR TITLE
test(apps/prod/tekton/configs/triggers): fix trigger name length issue

### DIFF
--- a/apps/prod/tekton/configs/pipelines/pingcap-build-package-darwin.yaml
+++ b/apps/prod/tekton/configs/pipelines/pingcap-build-package-darwin.yaml
@@ -115,7 +115,7 @@ spec:
         - name: server-url
           value: http://boskos.apps.svc
         - name: timeout
-          value: 10m
+          value: 15m
         - name: type
           value: "mac-machine-$(params.arch)"
         - name: owner-name
@@ -160,6 +160,7 @@ spec:
     - name: release-mac-machine
       taskRef:
         name: boskos-release
+      timeout: 2m0s
       params:
         - name: server-url
           value: http://boskos.apps.svc

--- a/apps/prod/tekton/configs/triggers/triggers/_/ctl/artifact-push-on-harbor.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/ctl/artifact-push-on-harbor.yaml
@@ -1,7 +1,7 @@
 apiVersion: triggers.tekton.dev/v1beta1
 kind: Trigger
 metadata:
-  name: artifact-push-on-harbor-with-trunk-branch-tags-ctl-upstream-repos
+  name: artifact-push-on-harbor-with-trunk-branch-tags-ctl-repos
   labels:
     type: image-push
 spec:
@@ -48,7 +48,7 @@ spec:
 apiVersion: triggers.tekton.dev/v1beta1
 kind: Trigger
 metadata:
-  name: artifact-push-on-harbor-with-release-branch-tags-ctl-upstream-repos
+  name: artifact-push-on-harbor-with-release-branch-tags-ctl-repos
   labels:
     type: image-push
 spec:
@@ -95,7 +95,7 @@ spec:
 # apiVersion: triggers.tekton.dev/v1beta1
 # kind: Trigger
 # metadata:
-#   name: artifact-push-on-harbor-with-git-tags-ctl-upstream-repos
+#   name: artifact-push-on-harbor-with-git-tags-ctl-repos
 #   labels:
 #     type: image-push
 # spec:


### PR DESCRIPTION
Why: length must be no more than 63 characters for `metadata.name`
Signed-off-by: wuhuizuo <wuhuizuo@126.com>