### PR TITLE
refactor(apps/prod/tekton/configs): use delicated publisher to fast tiup publishing

### DIFF
--- a/apps/prod/tekton/configs/tasks/kustomization.yaml
+++ b/apps/prod/tekton/configs/tasks/kustomization.yaml
@@ -36,6 +36,7 @@ resources:
   - pingcap-git-clone-ext.yaml
   - pingcap-upload-enterprise-plugins.yaml
   - pingcap-upload-offline-package.yaml
+  - publish-tiup-from-oci-artifact-v2.yaml
   - publish-tiup-from-oci-artifact.yaml
   - release/create-pr-to-add-release-anchor-commit.yaml
   - release/create-pr-to-bump-tikv-version.yaml

--- a/apps/prod/tekton/configs/tasks/publish-tiup-from-oci-artifact-v2.yaml
+++ b/apps/prod/tekton/configs/tasks/publish-tiup-from-oci-artifact-v2.yaml
@@ -1,0 +1,53 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: publish-tiup-from-oci-artifact-v2
+spec:
+  description: |
+    The working flow:
+    1. fetch the manifect config
+    2. get the `.tiup` filed from the config.
+    3. loop to publish to tiup mirror.
+  params:
+    - name: artifact-url
+      description: |
+        The full url of the pushed image, contain the tag part.
+        It will parse the repo from it.
+    - name: publisher-url
+      description: Staging is http://publisher-staging-mirror.apps.svc, product is http://publisher-prod-mirror.apps.svc.
+      default: http://publisher-staging-mirror.apps.svc
+    - name: force-version
+      description: >
+        Force set the version.
+        Default is the artifact version read from `org.opencontainers.image.version` of the manifest config.
+      default: ""
+  results:
+    - name: request-ids
+      type: array
+  steps:
+    - name: request-and-wait
+      image: ghcr.io/pingcap-qe/ee-apps/publisher:v2024.10.14-4-ga7470b6
+      script: |
+        #!/usr/bin/env bash
+        set -eo pipefail
+
+        # send event
+        /app/publisher-cli --url $(params.publisher-url) tiup request-to-publish --body '{ "artifact_url": "$(params.artifact-url)" }' | tee $(results.request-ids.path)
+
+        # wait for request statuses
+        for request_id in $(jq -r '.[]' $(results.request-ids.path)); do
+          echo "🔍 query for request id: ${request_id} ..."
+          while true; do
+            status=$(/app/publisher-cli --url $(params.publisher-url) tiup query-publishing-status --request-id "$request_id" | jq -r .)
+            if [ "$status" = "failed" ]; then
+              echo "❌ $status"
+              exit 1
+            elif [ "$status" = "success" ]; then
+              echo "✅ $status"
+              break
+            else
+              echo "⌛️ $status"
+              sleep 10
+            fi
+          done
+        done

--- a/apps/prod/tekton/configs/triggers/templates/_/push-oci-artifact-to-tiup.yaml
+++ b/apps/prod/tekton/configs/triggers/templates/_/push-oci-artifact-to-tiup.yaml
@@ -17,37 +17,12 @@ spec:
           server: staging
       spec:
         taskRef:
-          name: publish-tiup-from-oci-artifact
+          name: publish-tiup-from-oci-artifact-v2
         params:
           - name: artifact-url
             value: "$(tt.params.image_url)"
-          - name: nightly
-            value: "true"
-          - name: tiup-mirror
-            value: http://tiup.pingcap.net:8988
-        workspaces:
-          - name: lock-tiup
-            persistentVolumeClaim:
-              claimName: pvc-lock-tiup-staging
-          - name: dockerconfig
-            secret:
-              secretName: hub-pingcap-net-ee
-          - name: tiup-keys
-            secret:
-              secretName: tiup-credentials-staging
-        podTemplate:
-          affinity:
-            podAntiAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                - labelSelector:
-                    matchExpressions:
-                      - key: "tekton.dev/task"
-                        operator: In
-                        values: [publish-tiup-from-oci-artifact]
-                      - key: server
-                        operator: In
-                        values: [staging]
-                  topologyKey: "kubernetes.io/hostname"
+          - name: publisher-url
+            value: http://publisher-staging-mirror.apps.svc
     - apiVersion: tekton.dev/v1beta1
       kind: TaskRun
       metadata:
