### PR TITLE
tests(apps/prod/tekton/configs/triggers/templates):  reserve timeout for finally task

### DIFF
--- a/apps/prod/tekton/configs/triggers/templates/_/build-component-all-platforms.yaml
+++ b/apps/prod/tekton/configs/triggers/templates/_/build-component-all-platforms.yaml
@@ -194,6 +194,7 @@ spec:
                 kubernetes.io/arch: amd64
         timeouts:
           pipeline: $(tt.params.timeout)
+          finally: 5m0s # reserve for darwin machine resource releasing.
         workspaces:
           - name: dockerconfig
             secret:
@@ -250,6 +251,7 @@ spec:
                 kubernetes.io/arch: amd64
         timeouts:
           pipeline: $(tt.params.timeout)
+          finally: 5m0s # reserve for darwin machine resource releasing.
         workspaces:
           - name: dockerconfig
             secret:


### PR DESCRIPTION
reserve for darwin machine resource releasing.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>