### PR TITLE
fix(apps/gcp/prow/release): bump hook to v20240614-fd27fb709

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -74,7 +74,7 @@ spec:
         enabled: false
       image:
         repository: ticommunityinfra/hook
-        tag: v20240301-09ad8bf
+        tag: v20240614-fd27fb709
       kubeconfigSecret: prow-kubeconfig
       additionalArgs:
         - --kubeconfig=/etc/kubeconfig/config


### PR DESCRIPTION
Fix dco plugin to ignore merge type commits.