### PR TITLE
chore(deps): bump docker image for tibuild to v2024.11.4-3-gcec492f

### DIFF
--- a/apps/prod/tibuild/deployment.yaml
+++ b/apps/prod/tibuild/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app: tibuild
     spec:
       containers:
-      - image: ghcr.io/pingcap-qe/ee-apps/tibuild:v20240228-72-gd319bf4
+      - image: ghcr.io/pingcap-qe/ee-apps/tibuild:v2024.11.4-3-gcec492f
         imagePullPolicy: Always
         name: tibuild
         ports:


### PR DESCRIPTION
Ref: https://github.com/PingCAP-QE/ee-apps/pull/194