### PR TITLE
fix(apps/prod/tekton/configs/triggers/triggers): fix binding for triggers

### DIFF
--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml
@@ -66,6 +66,6 @@ spec:
     - { name: builder-resources-cpu, value: $(extensions.builder-resources-cpu) }
     - { name: builder-resources-memory, value: $(extensions.builder-resources-memory) }
     - { name: registry, value: hub.pingcap.net/devbuild }
-    - { name: force-builder-image, value: $(extensions.custom-params.force-builder-image) }
+    - { name: force-builder-image, value: $(extensions.custom-params.builder-image) }
   template:
     ref: build-component

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr.yaml
@@ -66,6 +66,6 @@ spec:
     - { name: builder-resources-cpu, value: $(extensions.builder-resources-cpu) }
     - { name: builder-resources-memory, value: $(extensions.builder-resources-memory) }
     - { name: registry, value: hub.pingcap.net/devbuild }
-    - { name: force-builder-image, value: $(extensions.custom-params.force-builder-image) }
+    - { name: force-builder-image, value: $(extensions.custom-params.builder-image) }
   template:
     ref: build-component

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create.yaml
@@ -68,6 +68,6 @@ spec:
     - { name: builder-resources-cpu, value: $(extensions.builder-resources-cpu) }
     - { name: builder-resources-memory, value: $(extensions.builder-resources-memory) }
     - { name: registry, value: hub.pingcap.net/devbuild }
-    - { name: force-builder-image, value: $(extensions.custom-params.force-builder-image) }
+    - { name: force-builder-image, value: $(extensions.custom-params.builder-image) }
   template:
     ref: build-component


### PR DESCRIPTION
### **User description**
Signed-off-by: wuhuizuo <wuhuizuo@126.com>


___

### **PR Type**
Bug fix


___

### **Description**
- Corrected the parameter name from `force-builder-image` to `builder-image` in the following trigger configurations:
  - fake-github-branch-push
  - fake-github-pr
  - fake-github-tag-create



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fake-github-branch-push.yaml</strong><dd><code>Fix parameter name in fake-github-branch-push trigger configuration</code></dd></summary>
<hr>

apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml

<li>Corrected the parameter name from <code>force-builder-image</code> to <br><code>builder-image</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/PingCAP-QE/ee-ops/pull/1180/files#diff-568be39468441f09f11d91d4c71d77c96952fb478d3695735af6b02f24cb8969">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>fake-github-pr.yaml</strong><dd><code>Fix parameter name in fake-github-pr trigger configuration</code></dd></summary>
<hr>

apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr.yaml

<li>Corrected the parameter name from <code>force-builder-image</code> to <br><code>builder-image</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/PingCAP-QE/ee-ops/pull/1180/files#diff-16116bc799a164aec2da92871c9b9f6e55fc88587d954afb5d13c261f014fefc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>fake-github-tag-create.yaml</strong><dd><code>Fix parameter name in fake-github-tag-create trigger configuration</code></dd></summary>
<hr>

apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create.yaml

<li>Corrected the parameter name from <code>force-builder-image</code> to <br><code>builder-image</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/PingCAP-QE/ee-ops/pull/1180/files#diff-91cd5bc58ced2d97dfd4052e5009edbe7fffbe44f7427f2bb0a0d084636dc615">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

