### PR TITLE
feat(pingcap/tidb-operator): add trigger for git push on `feature/v2` branch

### DIFF
--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb-operator/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb-operator/git-push.yaml
@@ -16,7 +16,7 @@ spec:
           value: >-
             body.repository.full_name == 'pingcap/tidb-operator'
             &&
-            body.ref.matches('^refs/heads/(master|release-.*)$')
+            body.ref.matches('^refs/heads/(master|release-.*|feature/v2)$')
   bindings:
     - ref: github-branch-push
     - { name: component, value: $(body.repository.name) }


### PR DESCRIPTION
This pull request includes a small but important change to the `git-push.yaml` configuration file. The change updates the branch matching pattern to include a new branch for triggering actions.

* [`apps/prod/tekton/configs/triggers/triggers/pingcap/tidb-operator/git-push.yaml`](diffhunk://#diff-3ca1bad252676f3082e361e731ac95e805883b344a366d3b27d5092ad5e51eddL19-R19): Updated the branch matching pattern to include `feature/v2` in addition to `master` and `release-*` branches.