### PR TITLE
feat(apps/prod): deploy chatops lark bot

### DIFF
--- a/apps/prod/chatops-lark/kustomization.yaml
+++ b/apps/prod/chatops-lark/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: apps
+resources:
+  - release.yaml

--- a/apps/prod/chatops-lark/release.yaml
+++ b/apps/prod/chatops-lark/release.yaml
@@ -1,0 +1,46 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: chatops-lark
+spec:
+  releaseName: chatops-lark
+  chart:
+    spec:
+      chart: chatops-lark
+      version: 0.1.0
+      sourceRef:
+        kind: HelmRepository
+        name: ee-apps
+        namespace: flux-system
+  interval: 5m
+  timeout: 5m
+  install:
+    remediation:
+      retries: 3
+  rollback:
+    cleanupOnFail: true
+    recreate: true
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  test:
+    enable: true
+    ignoreFailures: false
+  values:
+    replicaCount: 1
+    resources:
+      limits:
+        cpu: "500m"
+        memory: 512Mi
+    nodeSelector:
+      kubernetes.io/arch: amd64
+    image:
+      repository: ghcr.io/pingcap-qe/ee-apps/chatops-lark
+      # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/chatops-lark versioning=semver
+      tag: v2025.1.30-7-gce0dddc
+    server:
+      secretKey: chatops-lark
+      appIdSecretKey: app-id
+      appSecretSecretKey: app-secret
+      configFileSecretKey: config.yaml

--- a/apps/prod/kustomization.yaml
+++ b/apps/prod/kustomization.yaml
@@ -24,3 +24,4 @@ resources:
   - coder
   - redis
   - publisher
+  - chatops-lark


### PR DESCRIPTION
This pull request introduces a new HelmRelease for the `chatops-lark` application and updates the kustomization files to include this new resource. The most important changes include the addition of `chatops-lark` to the kustomization resources and the detailed configuration of the HelmRelease.

Additions to kustomization and HelmRelease configuration:

* [`apps/prod/chatops-lark/kustomization.yaml`](diffhunk://#diff-4119b17540b0e13598661402ee1efba2b16ef8512cab59ab1f20a80bc40646eaR1-R5): Created a new kustomization file for the `chatops-lark` application.
* [`apps/prod/chatops-lark/release.yaml`](diffhunk://#diff-20c9387c8f1e6985fb4d41f78c9b9b82835b612abbd3e778c45947b2de277079R1-R46): Added detailed HelmRelease configuration for `chatops-lark`, including chart specifications, installation and upgrade strategies, resource limits, and image details.
* [`apps/prod/kustomization.yaml`](diffhunk://#diff-ee20854a69c2a0d1fcc07e8216c968e5895b76a9f9ffc942a8aa69a9747354e5R27): Included `chatops-lark` in the list of resources to be managed by kustomize.