### PR TITLE
feat(apps/prod): add tiup-publisher

### DIFF
--- a/apps/prod/kustomization.yaml
+++ b/apps/prod/kustomization.yaml
@@ -22,3 +22,4 @@ resources:
   - dl
   - harbor
   - coder
+  - tiup-publisher

--- a/apps/prod/tiup-publisher/kustomization.yaml
+++ b/apps/prod/tiup-publisher/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - release-prod-mirror.yaml
+  - release-staging-mirror.yaml

--- a/apps/prod/tiup-publisher/release-prod-mirror.yaml
+++ b/apps/prod/tiup-publisher/release-prod-mirror.yaml
@@ -1,0 +1,47 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: tiup-publisher-prod-mirror
+  namespace: apps
+spec:
+  chart:
+    spec:
+      chart: tiup-publisher
+      version: 0.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: ee-apps
+        namespace: flux-system
+  interval: 1h
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+  test:
+    enable: false
+  values:
+    # Additional volumes on the output Deployment definition.
+    image:
+      tag: v20240228-83-g645b571
+    args:
+      - --config=/etc/config/config.yaml
+    volumes:
+      - name: tiup-config
+        secret:
+          secretName: tiup-config
+      - name: tiup-credentials
+        secret:
+          secretName: tiup-credentials-prod
+
+    volumeMounts:
+      - name: tiup-config
+        subPath: config-prod.yaml
+        mountPath: /etc/config/config.yaml
+        readOnly: true
+      - name: tiup-credentials
+        subPath: private.json
+        mountPath: /root/.tiup/keys/private.json
+
+    nodeSelector:
+      kubernetes.io/arch: amd64

--- a/apps/prod/tiup-publisher/release-staging-mirror.yaml
+++ b/apps/prod/tiup-publisher/release-staging-mirror.yaml
@@ -1,0 +1,47 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: tiup-publisher-staging-mirror
+  namespace: apps
+spec:
+  chart:
+    spec:
+      chart: tiup-publisher
+      version: 0.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: ee-apps
+        namespace: flux-system
+  interval: 1h
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+  test:
+    enable: false
+  values:
+    # Additional volumes on the output Deployment definition.
+    image:
+      tag: v20240228-83-g645b571
+    args:
+      - --config=/etc/config/config.yaml
+    volumes:
+      - name: tiup-config
+        secret:
+          secretName: tiup-config
+      - name: tiup-credentials
+        secret:
+          secretName: tiup-credentials-staging
+
+    volumeMounts:
+      - name: tiup-config
+        subPath: config-staging.yaml
+        mountPath: /etc/config/config.yaml
+        readOnly: true
+      - name: tiup-credentials
+        subPath: private.json
+        mountPath: /root/.tiup/keys/private.json
+
+    nodeSelector:
+      kubernetes.io/arch: amd64


### PR DESCRIPTION
This pull request adds a new service, `tiup-publisher`, to the production environment. The changes include updates to the kustomization files and the addition of HelmRelease configurations for both production and staging mirrors.

### Additions to `tiup-publisher` service:

* [`apps/prod/kustomization.yaml`](diffhunk://#diff-ee20854a69c2a0d1fcc07e8216c968e5895b76a9f9ffc942a8aa69a9747354e5R25): Added `tiup-publisher` to the list of resources.
* [`apps/prod/tiup-publisher/kustomization.yaml`](diffhunk://#diff-54630566ef0b0b3c9dcdcd9d06b3bb924fc49d8a20364ea78c06c21a8fea5cfbR1-R5): Created a new kustomization file for `tiup-publisher` with references to `release-prod-mirror.yaml` and `release-staging-mirror.yaml`.

### HelmRelease configurations:

* [`apps/prod/tiup-publisher/release-prod-mirror.yaml`](diffhunk://#diff-6e5ab966061a7a1c3ec666fc99421d86aa4ce2aba340522ff22e909439fc733cR1-R47): Added HelmRelease configuration for the production mirror of `tiup-publisher`, including image tag, volumes, and node selector.
* [`apps/prod/tiup-publisher/release-staging-mirror.yaml`](diffhunk://#diff-4cd3cadac6a6bd62d698da77ccc6503a663efced3f2319f01ac0fdbb7fa5fec4R1-R47): Added HelmRelease configuration for the staging mirror of `tiup-publisher`, including image tag, volumes, and node selector.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>