### PR TITLE
fix(apps/prod/tekton/configs/tasks/release): avoid label be removed by prow plugins

### DIFF
--- a/apps/prod/tekton/configs/tasks/release/create-pr-to-bump-tikv-version.yaml
+++ b/apps/prod/tekton/configs/tasks/release/create-pr-to-bump-tikv-version.yaml
@@ -125,6 +125,12 @@ spec:
         fi
 
         gh pr create -B "$base_branch" -H "$head_branch" -t "$commit_msg" -F pr_body.txt $label_options
+        
+        # solve the problem that the prow plugin will remove the approved label.
+        sleep 10
+        pr_url=$(gh pr list --repo $(params.git-url) --base "$base_branch" --head "$head_branch"  --json url --jq .[].url | head -1)
+        gh pr edit --add-label lgtm --add-label approved --add-label cherry-pick-approved ${pr_url}
+
   workspaces:
     - name: github
       description: Must includes a key `token`


### PR DESCRIPTION
This pull request includes a small but important change to the `create-pr-to-bump-tikv-version.yaml` file in the `spec` directory. The change addresses an issue where the prow plugin removes the approved label by adding a delay and reapplying the necessary labels.

* [`apps/prod/tekton/configs/tasks/release/create-pr-to-bump-tikv-version.yaml`](diffhunk://#diff-a96c12396451377af34efa48805fc711eed0d71f0d6b51a4c6f94a0fa91edb85R128-R133): Added a sleep command and logic to reapply the `lgtm`, `approved`, and `cherry-pick-approved` labels to the pull request after creation.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>