### PR TITLE
chore(apps/prod/chatops-lark): bump chart release with new image

### DIFF
--- a/apps/prod/chatops-lark/release.yaml
+++ b/apps/prod/chatops-lark/release.yaml
@@ -7,7 +7,7 @@ spec:
   chart:
     spec:
       chart: chatops-lark
-      version: 0.1.1
+      version: 0.1.2
       sourceRef:
         kind: HelmRepository
         name: ee-apps
@@ -25,7 +25,7 @@ spec:
     remediation:
       retries: 3
   test:
-    enable: false
+    enable: true
     ignoreFailures: false
   values:
     replicaCount: 1
@@ -38,7 +38,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/chatops-lark
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/chatops-lark versioning=semver
-      tag: v2025.1.30-7-gce0dddc
+      tag: v2025.1.30-11-g3b74562
     server:
       secretName: chatops-lark
       appIdSecretKey: app-id


### PR DESCRIPTION
ref https://github.com/PingCAP-QE/ee-apps/pull/238

This pull request includes updates to the `apps/prod/chatops-lark/release.yaml` file to update the chart version, enable testing, and update the image tag.

Chart and version updates:

* Updated the chart version from `0.1.1` to `0.1.2` in the `spec:` section.

Testing configuration:

* Enabled testing by changing the `enable` field from `false` to `true` in the `spec:` section.

Image updates:

* Updated the image tag from `v2025.1.30-7-gce0dddc` to `v2025.1.30-11-g3b74562` in the `spec:` section.