### PR TITLE
fix(apps/gcp/prow/release): fix jenkins url link pr context

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -51,8 +51,8 @@ spec:
           configMapName: prow-job-config
     crier:
       image:
-        repository: ticommunityinfra/crier
-        tag: v20221227-9bc8171e1d
+        repository: ghcr.io/ti-community-infra/prow/crier
+        tag: v20241218-c96901f3d
     deck:
       ingress:
         enabled: false


### PR DESCRIPTION
bump the crier image to include the fix for jenkins url link in presubmit jobs

Signed-off-by: wuhuizuo <wuhuizuo@126.com>