### PR TITLE
fix(jenkins/cronjob): update to remove the extra double quotation marks

### DIFF
--- a/apps/prod/jenkins/pre/cronjobs.yaml
+++ b/apps/prod/jenkins/pre/cronjobs.yaml
@@ -54,7 +54,7 @@ spec:
                 - --allow-net
                 - --allow-env
                 - https://github.com/PingCAP-QE/ci/raw/main/scripts/plugins/monitor-s3-object-size.ts
-                - --path="git/PingCAP-QE/tidb-test"
+                - --path=git/PingCAP-QE/tidb-test
                 - --threshold-mb=2500
                 - --feishu-webhook="${CI_MONITOR_FEISHU_WEBHOOK_URL}"
                 - --cleanup


### PR DESCRIPTION
update to remove the extra double quotation marks in yaml args.