### PR TITLE
fix(prod/jenkins): correct read file credentials

### DIFF
--- a/apps/prod/jenkins/release/values-JCasC.yaml
+++ b/apps/prod/jenkins/release/values-JCasC.yaml
@@ -98,7 +98,7 @@ controller:
                       scope: GLOBAL
                       id: "ks3util-config"
                       fileName: "ks3util.conf"
-                      secretBytes: "${ks3util-config}"
+                      secretBytes: "${base64:${ks3util-config}}"
               - domain:
                   name: github.com
                   description: github ssh and open api


### PR DESCRIPTION
use base64 to correct read file credentials.