### PR TITLE
chore(apps/gcp/prow): bump tide image tag to v20250516-ceae038a4

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -70,8 +70,8 @@ spec:
         size: 10Gi
     tide:
       image:
-        repository: ticommunityinfra/tide
-        tag: v20230706-5546ede
+        repository: ghcr.io/ti-community-infra/prow/tide
+        tag: v20250516-ceae038a4
       additionalArgs:
         - --sync-hourly-tokens=1200 # default is 800
         - --status-hourly-tokens=600 # default is 400


### PR DESCRIPTION
Ref ti-community-infra/prow@ceae038a4