### PR TITLE
fix(pingcap-qe/artifacts): fix cache sync task

### DIFF
--- a/apps/prod/tekton/configs/triggers/triggers/PingCAP-QE/artifacts/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/PingCAP-QE/artifacts/git-push.yaml
@@ -48,7 +48,7 @@ spec:
 
                   wget "https://github.com/${org}/${repo}/archive/${branch}.zip" -O - | unzip -
 
-                  ks3util sync "${repo}-${branch}" ks3://ee-fileserver/download/raw.githubusercontent.com/${org}/${repo}/${branch}
+                  ks3util sync "${repo}-${branch}" ks3://ee-fileserver/download/raw.githubusercontent.com/${org}/${repo}/${branch} --delete -f
               - name: ARGS
                 value: []
             workspaces:


### PR DESCRIPTION
### **User description**
Signed-off-by: wuhuizuo <wuhuizuo@126.com>


___

### **PR Type**
Bug fix


___

### **Description**
- Added `--delete -f` flags to `ks3util sync` command in `git-push.yaml` to ensure proper cache synchronization.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>git-push.yaml</strong><dd><code>Fix cache sync task with additional flags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/prod/tekton/configs/triggers/triggers/PingCAP-QE/artifacts/git-push.yaml

- Added `--delete -f` flags to `ks3util sync` command.



</details>


  </td>
  <td><a href="https://github.com/PingCAP-QE/ee-ops/pull/1176/files#diff-0be829dd6735a25ee2dcd3ba6229d657d5c901e58e1debad1f228242e3563300">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

