### PR TITLE
feat(apps/prod/tekton): add task and trigger template for updating ladp crt/key in hotfix branches

### DIFF
--- a/apps/prod/tekton/configs/tasks/hotfix/create-pr-to-update-gomod-fix-ladp.yaml
+++ b/apps/prod/tekton/configs/tasks/hotfix/create-pr-to-update-gomod-fix-ladp.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: create-pr-to-update-gomod-fix-ladp
+  name: create-pr-to-update-gomod-fix-ladp-debug-by-wulifu
   labels:
     app.kubernetes.io/version: "0.1"
   annotations:
@@ -62,11 +62,14 @@ spec:
           echo "Branch $(params.branch) is a hotfix branch for $base_release_branch which may need to update the ldap crt/key."
           echo "Fetching base release branch: $base_release_branch..."
           git fetch origin $base_release_branch
+          git remote -v 
+          git branch
           echo "Successfully fetched $base_release_branch."
           
           echo "Performing git cherry-pick if needed..."
-          commit_to_cherry_pick=$(git log origin/$base_release_branch --grep="re-generate crt/key for ldap test" --format=%H -n 1)
-          if [[ -n "$commit_to_cherry_pick" ]]; then
+          commit_to_cherry_pick=$(git log FETCH_HEAD --grep="re-generate crt/key for ldap test" --format=%H -n 1)
+          echo "commit_to_cherry_pick: $commit_to_cherry_pick"
+          if [ -n "$commit_to_cherry_pick" ]; then
             echo "Cherry-picking commit $commit_to_cherry_pick from $base_release_branch"
             git cherry-pick $commit_to_cherry_pick
           else
@@ -126,21 +129,40 @@ spec:
           echo "Local branch $(params.branch) is not ahead of origin/$(params.branch)."
         fi
 
-        if [ "$gomod_has_changes" = false ] && [ "$local_branch_is_ahead" = false ]; then
+        pr_title=""
+        head_branch_name_suffix=""
+
+        if [ "$gomod_has_changes" = true ] && [ "$local_branch_is_ahead" = true ]; then
+          # Case 1: Both go.mod changed AND LDAP commit exists
+          pr_title="deps: update go.mod and re-generate crt/key for ldap test"
+          head_branch_name_suffix="gomod-appdash-and-ldap-crt-key-update"
+        elif [ "$gomod_has_changes" = true ]; then
+          # Case 2: Only go.mod changed
+          pr_title="deps: replace 'sourcegraph.com/sourcegraph/appdash*' in go.mod"
+          head_branch_name_suffix="go-module-appdash"
+        elif [ "$local_branch_is_ahead" = true ]; then
+          # Case 3: Only LDAP commit exists
+          pr_title="ldap,test: re-generate crt/key for ldap test"
+          head_branch_name_suffix="ldap-crt-key-update"
+        else
+          # Case 4: No changes
           echo "🤷 No uncommitted go.mod/go.sum changes and local branch is not ahead of remote. Exiting without creating PR."
           exit 0
-        else
-          echo "🚀 Changes detected, proceeding to create PR..."
         fi
 
+        echo "🚀 Changes detected, proceeding to create PR..."
+        echo "PR Title: $pr_title"
+        echo "Head branch suffix: $head_branch_name_suffix"
+
         if [ "$gomod_has_changes" = true ]; then
-          go_mod_changed_commit_msg="deps: replace 'sourcegraph.com/sourcegraph/appdash*' in go.mod"
-          git commit -am "$go_mod_changed_commit_msg"
+          go_mod_commit_msg="deps: replace 'sourcegraph.com/sourcegraph/appdash*' in go.mod"
+          echo "Committing go.mod changes with message: $go_mod_commit_msg"
+          git commit -am "$go_mod_commit_msg"
         fi
 
         # login and setup git (gh tool installation assumed to be idempotent or handled)
         # install `gh` tool (ensure it's available)
-        type -p curl >/dev/null || ( apt update &&  apt install curl -y)
+        type -p curl >/dev/null || ( apt update && apt install curl -y)
         curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg |  dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
         && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
         && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" |  tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
@@ -150,10 +172,8 @@ spec:
         gh auth login --with-token < $(workspaces.github.path)/token
         gh auth setup-git
 
