### PR TITLE
Update cargo-home.yaml

### DIFF
--- a/apps/prod/tekton/configs/pvcs/cargo-home.yaml
+++ b/apps/prod/tekton/configs/pvcs/cargo-home.yaml
@@ -21,11 +21,11 @@ spec:
     spec:
       restartPolicy: Never
       containers:
-        - name: add-cargo-config
+        - name: add-cargo-config-with-git-type-mirror
           image: busybox:1.36.1
           env:
             - name: CRATES_IO_REGISTRY_MIRROR
-              value: "sparse+https://mirrors.tuna.tsinghua.edu.cn/crates.io-index/"
+              value: "https://mirrors.tuna.tsinghua.edu.cn/git/crates.io-index.git"
           command:
             - /bin/sh
             - -c


### PR DESCRIPTION
TiFlash use rust nightly-2022-11-15, can not use sparse type mirror without modify the build commands.