### PR TITLE
chore(apps/gcp/prow): update docker image of cherry-picker plugin to v2.4.4

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -238,7 +238,7 @@ spec:
           name: prow-hook
         image:
           repository: ticommunityinfra/tichi-cherrypicker-plugin
-          tag: v2.4.2
+          tag: v2.4.4
         args:
           - --dry-run=false
           - --github-token-path=/etc/github/token


### PR DESCRIPTION
Ref: https://github.com/ti-community-infra/tichi/pull/1188