### PR TITLE
Update publish-fileserver-from-oci-artifact.yaml

### DIFF
--- a/apps/prod/tekton/configs/tasks/publish-fileserver-from-oci-artifact.yaml
+++ b/apps/prod/tekton/configs/tasks/publish-fileserver-from-oci-artifact.yaml
@@ -21,7 +21,7 @@ spec:
       type: array
   steps:
     - name: request-and-wait
-      image: ghcr.io/pingcap-qe/ee-apps/publisher:v2024.11.4-10-g93bf843    
+      image: ghcr.io/pingcap-qe/ee-apps/publisher:v2024.11.4-10-g93bf843
       script: |
         #!/usr/bin/env bash
         set -eo pipefail

--- a/apps/prod/tekton/configs/tasks/publish-fileserver-from-oci-artifact.yaml
+++ b/apps/prod/tekton/configs/tasks/publish-fileserver-from-oci-artifact.yaml
@@ -21,7 +21,7 @@ spec:
       type: array
   steps:
     - name: request-and-wait
-      image: ghcr.io/pingcap-qe/ee-apps/publisher:v2024.10.14-6-g2e1e85d
+      image: ghcr.io/pingcap-qe/ee-apps/publisher:v2024.11.4-10-g93bf843    
       script: |
         #!/usr/bin/env bash
         set -eo pipefail


### PR DESCRIPTION
This pull request updates the image version used in the `publish-fileserver-from-oci-artifact.yaml` configuration file.

* [`apps/prod/tekton/configs/tasks/publish-fileserver-from-oci-artifact.yaml`](diffhunk://#diff-b011326797c9dbb4f120d043a4a26889892a4bbdcce316c35881875138371b7aL24-R24): Updated the image version from `v2024.10.14-6-g2e1e85d` to `v2024.11.4-10-g93bf843`.