### PR TITLE
fix(apps/gcp/prow): bump hook image tag to v20250520-2df574a5

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -87,7 +87,7 @@ spec:
         enabled: false
       image:
         repository: ghcr.io/ti-community-infra/prow/hook
-        tag: v20250519-ceae038a4
+        tag: v20250520-2df574a5a
       kubeconfigSecret: prow-kubeconfig
       additionalArgs:
         - --kubeconfig=/etc/kubeconfig/config


### PR DESCRIPTION
Relate to PR https://github.com/ti-community-infra/prow/pull/9.

Support approve gitHub action run with comment `/test all`. 