### PR TITLE
chore(deps): bump docker image ghcr.io/pingcap-qe/ee-apps/cloudevents-server to v2024.11.4-6-g495e6f0

### DIFF
--- a/apps/prod/cloudevents-server/release.yaml
+++ b/apps/prod/cloudevents-server/release.yaml
@@ -38,7 +38,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/cloudevents-server
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/cloudevents-server versioning=docker
-      tag: v20240228-76-geadd400
+      tag: v2024.11.4-6-g495e6f0
     server:
       args: [--config=/config/config.yaml]
       volumeMounts:


### PR DESCRIPTION
This pull request updates the Docker image tag for the `cloudevents-server` in the `release.yaml` file.

* [`apps/prod/cloudevents-server/release.yaml`](diffhunk://#diff-8a4c3e74c2f6de5e90a075b75bfac27a046bd7b89d0564d0b889ac6e49029cfaL41-R41): Updated the Docker image tag from `v20240228-76-geadd400` to `v2024.11.4-6-g495e6f0`.