### PR TITLE
chore(apps/prod/tibuild): bump tibuild image tag to `v2024.12.12-9-g8a17a7b`

### DIFF
--- a/apps/prod/tibuild/deployment.yaml
+++ b/apps/prod/tibuild/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app: tibuild
     spec:
       containers:
-        - image: ghcr.io/pingcap-qe/ee-apps/tibuild:v2024.12.12-8-g69b4764
+        - image: ghcr.io/pingcap-qe/ee-apps/tibuild:v2024.12.12-9-g8a17a7b
           imagePullPolicy: Always
           name: tibuild
           ports:


### PR DESCRIPTION

Ref: https://github.com/PingCAP-QE/ee-apps/pull/222