### PR TITLE
fix(apps/prod/tekton/configs/triggers): merge platform-specific build templates into single template

### DIFF
--- a/apps/prod/tekton/configs/triggers/templates/_/build-component-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/templates/_/build-component-single-platform.yaml
@@ -1,7 +1,7 @@
 apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerTemplate
 metadata:
-  name: build-component-single-platform-linux
+  name: build-component-single-platform
 spec:
   params:
     - name: git-url
@@ -75,6 +75,8 @@ spec:
             value: $(tt.params.registry)
           - name: force-builder-image
             value: $(tt.params.force-builder-image)
+          - name: boskos-server-url # for darwin platforms
+            value: http://boskos.apps.svc
         taskRunSpecs:
           - pipelineTaskName: build-binaries
             taskPodTemplate:
@@ -108,9 +110,12 @@ spec:
           - name: git-basic-auth # fetch with git-cdn.
             secret:
               secretName: git-credentials-basic
-          - name: cargo-home
+          - name: cargo-home # for linux platforms
             persistentVolumeClaim:
               claimName: cargo-home
-          - name: cypress-cache
+          - name: cypress-cache # for linux platforms
             persistentVolumeClaim:
               claimName: cypress-cache
+          - name: mac-ssh-credentials # for darwin platforms
+            secret:
+              secretName: mac-ssh-credentials

--- a/apps/prod/tekton/configs/triggers/templates/kustomization.yaml
+++ b/apps/prod/tekton/configs/triggers/templates/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
   - _/build-component-all-platforms.yaml
   - _/build-component-single-platform-darwin.yaml
-  - _/build-component-single-platform-linux.yaml
+  - _/build-component-single-platform.yaml
   - _/build-component.yaml
   - _/ci-helper-for-pr.yaml
   - _/image-push.yaml

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push-single-platform.yaml
@@ -110,4 +110,4 @@ spec:
     - { name: os, value: $(extensions.custom-params.os) }
     - { name: arch, value: $(extensions.custom-params.arch) }
   template:
-    ref: build-component-single-platform-$(extensions.custom-params.os)
+    ref: build-component-single-platform

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr-single-platform.yaml
@@ -110,4 +110,4 @@ spec:
     - { name: os, value: $(extensions.custom-params.os) }
     - { name: arch, value: $(extensions.custom-params.arch) }
   template:
-    ref: build-component-single-platform-$(extensions.custom-params.os)
+    ref: build-component-single-platform

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create-single-platform.yaml
@@ -112,4 +112,4 @@ spec:
     - { name: os, value: $(extensions.custom-params.os) }
     - { name: arch, value: $(extensions.custom-params.arch) }
   template:
-    ref: build-component-single-platform-$(extensions.custom-params.os)
+    ref: build-component-single-platform


### PR DESCRIPTION
This pull request consolidates the Tekton TriggerTemplate configurations for single-platform builds by renaming and generalizing the `build-component-single-platform-linux.yaml` file to `build-component-single-platform.yaml`. It also introduces platform-specific parameters and updates references across related configurations.

### Consolidation of TriggerTemplate configurations:
* Renamed `build-component-single-platform-linux.yaml` to `build-component-single-platform.yaml` and updated the `metadata.name` field accordingly.
* Added platform-specific parameters, such as `boskos-server-url` for Darwin platforms and `mac-ssh-credentials` for Darwin-specific secrets, while annotating existing parameters like `cargo-home` and `cypress-cache` for Linux platforms. [[1]](diffhunk://#diff-788df9ab2dc5c1e297afef925368de9ee26f0e579af86e4cada9fb3ec09e6a67R78-R79) [[2]](diffhunk://#diff-788df9ab2dc5c1e297afef925368de9ee26f0e579af86e4cada9fb3ec09e6a67L111-R121)

### Updates to related configurations:
* Updated `kustomization.yaml` to replace the reference to `build-component-single-platform-linux.yaml` with `build-component-single-platform.yaml`.
* Modified references in trigger configurations (`fake-github-branch-push-single-platform.yaml`, `fake-github-pr-single-platform.yaml`, and `fake-github-tag-create-single-platform.yaml`) to use the generalized `build-component-single-platform` template instead of OS-specific templates. [[1]](diffhunk://#diff-9f6aafe661ca69015d119375f5de54fd57e71c13bff121900c949b7da4e4ea44L113-R113) [[2]](diffhunk://#diff-f47ef76783868fa5903469faff959797e265e6527a0b39896da5063fc6025f74L113-R113) [[3]](diffhunk://#diff-c5ec0b4a95dd4fb6387063bec2c95619e03db865759f992808360bc4d539cf6dL115-R115)