### PR TITLE
fix(apps/prod/tibuild): bump docker image to v20240228-72-gd319bf4

### DIFF
--- a/apps/prod/tibuild/deployment.yaml
+++ b/apps/prod/tibuild/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app: tibuild
     spec:
       containers:
-      - image: ghcr.io/pingcap-qe/ee-apps/tibuild:v20240228-53-g80bb966
+      - image: ghcr.io/pingcap-qe/ee-apps/tibuild:v20240228-72-gd319bf4
         imagePullPolicy: Always
         name: tibuild
         ports:


### PR DESCRIPTION
Ref: https://github.com/PingCAP-QE/ee-apps/pull/164