### PR TITLE
build(pingcap/ticdc): add build triggers

### DIFF
--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml
@@ -11,54 +11,58 @@ spec:
       params:
         - name: filter
           value: >-
-            body.repository.full_name in ['pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'tikv/tikv', 'tikv/pd']
+            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'tikv/tikv', 'tikv/pd']
         - name: overlays
           value:
-          - key: timeout
-            expression: >-
-              {
-              'pingcap/tidb': '40m',
-              'pingcap/tiflash': '2h',
-              'pingcap/tiflow': '40m',
-              'pingcap/tidb-dashboard': '40m',
-              'tikv/pd': '40m',
-              'tikv/tikv': '2h30m',
-              }[body.repository.full_name]
-          - key: source-ws-size
-            expression: >-
-              {
-              'pingcap/tidb': '50Gi',
-              'pingcap/tiflash': '100Gi',
-              'pingcap/tiflow': '50Gi',
-              'pingcap/tidb-dashboard': '8Gi',
-              'tikv/pd': '50Gi',
-              'tikv/tikv': '100Gi',
-              }[body.repository.full_name]
-          - key: builder-resources-cpu
-            expression: >-
-              {
-              'pingcap/tidb': '8',
-              'pingcap/tiflash': '16',
-              'pingcap/tiflow': '8',
-              'pingcap/tidb-dashboard': '2',
-              'tikv/pd': '8',
-              'tikv/tikv': '16',
-              }[body.repository.full_name]
-          - key: builder-resources-memory
-            expression: >-
-              {
-              'pingcap/tidb': '32Gi',
-              'pingcap/tiflash': '64Gi',
-              'pingcap/tiflow': '32Gi',
-              'pingcap/tidb-dashboard': '4Gi',
-              'tikv/pd': '32Gi',
-              'tikv/tikv': '64Gi',
-              }[body.repository.full_name]
-          - key: custom-params
-            expression: >-
-              {                
-                'builder-image': header.canonical('ce-paramBuilderImage')
-              }
+            - key: timeout
+              expression: >-
+                {
+                'pingcap/ticdc: '20m',
+                'pingcap/tidb': '40m',
+                'pingcap/tiflash': '2h',
+                'pingcap/tiflow': '40m',
+                'pingcap/tidb-dashboard': '40m',
+                'tikv/pd': '40m',
+                'tikv/tikv': '2h30m',
+                }[body.repository.full_name]
+            - key: source-ws-size
+              expression: >-
+                {
+                'pingcap/ticdc': '50Gi',
+                'pingcap/tidb': '50Gi',
+                'pingcap/tiflash': '100Gi',
+                'pingcap/tiflow': '50Gi',
+                'pingcap/tidb-dashboard': '8Gi',
+                'tikv/pd': '50Gi',
+                'tikv/tikv': '100Gi',
+                }[body.repository.full_name]
+            - key: builder-resources-cpu
+              expression: >-
+                {
+                'pingcap/ticdc': '4',
+                'pingcap/tidb': '8',
+                'pingcap/tiflash': '16',
+                'pingcap/tiflow': '8',
+                'pingcap/tidb-dashboard': '2',
+                'tikv/pd': '8',
+                'tikv/tikv': '16',
+                }[body.repository.full_name]
+            - key: builder-resources-memory
+              expression: >-
+                {
+                'pingcap/ticdc': '16Gi',
+                'pingcap/tidb': '32Gi',
+                'pingcap/tiflash': '64Gi',
+                'pingcap/tiflow': '32Gi',
+                'pingcap/tidb-dashboard': '4Gi',
+                'tikv/pd': '32Gi',
+                'tikv/tikv': '64Gi',
+                }[body.repository.full_name]
+            - key: custom-params
+              expression: >-
+                {
+                  'builder-image': header.canonical('ce-paramBuilderImage')
+                }
   bindings:
     - ref: github-branch-push
     - ref: ce-context
@@ -66,9 +70,18 @@ spec:
     - { name: profile, value: release }
     - { name: timeout, value: $(extensions.timeout) }
     - { name: source-ws-size, value: $(extensions.source-ws-size) }
