### PR TITLE
chore(apps/prod/tekton/configs/triggers): increase pipeline run timeout to 3h

### DIFF
--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tiflash/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tiflash/git-push.yaml
@@ -23,7 +23,7 @@ spec:
     - ref: github-branch-push
     - { name: component, value: $(body.repository.name) }
     - { name: profile, value: release }
-    - { name: timeout, value: 2h }
+    - { name: timeout, value: 3h }
     - { name: source-ws-size, value: 100Gi }
     - { name: builder-resources-memory, value: 64Gi }
     - { name: builder-resources-cpu, value: "16" }

--- a/apps/prod/tekton/configs/triggers/triggers/tikv/tikv/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/tikv/tikv/git-push.yaml
@@ -27,7 +27,7 @@ spec:
     - ref: github-branch-push
     - { name: component, value: $(body.repository.name) }
     - { name: profile, value: release }
-    - { name: timeout, value: 2h30m }
+    - { name: timeout, value: 3h }
     - { name: source-ws-size, value: 100Gi }
     - { name: builder-resources-memory, value: 64Gi }
     - { name: builder-resources-cpu, value: "16" }


### PR DESCRIPTION
### **User description**
avoid timeout on low performance mac machines.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>


___

### **PR Type**
Enhancement


___

### **Description**
- Increased the pipeline run timeout to 3 hours for `tiflash` and `tikv` components to avoid timeouts on low-performance Mac machines.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>git-push.yaml</strong><dd><code>Increase pipeline run timeout for tiflash to 3 hours</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/prod/tekton/configs/triggers/triggers/pingcap/tiflash/git-push.yaml

- Increased the pipeline run timeout from 2 hours to 3 hours.



</details>


  </td>
  <td><a href="https://github.com/PingCAP-QE/ee-ops/pull/1183/files#diff-6e78f2630b4e5890dc50fb9598495a196a1b7fe64a8c02dd8dfe8d5aa02de362">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>git-push.yaml</strong><dd><code>Increase pipeline run timeout for tikv to 3 hours</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/prod/tekton/configs/triggers/triggers/tikv/tikv/git-push.yaml

<li>Increased the pipeline run timeout from 2 hours 30 minutes to 3 hours.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/PingCAP-QE/ee-ops/pull/1183/files#diff-ceb19cb38b44288c72499046b4b06a1623e1bb43db2a0de59cfecc078a9b1583">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

