### PR TITLE
fix(apps/prod/tekton/configs/tasks): fix task `pingcap-get-set-release-version` for hotfix cases

### DIFF
--- a/apps/prod/tekton/configs/tasks/pingcap-get-set-release-version.yaml
+++ b/apps/prod/tekton/configs/tasks/pingcap-get-set-release-version.yaml
@@ -22,7 +22,7 @@ spec:
         echo "Delete the none-standard tags"
         if git tag | grep -E "v[0-9]+[.][0-9]+[.][0-9]+(-(alpha|beta|fips))?$" > /dev/null; then
           # Only delete the none-standard tags when the repo has standard semver tags.
-          git tag | grep -vE "^v[0-9]+[.][0-9]+[.][0-9]+(-(alpha|beta|fips))?$" | xargs git tag -d || true
+          git tag | grep -vE "^v[0-9]+[.][0-9]+[.][0-9]+(-(alpha|beta|fips|202[1-9][0-1][0-9][0-3][0-9]-[0-9a-f]{7,10}))?$" | xargs git tag -d || true
         fi
 
         RESULT_VERSION="$(git describe --tags --always --dirty --exclude 'v20[0-9][0-9].[0-1][0-9].[0-3][0-9]*')"


### PR DESCRIPTION
Avoid route in RC build logic, like this:

![image](https://github.com/user-attachments/assets/7bad9039-1f02-4eb7-9a88-97b36b01f485)
This pull request includes a small change to the `apps/prod/tekton/configs/tasks/pingcap-get-set-release-version.yaml` file. The change updates the regular expression used to filter git tags to include additional patterns.

* [`apps/prod/tekton/configs/tasks/pingcap-get-set-release-version.yaml`](diffhunk://#diff-21d26239b230e9f59b49651c03f88f72918acb020b89a894985105b787ec31feL25-R25): Updated the regular expression in the `grep -vE` command to include tags with date and hash patterns.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>