### PR TITLE
Revert "fix(apps/prod/cloudevents-server): bump cloudevents-server image version to `v2024.11.4-11-g58aa19e`"

### DIFF
--- a/apps/prod/cloudevents-server/release.yaml
+++ b/apps/prod/cloudevents-server/release.yaml
@@ -37,8 +37,8 @@ spec:
       kubernetes.io/arch: amd64
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/cloudevents-server
-      # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/cloudevents-server versioning=semver
-      tag: v2024.11.4-11-g58aa19e
+      # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/cloudevents-server versioning=docker
+      tag: v2024.11.4-6-g495e6f0
     server:
       args: [--config=/config/config.yaml]
       volumeMounts:


### PR DESCRIPTION
Reverts PingCAP-QE/ee-ops#1337