### PR TITLE
fix(apps/prod/tekton/configs/triggers): add filter to exclude old branch on renaming

### DIFF
--- a/apps/prod/tekton/configs/triggers/event-listeners/event-listener-public.yaml
+++ b/apps/prod/tekton/configs/triggers/event-listeners/event-listener-public.yaml
@@ -35,6 +35,13 @@ spec:
           params:
             - name: eventTypes
               value: ["push"]
+        - name: exclude the old branch when renaming
+          # Filter out the old branch when renaming to prevent unnecessary processing
+          ref:
+            name: cel
+          params:
+            - name: filter
+              value: body.after != '0000000000000000000000000000000000000000'
         # "refs/heads/main" => "main"
         - name: shortten the git REF
           ref:


### PR DESCRIPTION
This pull request updates the `event-listener-public.yaml` configuration to refine the event filtering logic for Tekton triggers. Specifically, it introduces a new filter to exclude events related to old branches during branch renaming.

### Event filtering improvements:

* [`apps/prod/tekton/configs/triggers/event-listeners/event-listener-public.yaml`](diffhunk://#diff-1be050bd43bb23918c4becd1cf77c1644c4a7273a3a7eeb2f452233c13425897R38-R43): Added a new condition under the `params` section to filter out events where `body.after` equals `0000000000000000000000000000000000000000`, effectively excluding old branch references during branch renaming.

Close #1480 