### PR TITLE
chore: adjust prow tide probe conf

### DIFF
--- a/charts/prow/Chart.yaml
+++ b/charts/prow/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates,
 # including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.9.9"
+version: "0.9.10"
 
 # This is the version number of the application being deployed.
 # This version number should be incremented each time you make changes to the

--- a/charts/prow/templates/components/tide/deployment.yaml
+++ b/charts/prow/templates/components/tide/deployment.yaml
@@ -98,6 +98,7 @@ spec:
             httpGet:
               path: /healthz/ready
               port: http
+            timeoutSeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           resources:

--- a/charts/prow/templates/components/tide/deployment.yaml
+++ b/charts/prow/templates/components/tide/deployment.yaml
@@ -90,17 +90,17 @@ spec:
             httpGet:
               path: /healthz
               port: http
-            timeoutSeconds: 5
-            periodSeconds: 20
             failureThreshold: 3
-            initialDelaySeconds: 300
+            initialDelaySeconds: 30 # "300" maybe it will cause ci failed.
+            periodSeconds: 20
+            timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /healthz/ready
               port: http
-            timeoutSeconds: 5
-            periodSeconds: 10
             failureThreshold: 3
+            periodSeconds: 10
+            timeoutSeconds: 5
           resources:
             {{- toYaml .Values.tide.resources | nindent 12 }}
       volumes:

--- a/charts/prow/templates/components/tide/deployment.yaml
+++ b/charts/prow/templates/components/tide/deployment.yaml
@@ -84,7 +84,7 @@ spec:
             httpGet:
               path: /healthz
               port: 8080
-            failureThreshold: 30
+            failureThreshold: 60
             periodSeconds: 10
           livenessProbe:
             httpGet:

--- a/charts/prow/templates/components/tide/deployment.yaml
+++ b/charts/prow/templates/components/tide/deployment.yaml
@@ -80,20 +80,26 @@ spec:
               name: kubeconfig
               readOnly: true
             {{- end }}
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            failureThreshold: 30
+            periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /healthz
               port: http
-            initialDelaySeconds: 30
-            periodSeconds: 30
             timeoutSeconds: 5
+            periodSeconds: 20
+            failureThreshold: 3
+            initialDelaySeconds: 300
           readinessProbe:
             httpGet:
               path: /healthz/ready
               port: http
-            initialDelaySeconds: 60
-            periodSeconds: 30
-            timeoutSeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
           resources:
             {{- toYaml .Values.tide.resources | nindent 12 }}
       volumes:

--- a/charts/prow/templates/components/tide/deployment.yaml
+++ b/charts/prow/templates/components/tide/deployment.yaml
@@ -80,12 +80,12 @@ spec:
               name: kubeconfig
               readOnly: true
             {{- end }}
-          startupProbe:
-            httpGet:
-              path: /healthz
-              port: 8080
-            failureThreshold: 60
-            periodSeconds: 10
+          # startupProbe:
+          #   httpGet:
+          #     path: /healthz
+          #     port: 8080
+          #   failureThreshold: 60
+          #   periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/prow/values.yaml
+++ b/charts/prow/values.yaml
@@ -392,13 +392,13 @@ tide:
     roleBinding:
       create: true
       name: ""
-  resources:
-    requests:
-      cpu: 1000m
-      memory: 4Gi
-    limits:
-      cpu: 1000m
-      memory: 4Gi
+  resources: {}
+    # requests:
+    #   cpu: 1000m
+    #   memory: 4Gi
+    # limits:
+    #   cpu: 1000m
+    #   memory: 4Gi
   kubeconfigSecret: ""
 
 pipeline:

--- a/charts/prow/values.yaml
+++ b/charts/prow/values.yaml
@@ -392,7 +392,13 @@ tide:
     roleBinding:
       create: true
       name: ""
-  resources: {}
+  resources:
+    requests:
+      cpu: 1000m
+      memory: 4Gi
+    limits:
+      cpu: 1000m
+      memory: 4Gi
   kubeconfigSecret: ""
 
 pipeline:


### PR DESCRIPTION
* During periods of high traffic, the tide interface response will be very slow and there is a probability that it may cause Pod restarts. During the initial startup period, the healthy interface response will also be slow, but the service can still handle other requests normally. Therefore, modify the probe settings to perform liveness and readiness checks 10 minutes after the service starts.
* To prevent resource shortages from causing service restarts, set resource limits to 1 core and 4GB.