### PR TITLE
chore(apps/prod/tekton/configs/triggers): allow next-gen tags in Harbor image push trigger

### DIFF
--- a/apps/prod/tekton/configs/triggers/triggers/_/harbor/image-push-on-harbor.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/harbor/image-push-on-harbor.yaml
@@ -46,9 +46,10 @@ spec:
             body.event_data.repository.repo_full_name.matches('^(pingcap|tikv)/')
             && !
             body.event_data.repository.repo_full_name.matches('/package(s)?')
-            ) &&
-            (
+            ) && (
             body.event_data.resources[0].tag.matches('^(master|main|release-[0-9]+[.][0-9]+(-beta[.][0-9]+)?|v[0-9]+[.][0-9]+[.][0-9]+(-(beta|rc)[.][0-9]+)?([-.]pre)?)(-[0-9a-f]+)?(-(enterprise|failpoint))?$')
+            ||
+            body.event_data.resources[0].tag.matches('^(master|feature_next-gen.*)(-.*)?-next-gen$')
             ||
             (
             body.event_data.repository.repo_full_name.matches('^pingcap/tidb-operator/')


### PR DESCRIPTION
Ref: https://github.com/PingCAP-QE/artifacts/pull/630