### PR TITLE
fix(apps/prod/tibuild): bump image tag to `v2025.6.8-1-g78867b3`

### DIFF
--- a/apps/prod/tibuild/deployment.yaml
+++ b/apps/prod/tibuild/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app: tibuild
     spec:
       containers:
-        - image: ghcr.io/pingcap-qe/ee-apps/tibuild:v2025.4.8-27-gd38ba90
+        - image: ghcr.io/pingcap-qe/ee-apps/tibuild:v2025.6.8-1-g78867b3
           imagePullPolicy: Always
           name: tibuild
           ports:


### PR DESCRIPTION
This pull request updates the container image version in the `tibuild` deployment configuration to ensure the application uses the latest build.

* [`apps/prod/tibuild/deployment.yaml`](diffhunk://#diff-7a638a35c3081658c6becc5d69691497c6d2b9ac58c12e048678f1c5d59dd094L23-R23): Updated the container image from `tibuild:v2025.4.8-27-gd38ba90` to `tibuild:v2025.6.8-1-g78867b3` in the deployment specification.

Ref pingcap-qe/ee-apps@78867b3