### PR TITLE
chore(apps/prod/cloudevents-server): bump docker image tag to `v20240228-76-geadd400`

### DIFF
--- a/apps/prod/cloudevents-server/release.yaml
+++ b/apps/prod/cloudevents-server/release.yaml
@@ -38,7 +38,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/cloudevents-server
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/cloudevents-server versioning=docker
-      tag: v20240228-49-g6a033f9
+      tag: v20240228-76-geadd400
     server:
       args: [--config=/config/config.yaml]
       volumeMounts:


### PR DESCRIPTION
Ref: 
- https://github.com/PingCAP-QE/ee-apps/pull/165
- https://github.com/PingCAP-QE/ee-apps/pull/168