### PR TITLE
fix(apps/prod/chatops-lark): bump image tag to v2025.4.8-26-gc793d80

### DIFF
--- a/apps/prod/chatops-lark/release.yaml
+++ b/apps/prod/chatops-lark/release.yaml
@@ -38,7 +38,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/chatops-lark
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/chatops-lark versioning=semver
-      tag: v2025.4.8-24-g290803f
+      tag: v2025.4.8-26-gc793d80
     server:
       secretName: chatops-lark
       appIdSecretKey: app-id


### PR DESCRIPTION
apply the fix in PingCAP-QE/ee-apps@c793d80