### PR TITLE
chore(apps/gcp/prow/release): update Prow hook image tag to v2025052-47c62ac71 to enhance retest github action

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -87,7 +87,7 @@ spec:
         enabled: false
       image:
         repository: ghcr.io/ti-community-infra/prow/hook
-        tag: v20250520-2df574a5a
+        tag: v20250526-47c62ac71
       kubeconfigSecret: prow-kubeconfig
       additionalArgs:
         - --kubeconfig=/etc/kubeconfig/config


### PR DESCRIPTION
Relate to https://github.com/ti-community-infra/prow/pull/10

If the current branch does not have a configured presubmit task, /retest and /test all should also trigger failed GitHub actions and pending approval GitHub actions.