### PR TITLE
Revert "feat(apps/prod/tekton/configs/pvcs): add global crate index mirror"

### DIFF
--- a/apps/prod/tekton/configs/pvcs/cargo-home.yaml
+++ b/apps/prod/tekton/configs/pvcs/cargo-home.yaml
@@ -15,13 +15,13 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: add-cargo-config-in-pvc
+  name: del-cargo-config-in-pvc
 spec:
   template:
     spec:
       restartPolicy: Never
       containers:
-        - name: add-cargo-config
+        - name: del-cargo-config
           image: busybox:1.36.1
           env:
             - name: CRATES_IO_REGISTRY_MIRROR
@@ -30,13 +30,7 @@ spec:
             - /bin/sh
             - -c
             - |
-              cat << EOF | tee -a /cargo/config
-              [source.crates-io]
-              replace-with = 'mirror'
-
-              [source.mirror]
-              registry = "${CRATES_IO_REGISTRY_MIRROR}"
-              EOF
+              rm -f /cargo/config
           volumeMounts:
             - name: cargo-home
               mountPath: /cargo


### PR DESCRIPTION
Reverts PingCAP-QE/ee-ops#1140

```
Caused by:
  File exists (os error 17)
+ r=101
+ set +x
make[2]: *** [Makefile:459: x-build-dist] Error 101
make[2]: Leaving directory '/workspace/source/tikv'
make[1]: *** [Makefile:270: build_dist_release] Error 2
make[1]: Leaving directory '/workspace/source/tikv'
make: *** [Makefile:259: dist_release] Error 2

```