### PR TITLE
chore(apps/prod/tibuild): bump docker image tag to v2024.11.4-4-g31622fb

### DIFF
--- a/apps/prod/tibuild/deployment.yaml
+++ b/apps/prod/tibuild/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app: tibuild
     spec:
       containers:
-      - image: ghcr.io/pingcap-qe/ee-apps/tibuild:v2024.11.4-3-gcec492f
+      - image: ghcr.io/pingcap-qe/ee-apps/tibuild:v2024.11.4-4-g31622fb
         imagePullPolicy: Always
         name: tibuild
         ports:


### PR DESCRIPTION
This pull request includes a small change to the `apps/prod/tibuild/deployment.yaml` file. The change updates the container image version for `tibuild`.

* [`apps/prod/tibuild/deployment.yaml`](diffhunk://#diff-7a638a35c3081658c6becc5d69691497c6d2b9ac58c12e048678f1c5d59dd094L23-R23): Updated the container image version from `v2024.11.4-3-gcec492f` to `v2024.11.4-4-g31622fb`.