### PR TITLE
Revert "feat(apps/prod/tekton/configs/tasks): add env var `RUSTUP_DIST_SERVER` in binary building step"

### DIFF
--- a/apps/prod/tekton/configs/tasks/pingcap-build-binaries-darwin.yaml
+++ b/apps/prod/tekton/configs/tasks/pingcap-build-binaries-darwin.yaml
@@ -127,11 +127,6 @@ spec:
 
         # 3. set npm mirror
         echo 'export NPM_CONFIG_REGISTRY="https://registry.npmmirror.com"' >> /workspace/remote.env
-
-        # 4. optional set for rust
-        echo 'export CARGO_NET_GIT_FETCH_WITH_CLI=true' >> /workspace/remote.env
-        echo 'export RUSTUP_DIST_SERVER= https://mirrors.tuna.tsinghua.edu.cn/rustup' >> /workspace/remote.env
-
     - name: build
       image: ghcr.io/pingcap-qe/cd/utils/remote:v20231216-51-g3bb25fd
       env:

--- a/apps/prod/tekton/configs/tasks/pingcap-build-binaries.yaml
+++ b/apps/prod/tekton/configs/tasks/pingcap-build-binaries.yaml
@@ -88,8 +88,6 @@ spec:
       env:
         - name: CARGO_NET_GIT_FETCH_WITH_CLI
           value: 'true'
-        - name: RUSTUP_DIST_SERVER
-          value: https://mirrors.tuna.tsinghua.edu.cn/rustup
         - name: GOPROXY
           value: 'http://goproxy.apps.svc,direct'
         - name: CARGO_HOME

--- a/apps/prod/tekton/configs/tasks/release/create-pr-to-bump-tikv-version.yaml
+++ b/apps/prod/tekton/configs/tasks/release/create-pr-to-bump-tikv-version.yaml
@@ -62,8 +62,6 @@ spec:
       env:
         - name: CARGO_NET_GIT_FETCH_WITH_CLI
           value: 'true'
-        - name: RUSTUP_DIST_SERVER
-          value: https://mirrors.tuna.tsinghua.edu.cn/rustup
         - name: CARGO_HOME
           value: /workspace/.cargo
       script: |


### PR DESCRIPTION
Reverts PingCAP-QE/ee-ops#1137

No nightly release found  in mirror, only have stable releases.