### PR TITLE
fix publish-tiup-from-oci-artifact-v2.yaml

### DIFF
--- a/apps/prod/tekton/configs/tasks/publish-tiup-from-oci-artifact-v2.yaml
+++ b/apps/prod/tekton/configs/tasks/publish-tiup-from-oci-artifact-v2.yaml
@@ -32,7 +32,7 @@ spec:
         set -eo pipefail
 
         # send event
-        /app/publisher-cli --url $(params.publisher-url) tiup request-to-publish --body '{ "artifact_url": "$(params.artifact-url)" }' | tee $(results.request-ids.path)
+        /app/publisher-cli --url $(params.publisher-url) tiup request-to-publish --body '{ "artifact_url": "$(params.artifact-url)" }' | jq '. // []' | tee $(results.request-ids.path)
 
         # wait for request statuses
         for request_id in $(jq -r '.[]' $(results.request-ids.path)); do


### PR DESCRIPTION
fix task result value when go return nil array.