-    - { name: builder-resources-cpu, value: $(extensions.builder-resources-cpu) }
-    - { name: builder-resources-memory, value: $(extensions.builder-resources-memory) }
+    - {
+        name: builder-resources-cpu,
+        value: $(extensions.builder-resources-cpu),
+      }
+    - {
+        name: builder-resources-memory,
+        value: $(extensions.builder-resources-memory),
+      }
     - { name: registry, value: hub.pingcap.net/devbuild }
-    - { name: force-builder-image, value: $(extensions.custom-params.builder-image) }
+    - {
+        name: force-builder-image,
+        value: $(extensions.custom-params.builder-image),
+      }
   template:
     ref: build-component-all-platforms

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml
@@ -70,10 +70,7 @@ spec:
     - { name: profile, value: release }
     - { name: timeout, value: $(extensions.timeout) }
     - { name: source-ws-size, value: $(extensions.source-ws-size) }
-    - {
-        name: builder-resources-cpu,
-        value: $(extensions.builder-resources-cpu),
-      }
+    - { name: builder-resources-cpu, value: $(extensions.builder-resources-cpu) }
     - {
         name: builder-resources-memory,
         value: $(extensions.builder-resources-memory),

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml
@@ -17,7 +17,7 @@ spec:
             - key: timeout
               expression: >-
                 {
-                'pingcap/ticdc: '20m',
+                'pingcap/ticdc': '20m',
                 'pingcap/tidb': '40m',
                 'pingcap/tiflash': '2h',
                 'pingcap/tiflow': '40m',

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr.yaml
@@ -11,54 +11,58 @@ spec:
       params:
         - name: filter
           value: >-
-            body.repository.full_name in ['pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'tikv/tikv', 'tikv/pd']
+            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'tikv/tikv', 'tikv/pd']
         - name: overlays
           value:
-          - key: timeout
-            expression: >-
-              {
-              'pingcap/tidb': '40m',
-              'pingcap/tiflash': '2h',
-              'pingcap/tiflow': '40m',
-              'pingcap/tidb-dashboard': '40m',
-              'tikv/pd': '40m',
-              'tikv/tikv': '2h30m',
-              }[body.repository.full_name]
-          - key: source-ws-size
-            expression: >-
-              {
-              'pingcap/tidb': '50Gi',
-              'pingcap/tiflash': '100Gi',
-              'pingcap/tiflow': '50Gi',
-              'pingcap/tidb-dashboard': '8Gi',
-              'tikv/pd': '50Gi',
-              'tikv/tikv': '100Gi',
-              }[body.repository.full_name]
-          - key: builder-resources-cpu
-            expression: >-
-              {
-              'pingcap/tidb': '8',
-              'pingcap/tiflash': '16',
-              'pingcap/tiflow': '8',
-              'pingcap/tidb-dashboard': '2',
-              'tikv/pd': '8',
-              'tikv/tikv': '16',
-              }[body.repository.full_name]
-          - key: builder-resources-memory
-            expression: >-
-              {
-              'pingcap/tidb': '32Gi',
-              'pingcap/tiflash': '64Gi',
-              'pingcap/tiflow': '32Gi',
-              'pingcap/tidb-dashboard': '4Gi',
-              'tikv/pd': '32Gi',
-              'tikv/tikv': '64Gi',
-              }[body.repository.full_name]
-          - key: custom-params
-            expression: >-
-              {                
-                'builder-image': header.canonical('ce-paramBuilderImage')
-              }
+            - key: timeout
+              expression: >-
+                {
+                'pingcap/ticdc: '20m',
+                'pingcap/tidb': '40m',
+                'pingcap/tiflash': '2h',
+                'pingcap/tiflow': '40m',
+                'pingcap/tidb-dashboard': '40m',
+                'tikv/pd': '40m',
+                'tikv/tikv': '2h30m',
+                }[body.repository.full_name]
+            - key: source-ws-size
+              expression: >-
+                {
+                'pingcap/ticdc': '50Gi',
+                'pingcap/tidb': '50Gi',
+                'pingcap/tiflash': '100Gi',
+                'pingcap/tiflow': '50Gi',
+                'pingcap/tidb-dashboard': '8Gi',
+                'tikv/pd': '50Gi',
+                'tikv/tikv': '100Gi',
+                }[body.repository.full_name]
+            - key: builder-resources-cpu
+              expression: >-
+                {
+                'pingcap/ticdc': '4',
+                'pingcap/tidb': '8',
+                'pingcap/tiflash': '16',
+                'pingcap/tiflow': '8',
+                'pingcap/tidb-dashboard': '2',
+                'tikv/pd': '8',
+                'tikv/tikv': '16',
+                }[body.repository.full_name]
+            - key: builder-resources-memory
+              expression: >-
+                {
+                'pingcap/ticdc': '16Gi',
+                'pingcap/tidb': '32Gi',
+                'pingcap/tiflash': '64Gi',
+                'pingcap/tiflow': '32Gi',
+                'pingcap/tidb-dashboard': '4Gi',
+                'tikv/pd': '32Gi',
+                'tikv/tikv': '64Gi',
+                }[body.repository.full_name]
+            - key: custom-params
+              expression: >-
+                {
+                  'builder-image': header.canonical('ce-paramBuilderImage')
+                }
   bindings:
     - ref: github-pr
     - ref: ce-context
@@ -66,9 +70,18 @@ spec:
     - { name: profile, value: release }
     - { name: timeout, value: $(extensions.timeout) }
     - { name: source-ws-size, value: $(extensions.source-ws-size) }
-    - { name: builder-resources-cpu, value: $(extensions.builder-resources-cpu) }
-    - { name: builder-resources-memory, value: $(extensions.builder-resources-memory) }
+    - {
+        name: builder-resources-cpu,
+        value: $(extensions.builder-resources-cpu),
+      }
+    - {
+        name: builder-resources-memory,
+        value: $(extensions.builder-resources-memory),
+      }
     - { name: registry, value: hub.pingcap.net/devbuild }
-    - { name: force-builder-image, value: $(extensions.custom-params.builder-image) }
+    - {
+        name: force-builder-image,
+        value: $(extensions.custom-params.builder-image),
+      }
   template:
     ref: build-component-all-platforms

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr.yaml
@@ -17,7 +17,7 @@ spec:
             - key: timeout
               expression: >-
                 {
-                'pingcap/ticdc: '20m',
+                'pingcap/ticdc': '20m',
                 'pingcap/tidb': '40m',
                 'pingcap/tiflash': '2h',
                 'pingcap/tiflow': '40m',

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create.yaml
@@ -19,7 +19,7 @@ spec:
             - key: timeout
               expression: >-
                 {
-                'pingcap/ticdc: '20m',
+                'pingcap/ticdc': '20m',
                 'pingcap/tidb': '40m',
                 'pingcap/tiflash': '2h',
                 'pingcap/tiflow': '40m',

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create.yaml
@@ -11,56 +11,60 @@ spec:
       params:
         - name: filter
           value: >-
-            body.repository.full_name in ['pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'tikv/tikv', 'tikv/pd']
+            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'tikv/tikv', 'tikv/pd']
             &&
             body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+$')
         - name: overlays
           value:
-          - key: timeout
-            expression: >-
-              {
-              'pingcap/tidb': '40m',
-              'pingcap/tiflash': '2h',
-              'pingcap/tiflow': '40m',
-              'pingcap/tidb-dashboard': '40m',
-              'tikv/pd': '40m',
-              'tikv/tikv': '2h30m',
-              }[body.repository.full_name]
-          - key: source-ws-size
-            expression: >-
-              {
-              'pingcap/tidb': '50Gi',
-              'pingcap/tiflash': '100Gi',
-              'pingcap/tiflow': '50Gi',
-              'pingcap/tidb-dashboard': '8Gi',
-              'tikv/pd': '50Gi',
-              'tikv/tikv': '100Gi',
-              }[body.repository.full_name]
-          - key: builder-resources-cpu
-            expression: >-
-              {
-              'pingcap/tidb': '8',
-              'pingcap/tiflash': '16',
-              'pingcap/tiflow': '8',
-              'pingcap/tidb-dashboard': '2',
-              'tikv/pd': '8',
-              'tikv/tikv': '16',
-              }[body.repository.full_name]
-          - key: builder-resources-memory
-            expression: >-
-              {
-              'pingcap/tidb': '32Gi',
-              'pingcap/tiflash': '64Gi',
-              'pingcap/tiflow': '32Gi',
-              'pingcap/tidb-dashboard': '4Gi',
-              'tikv/pd': '32Gi',
-              'tikv/tikv': '64Gi',
-              }[body.repository.full_name]
-          - key: custom-params
-            expression: >-
-              {                
-                'builder-image': header.canonical('ce-paramBuilderImage')
-              }
+            - key: timeout
+              expression: >-
+                {
+                'pingcap/ticdc: '20m',
+                'pingcap/tidb': '40m',
+                'pingcap/tiflash': '2h',
+                'pingcap/tiflow': '40m',
+                'pingcap/tidb-dashboard': '40m',
+                'tikv/pd': '40m',
+                'tikv/tikv': '2h30m',
+                }[body.repository.full_name]
+            - key: source-ws-size
+              expression: >-
+                {
+                'pingcap/ticdc': '50Gi',
+                'pingcap/tidb': '50Gi',
+                'pingcap/tiflash': '100Gi',
+                'pingcap/tiflow': '50Gi',
+                'pingcap/tidb-dashboard': '8Gi',
+                'tikv/pd': '50Gi',
+                'tikv/tikv': '100Gi',
+                }[body.repository.full_name]
+            - key: builder-resources-cpu
+              expression: >-
+                {
+                'pingcap/ticdc': '4',
+                'pingcap/tidb': '8',
+                'pingcap/tiflash': '16',
+                'pingcap/tiflow': '8',
+                'pingcap/tidb-dashboard': '2',
+                'tikv/pd': '8',
+                'tikv/tikv': '16',
+                }[body.repository.full_name]
+            - key: builder-resources-memory
+              expression: >-
+                {
+                'pingcap/ticdc': '16Gi',
+                'pingcap/tidb': '32Gi',
+                'pingcap/tiflash': '64Gi',
+                'pingcap/tiflow': '32Gi',
+                'pingcap/tidb-dashboard': '4Gi',
+                'tikv/pd': '32Gi',
+                'tikv/tikv': '64Gi',
+                }[body.repository.full_name]
+            - key: custom-params
+              expression: >-
+                {
+                  'builder-image': header.canonical('ce-paramBuilderImage')
+                }
   bindings:
     - ref: github-tag-create
     - ref: ce-context
@@ -68,9 +72,18 @@ spec:
     - { name: profile, value: release }
     - { name: timeout, value: $(extensions.timeout) }
     - { name: source-ws-size, value: $(extensions.source-ws-size) }
-    - { name: builder-resources-cpu, value: $(extensions.builder-resources-cpu) }
-    - { name: builder-resources-memory, value: $(extensions.builder-resources-memory) }
+    - {
+        name: builder-resources-cpu,
+        value: $(extensions.builder-resources-cpu),
+      }
+    - {
+        name: builder-resources-memory,
+        value: $(extensions.builder-resources-memory),
+      }
     - { name: registry, value: hub.pingcap.net/devbuild }
-    - { name: force-builder-image, value: $(extensions.custom-params.builder-image) }
+    - {
+        name: force-builder-image,
+        value: $(extensions.custom-params.builder-image),
+      }
   template:
     ref: build-component-all-platforms

--- a/apps/prod/tekton/configs/triggers/triggers/_/harbor/artifact-push-on-harbor.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/harbor/artifact-push-on-harbor.yaml
@@ -13,7 +13,7 @@ spec:
         - name: filter
           value: >-
             body.event_data.repository.repo_full_name.matches('^(pingcap|tikv)/')
-            && 
+            &&
             body.event_data.repository.repo_full_name.matches('/package(s)?')
             &&
             body.event_data.resources[0].tag.matches('^(master|main|v[0-9]+[.][0-9]+[.][0-9]+)_(darwin|linux)_(amd64|arm64)$')
@@ -39,7 +39,7 @@ spec:
         - name: filter
           value: >-
             body.event_data.repository.repo_full_name.matches('^(pingcap|tikv)/')
-            && 
+            &&
             body.event_data.repository.repo_full_name.matches('/package(s)?')
             &&
             body.event_data.resources[0].tag.matches('^(release-[0-9]+[.][0-9]+)_(linux|darwin)_(amd64|arm64)$')

--- a/apps/prod/tekton/configs/triggers/triggers/kustomization.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - pingcap/advanced-statefulset/git-push.yaml
   - pingcap/monitoring/git-push.yaml
   - pingcap/ng-monitoring/git-push.yaml
+  - pingcap/ticdc/git-push.yaml
   - pingcap/tidb-binlog/git-push.yaml
   - pingcap/tidb-ctl/git-create-tag.yaml
   - pingcap/tidb-ctl/git-push.yaml

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/_/git-create-branch.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/_/git-create-branch.yaml
@@ -16,6 +16,7 @@ spec:
             'pingcap/tidb',
             'pingcap/tiflash',
             'pingcap/tiflow',
+            'pingcap/ticdc',
             'pingcap/tidb-binlog',
             'pingcap/tidb-dashboard',
             'pingcap/tidb-tools',

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/_/git-create-tag.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/_/git-create-tag.yaml
@@ -12,9 +12,12 @@ spec:
       params:
         - name: filter
           value: >-
-            body.repository.owner.login == 'pingcap'
-            &&
-            body.repository.name in ['monitoring', 'ng-monitoring', 'tidb-binlog', 'tidb-dashboard']
+            body.repository.full_name in [
+            'pingcap/monitoring',
+            'pingcap/ng-monitoring',
+            'pingcap/tidb-binlog',
+            'pingcap/tidb-dashboard',
+            ]
             &&
             body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+(-alpha)?$')
   bindings:

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/ticdc/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/ticdc/git-push.yaml
@@ -16,9 +16,7 @@ spec:
           # - master
           # - release-6.1, release-6.5, release-7.1, release-7.5
           value: >-
-            body.repository.owner.login == 'pingcap'
-            &&
-            body.repository.name == 'tiflow'
+            body.repository.full_name == 'pingcap/ticdc'
             &&
             body.ref.matches('^refs/heads/(master|release-[0-9]+[.][0-9]+)$')
 

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/ticdc/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/ticdc/git-push.yaml
@@ -1,0 +1,34 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: git-push-pingcap-ticdc
+  labels:
+    type: github-branch-push
+    github-owner: pingcap
+    github-repo: ticdc
+spec:
+  interceptors:
+    - name: filter on repo owner and name and branches
+      ref: { name: cel }
+      params:
+        - name: filter
+          # support branches:
+          # - master
+          # - release-6.1, release-6.5, release-7.1, release-7.5
+          value: >-
+            body.repository.owner.login == 'pingcap'
+            &&
+            body.repository.name == 'tiflow'
+            &&
+            body.ref.matches('^refs/heads/(master|release-[0-9]+[.][0-9]+)$')
+
+  bindings:
+    - ref: github-branch-push
+    - { name: component, value: $(body.repository.name) }
+    - { name: profile, value: release }
+    - { name: timeout, value: 20m }
+    - { name: source-ws-size, value: 50Gi }
+    - { name: builder-resources-memory, value: 16Gi }
+    - { name: builder-resources-cpu, value: "4" }
+  template:
+    ref: build-component-all-platforms


### PR DESCRIPTION
This pull request includes updates to several Tekton configuration files to add support for the `pingcap/ticdc` repository. The changes involve adding `pingcap/ticdc` to various filters and updating resource specifications for the repository.

Key changes include:

### Adding `pingcap/ticdc` to filters:
* [`apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml`](diffhunk://#diff-568be39468441f09f11d91d4c71d77c96952fb478d3695735af6b02f24cb8969L14-R20): Added `pingcap/ticdc` to the repository filter and updated resource specifications for timeout, source-ws-size, builder-resources-cpu, and builder-resources-memory. [[1]](diffhunk://#diff-568be39468441f09f11d91d4c71d77c96952fb478d3695735af6b02f24cb8969L14-R20) [[2]](diffhunk://#diff-568be39468441f09f11d91d4c71d77c96952fb478d3695735af6b02f24cb8969R31) [[3]](diffhunk://#diff-568be39468441f09f11d91d4c71d77c96952fb478d3695735af6b02f24cb8969R42) [[4]](diffhunk://#diff-568be39468441f09f11d91d4c71d77c96952fb478d3695735af6b02f24cb8969R53)
* [`apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr.yaml`](diffhunk://#diff-16116bc799a164aec2da92871c9b9f6e55fc88587d954afb5d13c261f014fefcL14-R20): Added `pingcap/ticdc` to the repository filter and updated resource specifications for timeout, source-ws-size, builder-resources-cpu, and builder-resources-memory. [[1]](diffhunk://#diff-16116bc799a164aec2da92871c9b9f6e55fc88587d954afb5d13c261f014fefcL14-R20) [[2]](diffhunk://#diff-16116bc799a164aec2da92871c9b9f6e55fc88587d954afb5d13c261f014fefcR31) [[3]](diffhunk://#diff-16116bc799a164aec2da92871c9b9f6e55fc88587d954afb5d13c261f014fefcR42) [[4]](diffhunk://#diff-16116bc799a164aec2da92871c9b9f6e55fc88587d954afb5d13c261f014fefcR53)
* [`apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create.yaml`](diffhunk://#diff-91cd5bc58ced2d97dfd4052e5009edbe7fffbe44f7427f2bb0a0d084636dc615L14-R22): Added `pingcap/ticdc` to the repository filter and updated resource specifications for timeout, source-ws-size, builder-resources-cpu, and builder-resources-memory. [[1]](diffhunk://#diff-91cd5bc58ced2d97dfd4052e5009edbe7fffbe44f7427f2bb0a0d084636dc615L14-R22) [[2]](diffhunk://#diff-91cd5bc58ced2d97dfd4052e5009edbe7fffbe44f7427f2bb0a0d084636dc615R33) [[3]](diffhunk://#diff-91cd5bc58ced2d97dfd4052e5009edbe7fffbe44f7427f2bb0a0d084636dc615R44) [[4]](diffhunk://#diff-91cd5bc58ced2d97dfd4052e5009edbe7fffbe44f7427f2bb0a0d084636dc615R55)
* [`apps/prod/tekton/configs/triggers/triggers/pingcap/_/git-create-branch.yaml`](diffhunk://#diff-9ddef8103f3cf2e639a5b0e93a7ad4530d28df90305b47ab5af9e861bb22aa38R19): Updated repository filter to use `body.repository.full_name`.
* [`apps/prod/tekton/configs/triggers/triggers/pingcap/_/git-create-tag.yaml`](diffhunk://#diff-2097aacd14bf070cf62cf28ef32eebed0c578e8304018a44d0dc358b8077c91bL15-R20): Updated repository filter to use `body.repository.full_name`.

### New configuration for `pingcap/ticdc`:
* [`apps/prod/tekton/configs/triggers/triggers/pingcap/ticdc/git-push.yaml`](diffhunk://#diff-d257e1812c73bd9af64b8bd869e047e0ca005d582cf296709afdba42d6f66328R1-R32): Added a new trigger configuration for `pingcap/ticdc` to handle Git push events.

### General updates:
* [`apps/prod/tekton/configs/triggers/triggers/kustomization.yaml`](diffhunk://#diff-9e987d6a977b5e794b91feff8d5f43c02c6113ba625f9a545a16845de78e456eR21): Included `pingcap/ticdc/git-push.yaml` in the resources list.

These changes ensure that the `pingcap/ticdc` repository is properly integrated into the Tekton pipeline configurations, allowing it to be processed similarly to other repositories in the `pingcap` organization.