### PR TITLE
chore(deps): bump docker images denoland/deno to `1.45.5`

### DIFF
--- a/apps/prod/jenkins/pre/cronjobs.yaml
+++ b/apps/prod/jenkins/pre/cronjobs.yaml
@@ -12,7 +12,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: deno
-              image: "denoland/deno:1.42.1"
+              image: "denoland/deno:1.45.5"
               tty: true
               args:
                 - run

--- a/apps/prod/tekton/configs/tasks/hotfix/create-pr-to-sync-owners.yaml
+++ b/apps/prod/tekton/configs/tasks/hotfix/create-pr-to-sync-owners.yaml
@@ -27,7 +27,7 @@ spec:
       script: |
         git clone https://github.com/pingcap/community.git --branch master
     - name: create-pull-request
-      image: denoland/deno:1.42.1
+      image: denoland/deno:1.45.5
       workingDir: /workspace/community
       script: |
         owner=$(basename $(dirname $(params.git-url)))

--- a/apps/prod/tekton/configs/tasks/release/create-pr-to-add-release-anchor-commit.yaml
+++ b/apps/prod/tekton/configs/tasks/release/create-pr-to-add-release-anchor-commit.yaml
@@ -74,7 +74,7 @@ spec:
           exit 1
         fi
     - name: create-pull-request
-      image: denoland/deno:1.42.1
+      image: denoland/deno:1.45.5
       script: |
         owner=$(basename $(dirname $(params.git-url)))
         repo=$(basename $(params.git-url) .git)

--- a/apps/staging/jenkins/pre/obc/cronjobs.yaml
+++ b/apps/staging/jenkins/pre/obc/cronjobs.yaml
@@ -12,7 +12,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: deno
-              image: "denoland/deno:1.42.1"
+              image: "denoland/deno:1.45.5"
               args:
                 - run
                 - --allow-all


### PR DESCRIPTION
Signed-off-by: wuhuizuo <wuhuizuo@126.com>