### PR TITLE
chore(apps/prod2): split coder workspaces into independent namespace

### DIFF
--- a/apps/prod2/coder/workspaces/kustomization.yaml
+++ b/apps/prod2/coder/workspaces/kustomization.yaml
@@ -1,7 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: coder-workspaces
 resources:
   - namespace.yaml
-  - db
-  - release.yaml
-  - workspaces
+  - rbac.yaml

--- a/apps/prod2/coder/workspaces/namespace.yaml
+++ b/apps/prod2/coder/workspaces/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: coder-workspaces

--- a/apps/prod2/coder/workspaces/rbac.yaml
+++ b/apps/prod2/coder/workspaces/rbac.yaml
@@ -1,0 +1,57 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: coder-workspace-perms
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: coder
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: coder-workspace-perms
+subjects:
+  - kind: ServiceAccount
+    name: coder
+    namespace: coder


### PR DESCRIPTION
Create namespace `coder-workspaces` and binding service account to `coder`