### PR TITLE
fix(apps/prod/tekton): add macOS single platform devbuild support

### DIFF
--- a/apps/prod/tekton/configs/triggers/templates/_/build-component-single-platform-darwin.yaml
+++ b/apps/prod/tekton/configs/triggers/templates/_/build-component-single-platform-darwin.yaml
@@ -1,0 +1,100 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: build-component-single-platform-darwin
+spec:
+  params:
+    - name: git-url
+      description: The git repository full url
+    - name: git-refspec
+      default: +refs/heads/*:refs/heads/*
+    - name: git-revision
+      description: The git revision
+    - name: git-ref
+      description: The git branch
+    - name: component
+      description: component name, tidb|tikv|pd|tiflow|tiflash, etc...
+    - name: os
+      default: linux
+    - name: arch
+      default: amd64
+    - name: profile
+      description: build target profile
+      default: release
+    - name: registry
+      default: hub.pingcap.net
+    - name: timeout
+      description: pipeline run timeout
+      default: 2h
+    - name: source-ws-size
+      description: workspace size for source.
+      default: 10Gi
+    - name: builder-resources-memory
+      default: 16Gi
+    - name: builder-resources-cpu
+      default: "4"
+    - name: ce-context
+      description: cloud event context.
+      default: "{}"
+    - name: force-builder-image
+      default: ""
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: bp-$(tt.params.component)-$(tt.params.profile)-$(tt.params.os)-$(tt.params.arch)-
+        annotations:
+          "tekton.dev/ce-context": $(tt.params.ce-context)
+          "tibuild.pingcap.net/git-repo": $(tt.params.git-url)
+          "tibuild.pingcap.net/git-ref": $(tt.params.git-ref)
+          "tibuild.pingcap.net/git-revision": $(tt.params.git-revision)
+          "tibuild.pingcap.net/component": $(tt.params.component)
+          "tibuild.pingcap.net/profile": $(tt.params.profile)
+          "tibuild.pingcap.net/platform": $(tt.params.os)/$(tt.params.arch)
+      spec:
+        pipelineRef:
+          name: pingcap-build-package-$(tt.params.os)
+        params:
+          - name: git-url
+            value: $(tt.params.git-url)
+          - name: git-refspec
+            value: $(tt.params.git-refspec)
+          - name: git-revision
+            value: $(tt.params.git-revision)
+          - name: git-ref
+            value: $(tt.params.git-ref)
+          - name: component
+            value: $(tt.params.component)
+          - name: profile
+            value: $(tt.params.profile)
+          - name: os
+            value: $(tt.params.os)
+          - name: arch
+            value: $(tt.params.arch)
+          - name: registry
+            value: $(tt.params.registry)
+          - name: force-builder-image
+            value: $(tt.params.force-builder-image)
+          - name: boskos-server-url
+            value: http://boskos.apps.svc
+        timeouts:
+          pipeline: $(tt.params.timeout)
+        workspaces:
+          - name: dockerconfig
+            secret:
+              secretName: hub-pingcap-net-ee
+          - name: source
+            volumeClaimTemplate:
+              spec:
+                storageClassName: ceph-block
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: $(tt.params.source-ws-size)
+          - name: git-basic-auth # fetch with git-cdn.
+            secret:
+              secretName: git-credentials-basic
+          - name: mac-ssh-credentials
+            secret:
+              secretName: mac-ssh-credentials

--- a/apps/prod/tekton/configs/triggers/templates/_/build-component-single-platform-darwin.yaml
+++ b/apps/prod/tekton/configs/triggers/templates/_/build-component-single-platform-darwin.yaml
@@ -15,7 +15,7 @@ spec:
     - name: component
       description: component name, tidb|tikv|pd|tiflow|tiflash, etc...
     - name: os
-      default: linux
+      default: darwin
     - name: arch
       default: amd64
     - name: profile

--- a/apps/prod/tekton/configs/triggers/templates/_/build-component-single-platform-linux.yaml
+++ b/apps/prod/tekton/configs/triggers/templates/_/build-component-single-platform-linux.yaml
@@ -1,7 +1,7 @@
 apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerTemplate
 metadata:
-  name: build-component-single-platform
+  name: build-component-single-platform-linux
 spec:
   params:
     - name: git-url
@@ -35,7 +35,9 @@ spec:
       default: "4"
     - name: ce-context
       description: cloud event context.
-      default: '{}'
+      default: "{}"
+    - name: force-builder-image
+      default: ""
   resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
@@ -51,7 +53,7 @@ spec:
           "tibuild.pingcap.net/platform": $(tt.params.os)/$(tt.params.arch)
       spec:
         pipelineRef:
-          name: pingcap-build-package-linux
+          name: pingcap-build-package-$(tt.params.os)
         params:
           - name: git-url
             value: $(tt.params.git-url)
@@ -71,6 +73,8 @@ spec:
             value: $(tt.params.arch)
           - name: registry
             value: $(tt.params.registry)
+          - name: force-builder-image
+            value: $(tt.params.force-builder-image)
         taskRunSpecs:
           - pipelineTaskName: build-binaries
             taskPodTemplate:

--- a/apps/prod/tekton/configs/triggers/templates/kustomization.yaml
+++ b/apps/prod/tekton/configs/triggers/templates/kustomization.yaml
@@ -2,7 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - _/build-component-all-platforms.yaml
-  - _/build-component-single-platform.yaml
+  - _/build-component-single-platform-darwin.yaml
+  - _/build-component-single-platform-linux.yaml
   - _/build-component.yaml
   - _/ci-helper-for-pr.yaml
   - _/image-push.yaml

--- a/apps/prod/tekton/configs/triggers/triggers/_/ctl/artifact-push-on-harbor.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/ctl/artifact-push-on-harbor.yaml
@@ -44,7 +44,7 @@ spec:
     - { name: os, value: $(extensions.os) }
     - { name: arch, value: $(extensions.arch) }
   template:
-    ref: build-component-single-platform
+    ref: build-component-single-platform-linux
 ---
 apiVersion: triggers.tekton.dev/v1beta1
 kind: Trigger
@@ -92,4 +92,4 @@ spec:
     - { name: os, value: $(extensions.os) }
     - { name: arch, value: $(extensions.arch) }
   template:
-    ref: build-component-single-platform
+    ref: build-component-single-platform-linux

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push-single-platform.yaml
@@ -91,4 +91,4 @@ spec:
     - { name: os, value: $(extensions.custom-params.os) }
     - { name: arch, value: $(extensions.custom-params.arch) }
   template:
-    ref: build-component-single-platform
+    ref: build-component-single-platform-$(extensions.custom-params.os)

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr-single-platform.yaml
@@ -91,4 +91,4 @@ spec:
     - { name: os, value: $(extensions.custom-params.os) }
     - { name: arch, value: $(extensions.custom-params.arch) }
   template:
-    ref: build-component-single-platform
+    ref: build-component-single-platform-$(extensions.custom-params.os)

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create-single-platform.yaml
@@ -93,4 +93,4 @@ spec:
     - { name: os, value: $(extensions.custom-params.os) }
     - { name: arch, value: $(extensions.custom-params.arch) }
   template:
-    ref: build-component-single-platform
+    ref: build-component-single-platform-$(extensions.custom-params.os)


### PR DESCRIPTION
Rename and restructure trigger templates to support OS-specific builds:
- Split single-platform template into Linux and Darwin variants
- Update references to use OS-specific templates
- Add macOS SSH credentials workspace for Darwin builds
- Make pipeline reference dynamic based on OS parameter