### PR TITLE
fix(apps/prod/tekton/configs/tasks): replace rustup mirror

### DIFF
--- a/apps/prod/tekton/configs/tasks/pingcap-build-binaries-darwin.yaml
+++ b/apps/prod/tekton/configs/tasks/pingcap-build-binaries-darwin.yaml
@@ -131,7 +131,8 @@ spec:
 
         # 4. optional set for rust
         echo 'export CARGO_NET_GIT_FETCH_WITH_CLI=true' >> /workspace/remote.env
-        echo 'export RUSTUP_DIST_SERVER=https://mirrors.ustc.edu.cn/rust-static' >> /workspace/remote.env
+        echo 'export RUSTUP_UPDATE_ROOT=https://mirrors.tuna.tsinghua.edu.cn/rustup/rustup' >> /workspace/remote.env
+        echo 'export RUSTUP_DIST_SERVER=https://mirrors.tuna.tsinghua.edu.cn/rustup' >> /workspace/remote.env
     - name: build
       image: ghcr.io/pingcap-qe/cd/utils/remote:v20231216-51-g3bb25fd
       env:

--- a/apps/prod/tekton/configs/tasks/pingcap-build-binaries.yaml
+++ b/apps/prod/tekton/configs/tasks/pingcap-build-binaries.yaml
@@ -94,7 +94,9 @@ spec:
         - name: CARGO_NET_GIT_FETCH_WITH_CLI
           value: 'true'
         - name: RUSTUP_DIST_SERVER
-          value: https://mirrors.ustc.edu.cn/rust-static
+          value: https://mirrors.tuna.tsinghua.edu.cn/rustup
+        - name: RUSTUP_UPDATE_ROOT
+          value: https://mirrors.tuna.tsinghua.edu.cn/rustup/rustup
         - name: GOPROXY
           value: 'http://goproxy.apps.svc,direct'
         - name: CARGO_HOME

--- a/apps/prod/tekton/configs/tasks/release/create-pr-to-bump-tikv-version.yaml
+++ b/apps/prod/tekton/configs/tasks/release/create-pr-to-bump-tikv-version.yaml
@@ -63,7 +63,9 @@ spec:
         - name: CARGO_NET_GIT_FETCH_WITH_CLI
           value: 'true'
         - name: RUSTUP_DIST_SERVER
-          value: https://mirrors.ustc.edu.cn/rust-static
+          value: https://mirrors.tuna.tsinghua.edu.cn/rustup
+        - name: RUSTUP_UPDATE_ROOT
+          value: https://mirrors.tuna.tsinghua.edu.cn/rustup/rustup
         - name: CARGO_HOME
           value: /workspace/.cargo
       script: |


### PR DESCRIPTION
Try to address the mirror issue:
```log
info: latest update on 2023-12-28, rust version 1.77.0-nightly (89e2160c4 2023-12-27)
info: downloading component 'cargo'
error: component download failed for cargo-aarch64-unknown-linux-gnu: could not download file from 'https://mirrors.ustc.edu.cn/rust-static/dist/2023-12-28/cargo-nightly-aarch64-unknown-linux-gnu.tar.xz' to '/root/.rustup/downloads/842067905bb35f5ecd6bedd36c1400dc8d125b9d077df2d8b3b704a4cfc8de35.partial'
+ r=1
+ set +x
make[2]: *** [Makefile:459: x-build-dist] Error 1
make[2]: Leaving directory '/workspace/source/tikv'
make[1]: *** [Makefile:270: build_dist_release] Error 2
make[1]: Leaving directory '/workspace/source/tikv'
make: *** [Makefile:259: dist_release] Error 2
```


Signed-off-by: wuhuizuo <wuhuizuo@126.com>