### PR TITLE
fix(jenkins/release/jenkins): upgrade to jdk17 edition

### DIFF
--- a/apps/prod/jenkins/release/values-controller.yaml
+++ b/apps/prod/jenkins/release/values-controller.yaml
@@ -3,7 +3,7 @@ controller:
   image:
     registry: "docker.io"
     repository: "jenkins/jenkins"
-    tag: "2.426.3-lts-jdk11"
+    tag: "2.426.3-lts-jdk17"
   resources:
     requests:
       cpu: "16"


### PR DESCRIPTION
Java 11 EOL is 2024-09 for jenkins LTS.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>