### PR TITLE
feat(apps/prod/tekton/configs/triggers): parse `profile` param from cloud event extension

### DIFF
--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml
@@ -61,16 +61,20 @@ spec:
             - key: custom-params
               expression: >-
                 {
-                  'builder-image': header.canonical('ce-paramBuilderImage')
+                  'builder-image': header.canonical('ce-paramBuilderImage'),
+                  'profile': header.canonical('ce-paramProfile') || 'release',
                 }
   bindings:
     - ref: github-branch-push
     - ref: ce-context
     - { name: component, value: $(body.repository.name) }
-    - { name: profile, value: release }
+    - { name: profile, value: $(extensions.custom-params.profile) }
     - { name: timeout, value: $(extensions.timeout) }
     - { name: source-ws-size, value: $(extensions.source-ws-size) }
-    - { name: builder-resources-cpu, value: $(extensions.builder-resources-cpu) }
+    - {
+        name: builder-resources-cpu,
+        value: $(extensions.builder-resources-cpu),
+      }
     - {
         name: builder-resources-memory,
         value: $(extensions.builder-resources-memory),

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr.yaml
@@ -61,13 +61,14 @@ spec:
             - key: custom-params
               expression: >-
                 {
-                  'builder-image': header.canonical('ce-paramBuilderImage')
+                  'builder-image': header.canonical('ce-paramBuilderImage'),
+                  'profile': header.canonical('ce-paramProfile') || 'release',
                 }
   bindings:
     - ref: github-pr
     - ref: ce-context
     - { name: component, value: $(body.repository.name) }
-    - { name: profile, value: release }
+    - { name: profile, value: $(extensions.custom-params.profile) }
     - { name: timeout, value: $(extensions.timeout) }
     - { name: source-ws-size, value: $(extensions.source-ws-size) }
     - {

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create.yaml
@@ -63,13 +63,14 @@ spec:
             - key: custom-params
               expression: >-
                 {
-                  'builder-image': header.canonical('ce-paramBuilderImage')
+                  'builder-image': header.canonical('ce-paramBuilderImage'),
+                  'profile': header.canonical('ce-paramProfile') || 'release',
                 }
   bindings:
     - ref: github-tag-create
     - ref: ce-context
     - { name: component, value: $(body.repository.name) }
-    - { name: profile, value: release }
+    - { name: profile, value: $(extensions.custom-params.profile) }
     - { name: timeout, value: $(extensions.timeout) }
     - { name: source-ws-size, value: $(extensions.source-ws-size) }
     - {


### PR DESCRIPTION
This pull request includes changes to the Tekton trigger configurations to improve the handling of the `profile` parameter. The main updates involve reading the `profile` parameter from the header or defaulting to 'release' and ensuring that the `profile` parameter is correctly passed to the bindings.

Key changes:

* [`apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml`](diffhunk://#diff-568be39468441f09f11d91d4c71d77c96952fb478d3695735af6b02f24cb8969L64-R77): Updated the `custom-params` to include the `profile` parameter from the header or default to 'release', and modified the binding to use `$(extensions.custom-params.profile)` for the `profile` parameter.
* [`apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr.yaml`](diffhunk://#diff-16116bc799a164aec2da92871c9b9f6e55fc88587d954afb5d13c261f014fefcL64-R71): Similar update to include the `profile` parameter in `custom-params` and use `$(extensions.custom-params.profile)` in the binding.
* [`apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create.yaml`](diffhunk://#diff-91cd5bc58ced2d97dfd4052e5009edbe7fffbe44f7427f2bb0a0d084636dc615L66-R73): Included the `profile` parameter in `custom-params` and updated the binding to use `$(extensions.custom-params.profile)`.