### PR TITLE
fix(apps/prod/tekton/configs/triggers): fix fake github triggers

### DIFF
--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml
@@ -53,7 +53,7 @@ spec:
           - key: custom-params
             expression: >-
               {                
-                'builder-image': header.canonical('ce-param-builder-image')
+                'builder-image': header.canonical('ce-paramBuilderImage')
               }
   bindings:
     - ref: github-branch-push

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr.yaml
@@ -53,7 +53,7 @@ spec:
           - key: custom-params
             expression: >-
               {                
-                'builder-image': header.canonical('ce-param-builder-image')
+                'builder-image': header.canonical('ce-paramBuilderImage')
               }
   bindings:
     - ref: github-pr

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create.yaml
@@ -55,7 +55,7 @@ spec:
           - key: custom-params
             expression: >-
               {                
-                'builder-image': header.canonical('ce-param-builder-image')
+                'builder-image': header.canonical('ce-paramBuilderImage')
               }
   bindings:
     - ref: github-tag-create


### PR DESCRIPTION
The cloud events can not support extension header
with "-" chars, only support a-z and A-Z and
number chars.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>