### PR TITLE
fix(apps/gcp/prow/release): bump image tag for needs-rebase plugin and ghproxy service

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -63,6 +63,9 @@ spec:
       additionalArgs:
         - --kubeconfig=/etc/kubeconfig/config
     ghproxy:
+      image:
+        repository: gcr.io/k8s-prow/ghproxy
+        tag: v20240805-533a2035d
       persistence:
         size: 10Gi
     tide:
@@ -168,6 +171,7 @@ spec:
         replicaCount: 1
         image:
           repository: gcr.io/k8s-prow/needs-rebase
+          tag: v20240805-533a2035d
         ports:
           http: 8888
         resources: {}


### PR DESCRIPTION
Signed-off-by: wuhuizuo <wuhuizuo@126.com>