@@ -107,35 +82,12 @@ spec:
           server: staging
       spec:
         taskRef:
-          name: publish-tiup-from-oci-artifact
+          name: publish-tiup-from-oci-artifact-v2
         params:
           - name: artifact-url
             value: "$(tt.params.image_url)"
-          - name: tiup-mirror
-            value: http://tiup.pingcap.net:8988
-        workspaces:
-          - name: lock-tiup
-            persistentVolumeClaim:
-              claimName: pvc-lock-tiup-staging
-          - name: dockerconfig
-            secret:
-              secretName: hub-pingcap-net-ee
-          - name: tiup-keys
-            secret:
-              secretName: tiup-credentials-staging
-        podTemplate:
-          affinity:
-            podAntiAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                - labelSelector:
-                    matchExpressions:
-                      - key: "tekton.dev/task"
-                        operator: In
-                        values: [publish-tiup-from-oci-artifact]
-                      - key: server
-                        operator: In
-                        values: [staging]
-                  topologyKey: "kubernetes.io/hostname"
+          - name: publisher-url
+            value: http://publisher-staging-mirror.apps.svc
 ---
 apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerTemplate
@@ -156,36 +108,13 @@ spec:
           server: staging
       spec:
         taskRef:
-          name: publish-tiup-from-oci-artifact
+          name: publish-tiup-from-oci-artifact-v2
         timeout: 2h
         params:
           - name: artifact-url
             value: "$(tt.params.image_url)"
-          - name: tiup-mirror
-            value: http://tiup.pingcap.net:8988
-        workspaces:
-          - name: lock-tiup
-            persistentVolumeClaim:
-              claimName: pvc-lock-tiup-staging
-          - name: dockerconfig
-            secret:
-              secretName: hub-pingcap-net-ee
-          - name: tiup-keys
-            secret:
-              secretName: tiup-credentials-staging
-        podTemplate:
-          affinity:
-            podAntiAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                - labelSelector:
-                    matchExpressions:
-                      - key: "tekton.dev/task"
-                        operator: In
-                        values: [publish-tiup-from-oci-artifact]
-                      - key: server
-                        operator: In
-                        values: [staging]
-                  topologyKey: "kubernetes.io/hostname"
+          - name: publisher-url
+            value: http://publisher-staging-mirror.apps.svc
     - apiVersion: tekton.dev/v1beta1
       kind: TaskRun
       metadata:
@@ -194,33 +123,10 @@ spec:
           server: prod
       spec:
         taskRef:
-          name: publish-tiup-from-oci-artifact
+          name: publish-tiup-from-oci-artifact-v2
         timeout: 2h
         params:
           - name: artifact-url
             value: "$(tt.params.image_url)"
-          - name: tiup-mirror
-            value: http://tiup.pingcap.net:8987
-        workspaces:
-          - name: lock-tiup
-            persistentVolumeClaim:
-              claimName: pvc-lock-tiup-prod
-          - name: dockerconfig
-            secret:
-              secretName: hub-pingcap-net-ee
-          - name: tiup-keys
-            secret:
-              secretName: tiup-credentials-prod
-        podTemplate:
-          affinity:
-            podAntiAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                - labelSelector:
-                    matchExpressions:
-                      - key: "tekton.dev/task"
-                        operator: In
-                        values: [publish-tiup-from-oci-artifact]
-                      - key: server
-                        operator: In
-                        values: [prod]
-                  topologyKey: "kubernetes.io/hostname"
+          - name: publisher-url
+            value: http://publisher-prod-mirror.apps.svc


### PR DESCRIPTION
- make fast and stable for staging nightly ad RC tiup pkg publishing
- make fast and stable for GA tiup pkg publishing.
- rate limit for nightly is not implemented yet, so we still use old way for prod nightly publising.