### PR TITLE
chore(apps/gcp/prow): bump external plugin version

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -254,7 +254,7 @@ spec:
           name: prow-hook
         image:
           repository: ticommunityinfra/tichi-cherrypicker-plugin
-          tag: v2.4.4
+          tag: v2.4.5
         args:
           - --dry-run=false
           - --github-token-path=/etc/github/token
@@ -325,7 +325,7 @@ spec:
           name: prow-hook
         image:
           repository: ticommunityinfra/tichi-issue-triage-plugin
-          tag: v2.4.3
+          tag: v2.4.5
         args:
           - --dry-run=false
           - --github-app-id=$(GITHUB_APP_ID)


### PR DESCRIPTION
- cherrypicker, ref: https://github.com/ti-community-infra/tichi/pull/1192
- issue-triage, ref: https://github.com/ti-community-infra/tichi/pull/1193