### PR TITLE
feat(apps/prod/tekton/configs/triggers): add single platform build tiggers for devbuild

### DIFF
--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push-single-platform.yaml
@@ -1,21 +1,19 @@
 apiVersion: triggers.tekton.dev/v1beta1
 kind: Trigger
 metadata:
-  name: fake-github-tag-create
+  name: fake-github-branch-push-single-platform
   labels:
-    type: fake-github-tag-create
+    type: fake-github-branch-push
 spec:
   interceptors:
-    - name: filter on repo owner and name and tags
+    - name: filter on repo
       ref: { name: cel }
       params:
         - name: filter
           value: >-
             body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'tikv/tikv', 'tikv/pd']
             &&
-            body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+(-(alpha|beta|rc)([.][0-9]+)?)?$')
-            &&
-            ! (header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64'])
+            header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64']
         - name: overlays
           value:
             - key: timeout
@@ -67,9 +65,11 @@ spec:
                 {
                   'builder-image': header.canonical('ce-paramBuilderImage'),
                   'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
+                  'os': header.canonical('ce-paramPlatform').split('/')[0],
+                  'arch': header.canonical('ce-paramPlatform').split('/')[1],
                 }
   bindings:
-    - ref: github-tag-create
+    - ref: github-branch-push
     - ref: ce-context
     - { name: component, value: $(body.repository.name) }
     - { name: profile, value: $(extensions.custom-params.profile) }
@@ -88,5 +88,7 @@ spec:
         name: force-builder-image,
         value: $(extensions.custom-params.builder-image),
       }
+    - { name: os, value: $(extensions.custom-params.os) }
+    - { name: arch, value: $(extensions.custom-params.arch) }
   template:
-    ref: build-component-all-platforms
+    ref: build-component-single-platform

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml
@@ -12,6 +12,8 @@ spec:
         - name: filter
           value: >-
             body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'tikv/tikv', 'tikv/pd']
+            &&
+            ! (header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64'])
         - name: overlays
           value:
             - key: timeout
@@ -62,7 +64,7 @@ spec:
               expression: >-
                 {
                   'builder-image': header.canonical('ce-paramBuilderImage'),
-                  'profile': header.canonical('ce-paramProfile') == '' ? 'release' : header.canonical('ce-paramProfile'),
+                  'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
                 }
   bindings:
     - ref: github-branch-push

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr-single-platform.yaml
@@ -1,21 +1,19 @@
 apiVersion: triggers.tekton.dev/v1beta1
 kind: Trigger
 metadata:
-  name: fake-github-tag-create
+  name: fake-github-pr-single-platform
   labels:
-    type: fake-github-tag-create
+    type: fake-github-pr
 spec:
   interceptors:
-    - name: filter on repo owner and name and tags
+    - name: filter on repo
       ref: { name: cel }
       params:
         - name: filter
           value: >-
             body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'tikv/tikv', 'tikv/pd']
             &&
-            body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+(-(alpha|beta|rc)([.][0-9]+)?)?$')
-            &&
-            ! (header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64'])
+            header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64']
         - name: overlays
           value:
             - key: timeout
@@ -67,9 +65,11 @@ spec:
                 {
                   'builder-image': header.canonical('ce-paramBuilderImage'),
                   'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
+                  'os': header.canonical('ce-paramPlatform').split('/')[0],
+                  'arch': header.canonical('ce-paramPlatform').split('/')[1],
                 }
   bindings:
-    - ref: github-tag-create
+    - ref: github-pr
     - ref: ce-context
     - { name: component, value: $(body.repository.name) }
     - { name: profile, value: $(extensions.custom-params.profile) }
@@ -88,5 +88,7 @@ spec:
         name: force-builder-image,
         value: $(extensions.custom-params.builder-image),
       }
+    - { name: os, value: $(extensions.custom-params.os) }
+    - { name: arch, value: $(extensions.custom-params.arch) }
   template:
-    ref: build-component-all-platforms
+    ref: build-component-single-platform

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr.yaml
@@ -12,6 +12,8 @@ spec:
         - name: filter
           value: >-
             body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'tikv/tikv', 'tikv/pd']
+            &&
+            ! (header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64'])
         - name: overlays
           value:
             - key: timeout
@@ -62,7 +64,7 @@ spec:
               expression: >-
                 {
                   'builder-image': header.canonical('ce-paramBuilderImage'),
-                  'profile': header.canonical('ce-paramProfile') == '' ? 'release' : header.canonical('ce-paramProfile'),
+                  'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
                 }
   bindings:
     - ref: github-pr

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create-single-platform.yaml
@@ -1,12 +1,12 @@
 apiVersion: triggers.tekton.dev/v1beta1
 kind: Trigger
 metadata:
-  name: fake-github-tag-create
+  name: fake-github-tag-create-single-platform
   labels:
     type: fake-github-tag-create
 spec:
   interceptors:
-    - name: filter on repo owner and name and tags
+    - name: filter on repo owner and name and tags and platform
       ref: { name: cel }
       params:
         - name: filter
@@ -15,7 +15,7 @@ spec:
             &&
             body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+(-(alpha|beta|rc)([.][0-9]+)?)?$')
             &&
-            ! (header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64'])
+            header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64']
         - name: overlays
           value:
             - key: timeout
@@ -67,6 +67,8 @@ spec:
                 {
                   'builder-image': header.canonical('ce-paramBuilderImage'),
                   'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
+                  'os': header.canonical('ce-paramPlatform').split('/')[0],
+                  'arch': header.canonical('ce-paramPlatform').split('/')[1],
                 }
   bindings:
     - ref: github-tag-create
@@ -88,5 +90,7 @@ spec:
         name: force-builder-image,
         value: $(extensions.custom-params.builder-image),
       }
+    - { name: os, value: $(extensions.custom-params.os) }
+    - { name: arch, value: $(extensions.custom-params.arch) }
   template:
-    ref: build-component-all-platforms
+    ref: build-component-single-platform

--- a/apps/prod/tekton/configs/triggers/triggers/kustomization.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/kustomization.yaml
@@ -2,8 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - _/ctl/artifact-push-on-harbor.yaml
+  - _/fake-github/fake-github-branch-push-single-platform.yaml
   - _/fake-github/fake-github-branch-push.yaml
+  - _/fake-github/fake-github-pr-single-platform.yaml
   - _/fake-github/fake-github-pr.yaml
+  - _/fake-github/fake-github-tag-create-single-platform.yaml
   - _/fake-github/fake-github-tag-create.yaml
   - _/git-push-on-fips-branches.yaml
   - _/github-pr-labeled-with-lgtm.yaml


### PR DESCRIPTION
devbuild will send fake GitHub events with a new header named 'ce-paramPlatform'.