### PR TITLE
chore(apps/prod/tekton/configs/triggers): update trigger for more repos

### DIFF
--- a/apps/prod/tekton/configs/triggers/triggers/_/github-pr-labeled-with-needs-ok-to-test.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/github-pr-labeled-with-needs-ok-to-test.yaml
@@ -15,7 +15,16 @@ spec:
             &&
             body.label.name in ['needs-ok-to-test']
             &&
-            body.repository.full_name in ['pingcap/tidb', 'tikv/tikv', 'tikv/pd']
+            body.repository.full_name in [
+            'pingcap/tidb',
+            'pingcap/tidb-dashboard',
+            'pingcap/tidb-operator',
+            'pingcap/tiflow',
+            'tikv/client-go',
+            'tikv/pd',
+            'tikv/raft-engine',
+            'tikv/tikv',
+            ]
             &&
             body.pull_request.user.login in ['mittalrishabh', 'Tema', 'HaoW30']
   bindings:


### PR DESCRIPTION
add more repos to make the PRs on them to be added `ok-to-test` label automatically for given contributors.