### PR TITLE
chore(apps/prod/publisher,apps/prod/tekton/configs): bump docker image ghcr.io/pingcap-qe/ee-apps/publisher to `v2024.10.14-5-ge877e83`

### DIFF
--- a/apps/prod/publisher/release-prod-mirror.yaml
+++ b/apps/prod/publisher/release-prod-mirror.yaml
@@ -24,7 +24,7 @@ spec:
     # Additional volumes on the output Deployment definition.
     image:
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/publisher versioning=semver
-      tag: v2024.10.14-4-ga7470b6
+      tag: v2024.10.14-5-ge877e83
     servers:
       publisher:
         config:

--- a/apps/prod/publisher/release-staging-mirror.yaml
+++ b/apps/prod/publisher/release-staging-mirror.yaml
@@ -24,7 +24,7 @@ spec:
     # Additional volumes on the output Deployment definition.
     image:
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/publisher versioning=semver
-      tag: v2024.10.14-4-ga7470b6
+      tag: v2024.10.14-5-ge877e83
     servers:
       publisher:
         config:

--- a/apps/prod/tekton/configs/tasks/publish-tiup-from-oci-artifact-v2.yaml
+++ b/apps/prod/tekton/configs/tasks/publish-tiup-from-oci-artifact-v2.yaml
@@ -26,7 +26,7 @@ spec:
       type: array
   steps:
     - name: request-and-wait
-      image: ghcr.io/pingcap-qe/ee-apps/publisher:v2024.10.14-4-ga7470b6
+      image: ghcr.io/pingcap-qe/ee-apps/publisher:v2024.10.14-5-ge877e83
       script: |
         #!/usr/bin/env bash
         set -eo pipefail


### PR DESCRIPTION
This pull request includes updates to several deployment and configuration files to use a new version of the `ghcr.io/pingcap-qe/ee-apps/publisher` Docker image.

Version updates:

* [`apps/prod/publisher/release-prod-mirror.yaml`](diffhunk://#diff-f22fa4fd4140f21f430eb3072f127a57a662acf1775d789a8babd5827f8c8d95L27-R27): Updated the Docker image tag to `v2024.10.14-5-ge877e83` (`spec:`).
* [`apps/prod/publisher/release-staging-mirror.yaml`](diffhunk://#diff-92e3225aae1ed300717cbb62eee36a88f1eddebffe04135866e9244c65a38fdeL27-R27): Updated the Docker image tag to `v2024.10.14-5-ge877e83` (`spec:`).
* [`apps/prod/tekton/configs/tasks/publish-tiup-from-oci-artifact-v2.yaml`](diffhunk://#diff-590004973598b5b2b28d13c9d43b1b06d4f5a9dc1b772608b1ad7cea64d9f808L29-R29): Updated the Docker image tag to `v2024.10.14-5-ge877e83` (`spec:`).

Signed-off-by: wuhuizuo <wuhuizuo@126.com>