### PR TITLE
fix(apps/prod/tekton/configs/triggers/bindings): fix binding `github-pr`

### DIFF
--- a/apps/prod/tekton/configs/triggers/bindings/github-pr.yaml
+++ b/apps/prod/tekton/configs/triggers/bindings/github-pr.yaml
@@ -22,8 +22,8 @@ spec:
     #   value: $(body.pull_request.title)
     # - name: pr-body
     #   value: $(body.pull_request.body)
-    - name: pr-author
-      value: $(body.pull_request.user.login)
+    # - name: pr-author
+    #   value: $(body.pull_request.user.login)
     - name: pr-owner
       value: $(body.repository.owner.login)
     - name: pr-repo


### PR DESCRIPTION
Comment the `pr-author` in the binding `github-pr` to compatible with TiBuild stories.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>