### PR TITLE
chore(apps/prod2/coder/release): bump to v2.21.0

### DIFF
--- a/apps/prod2/coder/release/release.yaml
+++ b/apps/prod2/coder/release/release.yaml
@@ -7,7 +7,7 @@ spec:
   chart:
     spec:
       chart: coder
-      version: 2.18.5
+      version: 2.21.0
       reconcileStrategy: ChartVersion
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
This pull request updates the Helm chart version in the `release.yaml` file to ensure the application uses the latest features and fixes.

* [`apps/prod2/coder/release/release.yaml`](diffhunk://#diff-d9857e0d055c5ef073117b02961d87ae45d567c44c51a17e4587d01e56e54542L10-R10): Updated the `chart.spec.version` from `2.18.5` to `2.21.0` to align with the latest chart release.