### PR TITLE
fix(apps/prod/tekton/configs/tasks): update image tag of crane

### DIFF
--- a/apps/prod/tekton/configs/tasks/pingcap-deliver-image.yaml
+++ b/apps/prod/tekton/configs/tasks/pingcap-deliver-image.yaml
@@ -39,7 +39,7 @@ spec:
           --yaml_file=delivery.yaml \
           --outfile=/workspace/delivery.sh
     - name: run-commands
-      image: gcr.io/go-containerregistry/crane/debug:v0.15.2
+      image: gcr.io/go-containerregistry/crane/debug:latest
       script: |
         #!/busybox/sh
         set -e


### PR DESCRIPTION
Now only `latest` exists on the repo.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>