### PR TITLE
fix(apps/gcp/prow/release): update jenkins-operator image

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -125,8 +125,8 @@ spec:
     jenkinsOperator:
       enabled: true
       image:
-        repository: ticommunityinfra/jenkins-operator
-        tag: v20230630-a19314f
+        repository: ghcr.io/ti-community-infra/prow/jenkins-operator
+        tag: v20250105-d73428bb3
       skipReport: true
       dryRun: false
       jenkinsUrl: ${JENKINS_BASE_URL}


### PR DESCRIPTION
fix the ci link issue for pending status in GitHub.