### PR TITLE
fix(apps/prod/tekton/configs/triggers/triggers/PingCAP-QE/artifacts): fix git archive download to save and unzip branch zip file

### DIFF
--- a/apps/prod/tekton/configs/triggers/triggers/PingCAP-QE/artifacts/git-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/PingCAP-QE/artifacts/git-push.yaml
@@ -46,7 +46,7 @@ spec:
                   branch="$(tt.params.git-ref)"
                   echo "Downloading from: https://github.com/${org}/${repo}/archive/${branch}.zip"
 
-                  wget "https://github.com/${org}/${repo}/archive/${branch}.zip" -O - | unzip -
+                  wget "https://github.com/${org}/${repo}/archive/${branch}.zip" -O ${branch}.zip && unzip "${branch}.zip"
 
                   ks3util sync "${repo}-${branch}" ks3://ee-fileserver/download/raw.githubusercontent.com/${org}/${repo}/${branch} --delete -f
               - name: ARGS


### PR DESCRIPTION
This pull request includes a minor improvement to the `git-push.yaml` file in the `PingCAP-QE` Tekton triggers configuration. The change updates the `wget` command to save the downloaded file with the branch name as the filename before unzipping it, ensuring better file management.

* [`apps/prod/tekton/configs/triggers/triggers/PingCAP-QE/artifacts/git-push.yaml`](diffhunk://#diff-0be829dd6735a25ee2dcd3ba6229d657d5c901e58e1debad1f228242e3563300L49-R49): Changed the `wget` command to save the downloaded file as `${branch}.zip` and then unzipped the file using the saved filename.