### PR TITLE
fix(apps/gcp/prow): bump image for hook to v20250519-ceae038a4

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -87,7 +87,7 @@ spec:
         enabled: false
       image:
         repository: ghcr.io/ti-community-infra/prow/hook
-        tag: v20250515-3d7188248
+        tag: v20250519-ceae038a4
       kubeconfigSecret: prow-kubeconfig
       additionalArgs:
         - --kubeconfig=/etc/kubeconfig/config


### PR DESCRIPTION
Ref ti-community/prow@ceae038a4