### PR TITLE
Update publish-tiup-from-oci-artifact-v2.yaml

### DIFF
--- a/apps/prod/tekton/configs/tasks/publish-tiup-from-oci-artifact-v2.yaml
+++ b/apps/prod/tekton/configs/tasks/publish-tiup-from-oci-artifact-v2.yaml
@@ -26,7 +26,7 @@ spec:
       type: array
   steps:
     - name: request-and-wait
-      image: ghcr.io/pingcap-qe/ee-apps/publisher:v2024.10.14-6-g2e1e85d
+      image: ghcr.io/pingcap-qe/ee-apps/publisher:v2024.11.4-10-g93bf843
       script: |
         #!/usr/bin/env bash
         set -eo pipefail


### PR DESCRIPTION
This pull request includes a small change to the `apps/prod/tekton/configs/tasks/publish-tiup-from-oci-artifact-v2.yaml` file. The change updates the image version used in the `request-and-wait` step.

* [`apps/prod/tekton/configs/tasks/publish-tiup-from-oci-artifact-v2.yaml`](diffhunk://#diff-590004973598b5b2b28d13c9d43b1b06d4f5a9dc1b772608b1ad7cea64d9f808L29-R29): Updated the image version from `v2024.10.14-6-g2e1e85d` to `v2024.11.4-10-g93bf843`.