### PR TITLE
chore(apps/prod/tekton/configs/pipelines): use pingcap-get-set-release-version-v2 in pipeline

### DIFF
--- a/apps/prod/tekton/configs/pipelines/pingcap-build-package-darwin.yaml
+++ b/apps/prod/tekton/configs/pipelines/pingcap-build-package-darwin.yaml
@@ -107,7 +107,7 @@ spec:
       runAfter:
         - checkout
       taskRef:
-        name: pingcap-get-set-release-version
+        name: pingcap-get-set-release-version-v2
       workspaces:
         - name: source
           workspace: source

--- a/apps/prod/tekton/configs/pipelines/pingcap-build-package-linux.yaml
+++ b/apps/prod/tekton/configs/pipelines/pingcap-build-package-linux.yaml
@@ -108,7 +108,7 @@ spec:
       runAfter:
         - checkout
       taskRef:
-        name: pingcap-get-set-release-version
+        name: pingcap-get-set-release-version-v2
       workspaces:
         - name: source
           workspace: source

--- a/apps/prod/tekton/configs/tasks/pingcap-get-set-release-version-v2.yaml
+++ b/apps/prod/tekton/configs/tasks/pingcap-get-set-release-version-v2.yaml
@@ -33,7 +33,7 @@ spec:
         if git tag | grep -E "v[0-9]+[.][0-9]+[.][0-9]+(-(alpha|beta|fips)([.][0-9]+)?)?$" > /dev/null; then
           # Only delete the none-standard tags when the repo has standard semver tags.
 
-          git tag | grep -vE "^v[0-9]+[.][0-9]+[.][0-9]+(-(alpha|beta|fips|202[1-9][0-1][0-9][0-3][0-9]-[0-9a-f]{7,10}))?$" | xargs git tag -d || true
+          git tag | grep -vE "^v[0-9]+[.][0-9]+[.][0-9]+(-(((alpha|beta|rc)([.].+)?)|fips|202[1-9][0-1][0-9][0-3][0-9]-[0-9a-f]{7,10}))?$" | xargs git tag -d || true
         fi
         # Get raw version and save to file for next step
         git describe --tags --always --dirty --exclude 'v20[0-9][0-9].[0-1][0-9].[0-3][0-9]*' > /workspace/raw-version.txt


### PR DESCRIPTION
This pull request includes updates to the Tekton pipeline configuration files and a task script to use a new version of a task and improve tag handling.

Updates to pipeline configuration:

* [`apps/prod/tekton/configs/pipelines/pingcap-build-package-darwin.yaml`](diffhunk://#diff-4375ee3268c7e5b103a5849b55d25ff2d4a9167389910c0e5836865cd14b392aL110-R110): Updated `taskRef` to use `pingcap-get-set-release-version-v2` instead of the previous version.
* [`apps/prod/tekton/configs/pipelines/pingcap-build-package-linux.yaml`](diffhunk://#diff-ce766b7b64adef72b7b3a177ad33e24ec5a6296eaea73fab93e0473927bed22bL111-R111): Updated `taskRef` to use `pingcap-get-set-release-version-v2` instead of the previous version.

Improvements to tag handling:

* [`apps/prod/tekton/configs/tasks/pingcap-get-set-release-version-v2.yaml`](diffhunk://#diff-b5fc328a8d15f645528a96e2d3b4720fc95c0f4cec188f784ae1f4a692d65009L36-R36): Modified the regex pattern in the script to include `rc` tags and improve the exclusion of non-standard tags.