-        head_branch="fix/$(params.branch)/go-module-appdash"
-        if [ "$local_branch_is_ahead" = true ]; then
-          head_branch="fix/$(params.branch)/gomod-appdash-and-ldap-crt-key-update"
-        fi
+        head_branch="fix/$(params.branch)/$head_branch_name_suffix"
+        echo "Checking out and pushing to new branch: $head_branch"
         git checkout -b "$head_branch"
         git push origin "$head_branch"
 
@@ -167,10 +187,12 @@ spec:
         None
         \`\`\`
         EOF
+        
+        echo "Creating PR with title: '$pr_title' for head branch '$head_branch' into base '$(params.branch)'"
         gh pr create \
           --base $(params.branch) \
           --head "$head_branch" \
-          --fill \
+          --title "$pr_title" \
           --body-file pr_body.txt
   workspaces:
     - name: github

--- a/apps/prod/tekton/configs/tasks/hotfix/create-pr-to-update-gomod-fix-ladp.yaml
+++ b/apps/prod/tekton/configs/tasks/hotfix/create-pr-to-update-gomod-fix-ladp.yaml
@@ -27,6 +27,55 @@ spec:
       workingDir: /workspace
       script: |
         git clone $(params.git-url) --branch $(params.branch) --depth 1 /workspace/src
+
+    - name: update-ladp-crt-key
+      image: bitnami/git:2.43.0
+      workingDir: /workspace/src
+      script: |
+        git config --global --add safe.directory `pwd`
+        
+        # Update ladp crt/key by cherry-pick specific commit from base release branch
+        # Check if the branch is a hotfix branch for specific hotfix release branch
+        
+        base_release_branch=""
+        needs_ldap_fix=false
+
+        case "$(params.branch)" in
+          release-7.5-*)
+            base_release_branch="release-7.5"
+            needs_ldap_fix=true
+            ;;
+          release-8.1-*)
+            base_release_branch="release-8.1"
+            needs_ldap_fix=true
+            ;;
+          release-8.5-*)
+            base_release_branch="release-8.5"
+            needs_ldap_fix=true
+            ;;
+          *)
+            echo "Branch $(params.branch) is not a designated hotfix release for ldap crt/key update (release-7.5-*, release-8.1-*, release-8.5-*)."
+            ;;
+        esac
+
+        if [ "$needs_ldap_fix" = "true" ] && [ -n "$base_release_branch" ]; then
+          echo "Branch $(params.branch) is a hotfix branch for $base_release_branch which may need to update the ldap crt/key."
+          echo "Fetching base release branch: $base_release_branch..."
+          git fetch origin $base_release_branch
+          echo "Successfully fetched $base_release_branch."
+          
+          echo "Performing git cherry-pick if needed..."
+          commit_to_cherry_pick=$(git log origin/$base_release_branch --grep="re-generate crt/key for ldap test" --format=%H -n 1)
+          if [[ -n "$commit_to_cherry_pick" ]]; then
+            echo "Cherry-picking commit $commit_to_cherry_pick from $base_release_branch"
+            git cherry-pick $commit_to_cherry_pick
+          else
+            echo "No relevant commit found in $base_release_branch to cherry-pick for ldap update."
+          fi
+        else
+          echo "Skipping ldap crt/key update for branch $(params.branch)."
+        fi
+
     - name: update-gomod
       image: "$(params.golang-image)"
       workingDir: /workspace/src
@@ -58,14 +107,39 @@ spec:
         git config --global user.email "ti-community-prow-bot@tidb.io"
         git config --global user.name  "ti-chi-bot"
 
-        if git diff --exit-code --name-status go.mod; then
-          echo "🤷 No need to update the go.mod file, they are updated."
-          exit 0
-        else
-          echo "🚀 Let's update go.mod and go.sum files..."
+        gomod_has_changes=false
+        if ! git diff --exit-code --quiet go.mod; then
+          echo "go.mod has uncommitted changes."
+          gomod_has_changes=true
         fi
 
-        # install `gh` tool
+        # Fetch the latest state of the remote branch to accurately compare
+        echo "Fetching remote branch $(params.branch)..."
+        git fetch origin $(params.branch)
+
+        local_commits_ahead_count=$(git rev-list origin/$(params.branch)..HEAD --count)
+        local_branch_is_ahead=false
+        if [ "$local_commits_ahead_count" -gt 0 ]; then
+          echo "Local branch $(params.branch) is $local_commits_ahead_count commit(s) ahead of origin/$(params.branch)."
+          local_branch_is_ahead=true
+        else
+          echo "Local branch $(params.branch) is not ahead of origin/$(params.branch)."
+        fi
+
+        if [ "$gomod_has_changes" = false ] && [ "$local_branch_is_ahead" = false ]; then
+          echo "🤷 No uncommitted go.mod/go.sum changes and local branch is not ahead of remote. Exiting without creating PR."
+          exit 0
+        else
+          echo "🚀 Changes detected, proceeding to create PR..."
+        fi
+
+        if [ "$gomod_has_changes" = true ]; then
+          go_mod_changed_commit_msg="deps: replace 'sourcegraph.com/sourcegraph/appdash*' in go.mod"
+          git commit -am "$go_mod_changed_commit_msg"
+        fi
+
+        # login and setup git (gh tool installation assumed to be idempotent or handled)
+        # install `gh` tool (ensure it's available)
         type -p curl >/dev/null || ( apt update &&  apt install curl -y)
         curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg |  dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
         && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
@@ -73,53 +147,15 @@ spec:
         && apt update \
         && apt install gh -y
 
-        # login and setup git
         gh auth login --with-token < $(workspaces.github.path)/token
         gh auth setup-git
 
-        # commit and push the changes.
         head_branch="fix/$(params.branch)/go-module-appdash"
-        git checkout -b "$head_branch"
-        commit_msg="deps: replace 'sourcegraph.com/sourcegraph/appdash*' in go.mod"
-        git commit -am "$commit_msg"
-        git push origin "$head_branch"
-
-
-        # Update ladp crt/key by cherry-pick specific commit from base release branch
-        # Check if the branch is a hotfix branch for specific release series
-        if [[ "$(params.branch)" == "release-7.5-"* || \
-              "$(params.branch)" == "release-8.1-"* || \
-              "$(params.branch)" == "release-8.5-"* ]]; then
-          echo "Branch $(params.branch) is a hotfix branch which may need to update the ldap crt/key."
-          
-          base_release_branch=""
-          if [[ "$(params.branch)" == "release-7.5-"* ]]; then
-            base_release_branch="release-7.5"
-          elif [[ "$(params.branch)" == "release-8.1-"* ]]; then
-            base_release_branch="release-8.1"
-          elif [[ "$(params.branch)" == "release-8.5-"* ]]; then
-            base_release_branch="release-8.5"
-          fi
-
-          if [[ -n "$base_release_branch" ]]; then
-            echo "Fetching base release branch: $base_release_branch..."
-            git fetch origin $base_release_branch
-            echo "Successfully fetched $base_release_branch."
-          else
-            echo "Could not determine base release branch for $(params.branch)"
-          fi
-          
-          commit_to_cherry_pick=$(git log origin/$base_release_branch --grep="re-generate crt/key for ldap test" --format=%H -n 1)
-          if [[ -n "$commit_to_cherry_pick" ]]; then
-            echo "Cherry-picking commit $commit_to_cherry_pick from $base_release_branch"
-            git cherry-pick $commit_to_cherry_pick
-            git push origin "$head_branch"
-          else
-            echo "No relevant commit found in $base_release_branch to cherry-pick for ldap crt/key update."
-          fi
-        else
-          echo "Branch $(params.branch) is not one of the specified hotfix release branches (release-7.5-*, release-8.1-*, release-8.5-*). Skipping fix ldap crt/key."
+        if [ "$local_branch_is_ahead" = true ]; then
+          head_branch="fix/$(params.branch)/gomod-appdash-and-ldap-crt-key-update"
         fi
+        git checkout -b "$head_branch"
+        git push origin "$head_branch"
 
         # create pull request
         cat <<EOF > pr_body.txt

--- a/apps/prod/tekton/configs/tasks/hotfix/create-pr-to-update-gomod-fix-ladp.yaml
+++ b/apps/prod/tekton/configs/tasks/hotfix/create-pr-to-update-gomod-fix-ladp.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: create-pr-to-fix-gomod
+  name: create-pr-to-update-gomod-fix-ladp
   labels:
     app.kubernetes.io/version: "0.1"
   annotations:
@@ -10,6 +10,7 @@ metadata:
 spec:
   description: >-
     Create pull request to fix `go.mod` file to github repository branch.
+    Also, update ldap crt/key if the branch is a hotfix branch for specific release series(release-7.5-*, release-8.1-*, release-8.5-*).
   params:
     - name: git-url
       description: repository clone url
@@ -35,6 +36,7 @@ spec:
       script: |
         git config --global --add safe.directory `pwd`
 
+        # replace appdash and update go.mod
         go mod edit -replace sourcegraph.com/sourcegraph/appdash=github.com/sourcegraph/appdash@v0.0.0-20190731080439-ebfcffb1b5c0
         go mod edit -replace sourcegraph.com/sourcegraph/appdash-data=github.com/sourcegraph/appdash-data@v0.0.0-20151005221446-73f23eafcf67
         go mod tidy
@@ -47,6 +49,7 @@ spec:
           echo 'build --remote_cache=http://ats.apps.svc/brc/tidb --remote_timeout="30s"' > ~/.bazelrc
           make bazel_prepare || true
         fi
+        
     - name: create-pr
       image: bitnami/git:2.43.0
       workingDir: /workspace/src
@@ -80,6 +83,43 @@ spec:
         commit_msg="deps: replace 'sourcegraph.com/sourcegraph/appdash*' in go.mod"
         git commit -am "$commit_msg"
         git push origin "$head_branch"
+
+
+        # Update ladp crt/key by cherry-pick specific commit from base release branch
+        # Check if the branch is a hotfix branch for specific release series
+        if [[ "$(params.branch)" == "release-7.5-"* || \
+              "$(params.branch)" == "release-8.1-"* || \
+              "$(params.branch)" == "release-8.5-"* ]]; then
+          echo "Branch $(params.branch) is a hotfix branch which may need to update the ldap crt/key."
+          
+          base_release_branch=""
+          if [[ "$(params.branch)" == "release-7.5-"* ]]; then
+            base_release_branch="release-7.5"
+          elif [[ "$(params.branch)" == "release-8.1-"* ]]; then
+            base_release_branch="release-8.1"
+          elif [[ "$(params.branch)" == "release-8.5-"* ]]; then
+            base_release_branch="release-8.5"
+          fi
+
+          if [[ -n "$base_release_branch" ]]; then
+            echo "Fetching base release branch: $base_release_branch..."
+            git fetch origin $base_release_branch
+            echo "Successfully fetched $base_release_branch."
+          else
+            echo "Could not determine base release branch for $(params.branch)"
+          fi
+          
+          commit_to_cherry_pick=$(git log origin/$base_release_branch --grep="re-generate crt/key for ldap test" --format=%H -n 1)
+          if [[ -n "$commit_to_cherry_pick" ]]; then
+            echo "Cherry-picking commit $commit_to_cherry_pick from $base_release_branch"
+            git cherry-pick $commit_to_cherry_pick
+            git push origin "$head_branch"
+          else
+            echo "No relevant commit found in $base_release_branch to cherry-pick for ldap crt/key update."
+          fi
+        else
+          echo "Branch $(params.branch) is not one of the specified hotfix release branches (release-7.5-*, release-8.1-*, release-8.5-*). Skipping fix ldap crt/key."
+        fi
 
         # create pull request
         cat <<EOF > pr_body.txt

--- a/apps/prod/tekton/configs/tasks/hotfix/create-pr-to-update-gomod-fix-ladp.yaml
+++ b/apps/prod/tekton/configs/tasks/hotfix/create-pr-to-update-gomod-fix-ladp.yaml
@@ -38,27 +38,27 @@ spec:
         # Check if the branch is a hotfix branch for specific hotfix release branch
         
         base_release_branch=""
-        needs_ldap_fix=false
+        does_need_ldap_fix=false
 
         case "$(params.branch)" in
           release-7.5-*)
             base_release_branch="release-7.5"
-            needs_ldap_fix=true
+            does_need_ldap_fix=true
             ;;
           release-8.1-*)
             base_release_branch="release-8.1"
-            needs_ldap_fix=true
+            does_need_ldap_fix=true
             ;;
           release-8.5-*)
             base_release_branch="release-8.5"
-            needs_ldap_fix=true
+            does_need_ldap_fix=true
             ;;
           *)
             echo "Branch $(params.branch) is not a designated hotfix release for ldap crt/key update (release-7.5-*, release-8.1-*, release-8.5-*)."
             ;;
         esac
 
-        if [ "$needs_ldap_fix" = "true" ] && [ -n "$base_release_branch" ]; then
+        if [ "$does_need_ldap_fix" = "true" ] && [ -n "$base_release_branch" ]; then
           echo "Branch $(params.branch) is a hotfix branch for $base_release_branch which may need to update the ldap crt/key."
           echo "Fetching base release branch: $base_release_branch..."
           git fetch origin $base_release_branch

--- a/apps/prod/tekton/configs/tasks/kustomization.yaml
+++ b/apps/prod/tekton/configs/tasks/kustomization.yaml
@@ -14,7 +14,7 @@ resources:
   - github-set-status.yaml
   - golang-build.yaml
   - golang-test.yaml
-  - hotfix/create-pr-to-fix-gomod-fix-ladp.yaml
+  - hotfix/create-pr-to-update-gomod-fix-ladp.yaml
   - hotfix/create-pr-to-sync-owners.yaml
   - https://raw.githubusercontent.com/tektoncd/catalog/main/task/kaniko/0.6/kaniko.yaml # kaniko task
   - https://raw.githubusercontent.com/tektoncd/catalog/main/task/ko/0.1/ko.yaml # ko task

--- a/apps/prod/tekton/configs/tasks/kustomization.yaml
+++ b/apps/prod/tekton/configs/tasks/kustomization.yaml
@@ -14,7 +14,7 @@ resources:
   - github-set-status.yaml
   - golang-build.yaml
   - golang-test.yaml
-  - hotfix/create-pr-to-fix-gomod.yaml
+  - hotfix/create-pr-to-fix-gomod-fix-ladp.yaml
   - hotfix/create-pr-to-sync-owners.yaml
   - https://raw.githubusercontent.com/tektoncd/catalog/main/task/kaniko/0.6/kaniko.yaml # kaniko task
   - https://raw.githubusercontent.com/tektoncd/catalog/main/task/ko/0.1/ko.yaml # ko task

--- a/apps/prod/tekton/configs/triggers/templates/kustomization.yaml
+++ b/apps/prod/tekton/configs/triggers/templates/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - _/push-oci-artifact-to-tiup.yaml
   - pingcap/bump-placeholder-version-in-readme.yaml
   - pingcap/sync-owners-for-hotfix-branch.yaml
-  - pingcap/tidb/update-gomod-for-hotfix-branch.yaml
+  - pingcap/tidb/update-gomod-fix-ladp-for-hotfix-branch.yaml
   - tikv/tikv/bump-tikv-cargo-pkg-version.yaml

--- a/apps/prod/tekton/configs/triggers/templates/pingcap/tidb/update-gomod-fix-ladp-for-hotfix-branch.yaml
+++ b/apps/prod/tekton/configs/triggers/templates/pingcap/tidb/update-gomod-fix-ladp-for-hotfix-branch.yaml
@@ -1,7 +1,7 @@
 apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerTemplate
 metadata:
-  name: update-pingcap-tidb-gomod-for-hotfix-branch
+  name: update-pingcap-tidb-gomod-fix-ladp-for-hotfix-branch
 spec:
   params:
     - name: git-url
@@ -15,7 +15,7 @@ spec:
     - apiVersion: tekton.dev/v1beta1
       kind: TaskRun
       metadata:
-        generateName: create-pr-to-fix-gomod-for-hotfix-
+        generateName: create-pr-to-update-gomod-fix-ladp-for-hotfix-
       spec:
         params:
           - name: git-url
@@ -26,7 +26,7 @@ spec:
             value: $(tt.params.golang-image)
         taskRef:
           kind: Task
-          name: create-pr-to-fix-gomod
+          name: create-pr-to-update-gomod-fix-ladp
         podTemplate:
             nodeSelector:
               kubernetes.io/arch: "amd64"


### PR DESCRIPTION
- Introduced a new Tekton task `create-pr-to-update-gomod-fix-ladp` to automate  handling LDAP certificate updates for specific hotfix branches(hotfix for v7.5 & v8.1 & v8.5).
- Added a corresponding TriggerTemplate `update-pingcap-tidb-gomod-fix-ladp-for-hotfix-branch` to facilitate the execution of the task with specified parameters.