### PR TITLE
feat(prod/jenkins): add cronjob to monitor s3 codecache size

### DIFF
--- a/apps/prod/jenkins/pre/cronjobs.yaml
+++ b/apps/prod/jenkins/pre/cronjobs.yaml
@@ -32,3 +32,41 @@ spec:
                 limits:
                   memory: "512Mi"
                   cpu: "500m"
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: monitor-ci-code-cache-size
+  namespace: apps
+spec:
+  schedule: "*/30 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: deno
+              image: "denoland/deno:1.45.5"
+              tty: true
+              args:
+                - run
+                - --allow-net
+                - --allow-env
+                - https://github.com/PingCAP-QE/ci/raw/main/scripts/plugins/monitor-s3-object-size.ts
+                - --path="git/PingCAP-QE/tidb-test"
+                - --threshold-mb=2500
+                - --feishu-webhook="${CI_MONITOR_FEISHU_WEBHOOK_URL}"
+                - --cleanup
+              envFrom:
+                - secretRef:
+                    name: ci-pipeline-cache2
+                - configMapRef:
+                    name: s3-ci-pipeline-cache2
+              resources:
+                requests:
+                  memory: "128Mi"
+                  cpu: "100m"
+                limits:
+                  memory: "512Mi"
+                  cpu: "500m"

--- a/apps/prod/jenkins/pre/cronjobs.yaml
+++ b/apps/prod/jenkins/pre/cronjobs.yaml
@@ -47,7 +47,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: deno
-              image: "denoland/deno:1.45.5"
+              image: "denoland/deno:2.0.5"
               tty: true
               args:
                 - run

--- a/apps/prod/jenkins/pre/cronjobs.yaml
+++ b/apps/prod/jenkins/pre/cronjobs.yaml
@@ -36,7 +36,7 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: monitor-ci-code-cache-size
+  name: fix-ci-code-cache-size
   namespace: apps
 spec:
   schedule: "*/30 * * * *"


### PR DESCRIPTION
Add cronjob to monitor s3 code cache size.