### PR TITLE
fix(jenkins/release/jenkins): use another ci cache bucket

### DIFF
--- a/apps/prod/jenkins/pre/cronjobs.yaml
+++ b/apps/prod/jenkins/pre/cronjobs.yaml
@@ -22,9 +22,9 @@ spec:
                 - --keep-size-g=1000
               envFrom:
                 - secretRef:
-                    name: ci-pipeline-cache
+                    name: ci-pipeline-cache2
                 - configMapRef:
-                    name: ci-pipeline-cache
+                    name: ci-pipeline-cache2
               resources:
                 requests:
                   memory: "128Mi"

--- a/apps/prod/jenkins/pre/obc/obc.yaml
+++ b/apps/prod/jenkins/pre/obc/obc.yaml
@@ -8,3 +8,14 @@ spec:
     maxSize: 2000G
   bucketName: ci-pipeline-cache
   storageClassName: ceph-bucket
+---
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: ci-pipeline-cache2
+  namespace: apps
+spec:
+  additionalConfig:
+    maxSize: 2000G
+  bucketName: ci-pipeline-cache2
+  storageClassName: ceph-bucket

--- a/apps/prod/jenkins/pre/secret.yaml
+++ b/apps/prod/jenkins/pre/secret.yaml
@@ -18,6 +18,6 @@ spec:
   postBuild:
     substituteFrom:
       - kind: Secret
-        name: ci-pipeline-cache
+        name: ci-pipeline-cache2
       - kind: ConfigMap
-        name: ci-pipeline-cache
+        name: ci-pipeline-cache2


### PR DESCRIPTION
the previous can not be GC well.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>