### PR TITLE
feat(triggers/fake-github): add overlays for pingcap/tidb-operator to all triggers (branch-push, tag-create, pr, single-platform)

### DIFF
--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push-single-platform.yaml
@@ -11,7 +11,7 @@ spec:
       params:
         - name: filter
           value: >-
-            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
+            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'pingcap/tidb-operator', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
             &&
             header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64']
         - name: overlays
@@ -25,6 +25,7 @@ spec:
                 'pingcap/tiflow': '40m',
                 'pingcap/tidb-dashboard': '40m',
                 'pingcap/tiproxy': '30m',
+                'pingcap/tidb-operator': '30m',
                 'tikv/pd': '40m',
                 'tikv/tikv': '2h30m',
                 'tidbcloud/tiflash-cse': '2h',
@@ -39,6 +40,7 @@ spec:
                 'pingcap/tiflow': '50Gi',
                 'pingcap/tidb-dashboard': '8Gi',
                 'pingcap/tiproxy': '10Gi',
+                'pingcap/tidb-operator': '10Gi',
                 'tikv/pd': '50Gi',
                 'tikv/tikv': '100Gi',
                 'tidbcloud/tiflash-cse': '100Gi',
@@ -53,6 +55,7 @@ spec:
                 'pingcap/tiflow': '8',
                 'pingcap/tidb-dashboard': '2',
                 'pingcap/tiproxy': '4',
+                'pingcap/tidb-operator': '2',
                 'tikv/pd': '8',
                 'tikv/tikv': '16',
                 'tidbcloud/tiflash-cse': '16',
@@ -67,6 +70,7 @@ spec:
                 'pingcap/tiflow': '32Gi',
                 'pingcap/tidb-dashboard': '4Gi',
                 'pingcap/tiproxy': '16Gi',
+                'pingcap/tidb-operator': '8Gi',
                 'tikv/pd': '32Gi',
                 'tikv/tikv': '64Gi',
                 'tidbcloud/tiflash-cse': '64Gi',

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml
@@ -11,7 +11,7 @@ spec:
       params:
         - name: filter
           value: >-
-            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
+            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'pingcap/tidb-operator', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
             &&
             ! (header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64'])
         - name: overlays
@@ -25,6 +25,7 @@ spec:
                 'pingcap/tiflow': '40m',
                 'pingcap/tidb-dashboard': '40m',
                 'pingcap/tiproxy': '30m',
+                'pingcap/tidb-operator': '30m',
                 'tikv/pd': '40m',
                 'tikv/tikv': '2h30m',
                 'tidbcloud/tiflash-cse': '2h',
@@ -39,6 +40,7 @@ spec:
                 'pingcap/tiflow': '50Gi',
                 'pingcap/tidb-dashboard': '8Gi',
                 'pingcap/tiproxy': '10Gi',
+                'pingcap/tidb-operator': '10Gi',
                 'tikv/pd': '50Gi',
                 'tikv/tikv': '100Gi',
                 'tidbcloud/tiflash-cse': '100Gi',
@@ -53,6 +55,7 @@ spec:
                 'pingcap/tiflow': '8',
                 'pingcap/tidb-dashboard': '2',
                 'pingcap/tiproxy': '4',
+                'pingcap/tidb-operator': '2',
                 'tikv/pd': '8',
                 'tikv/tikv': '16',
                 'tidbcloud/tiflash-cse': '16',
@@ -67,6 +70,7 @@ spec:
                 'pingcap/tiflow': '32Gi',
                 'pingcap/tidb-dashboard': '4Gi',
                 'pingcap/tiproxy': '16Gi',
+                'pingcap/tidb-operator': '8Gi',
                 'tikv/pd': '32Gi',
                 'tikv/tikv': '64Gi',
                 'tidbcloud/tiflash-cse': '64Gi',

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr-single-platform.yaml
@@ -11,7 +11,7 @@ spec:
       params:
         - name: filter
           value: >-
-            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
+            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'pingcap/tidb-operator', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
             &&
             header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64']
         - name: overlays
@@ -25,6 +25,7 @@ spec:
                 'pingcap/tiflow': '40m',
                 'pingcap/tidb-dashboard': '40m',
                 'pingcap/tiproxy': '30m',
+                'pingcap/tidb-operator': '30m',
                 'tikv/pd': '40m',
                 'tikv/tikv': '2h30m',
                 'tidbcloud/tiflash-cse': '2h',
@@ -39,6 +40,7 @@ spec:
                 'pingcap/tiflow': '50Gi',
                 'pingcap/tidb-dashboard': '8Gi',
                 'pingcap/tiproxy': '10Gi',
+                'pingcap/tidb-operator': '10Gi',
                 'tikv/pd': '50Gi',
                 'tikv/tikv': '100Gi',
                 'tidbcloud/tiflash-cse': '100Gi',
@@ -53,6 +55,7 @@ spec:
                 'pingcap/tiflow': '8',
                 'pingcap/tidb-dashboard': '2',
                 'pingcap/tiproxy': '4',
+                'pingcap/tidb-operator': '2',
                 'tikv/pd': '8',
                 'tikv/tikv': '16',
                 'tidbcloud/tiflash-cse': '16',
@@ -67,6 +70,7 @@ spec:
                 'pingcap/tiflow': '32Gi',
                 'pingcap/tidb-dashboard': '4Gi',
                 'pingcap/tiproxy': '16Gi',
+                'pingcap/tidb-operator': '8Gi',
                 'tikv/pd': '32Gi',
                 'tikv/tikv': '64Gi',
                 'tidbcloud/tiflash-cse': '64Gi',

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr.yaml
@@ -11,7 +11,7 @@ spec:
       params:
         - name: filter
           value: >-
-            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
+            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'pingcap/tidb-operator', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
             &&
             ! (header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64'])
         - name: overlays
@@ -25,6 +25,7 @@ spec:
                 'pingcap/tiflow': '40m',
                 'pingcap/tidb-dashboard': '40m',
                 'pingcap/tiproxy': '30m',
+                'pingcap/tidb-operator': '30m',
                 'tikv/pd': '40m',
                 'tikv/tikv': '2h30m',
                 'tidbcloud/tiflash-cse': '2h',
@@ -39,6 +40,7 @@ spec:
                 'pingcap/tiflow': '50Gi',
                 'pingcap/tidb-dashboard': '8Gi',
                 'pingcap/tiproxy': '10Gi',
+                'pingcap/tidb-operator': '10Gi',
                 'tikv/pd': '50Gi',
                 'tikv/tikv': '100Gi',
                 'tidbcloud/tiflash-cse': '100Gi',
@@ -53,6 +55,7 @@ spec:
                 'pingcap/tiflow': '8',
                 'pingcap/tidb-dashboard': '2',
                 'pingcap/tiproxy': '4',
+                'pingcap/tidb-operator': '2',
                 'tikv/pd': '8',
                 'tikv/tikv': '16',
                 'tidbcloud/tiflash-cse': '16',
@@ -67,6 +70,7 @@ spec:
                 'pingcap/tiflow': '32Gi',
                 'pingcap/tidb-dashboard': '4Gi',
                 'pingcap/tiproxy': '16Gi',
+                'pingcap/tidb-operator': '8Gi',
                 'tikv/pd': '32Gi',
                 'tikv/tikv': '64Gi',
                 'tidbcloud/tiflash-cse': '64Gi',

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create-single-platform.yaml
@@ -11,7 +11,7 @@ spec:
       params:
         - name: filter
           value: >-
-            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
+            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'pingcap/tidb-operator', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
             &&
             body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+(-(alpha|beta|rc)([.][0-9]+)?)?$')
             &&
@@ -27,6 +27,7 @@ spec:
                 'pingcap/tiflow': '40m',
                 'pingcap/tidb-dashboard': '40m',
                 'pingcap/tiproxy': '30m',
+                'pingcap/tidb-operator': '30m',
                 'tikv/pd': '40m',
                 'tikv/tikv': '2h30m',
                 'tidbcloud/tiflash-cse': '2h',
@@ -41,6 +42,7 @@ spec:
                 'pingcap/tiflow': '50Gi',
                 'pingcap/tidb-dashboard': '8Gi',
                 'pingcap/tiproxy': '10Gi',
+                'pingcap/tidb-operator': '10Gi',
                 'tikv/pd': '50Gi',
                 'tikv/tikv': '100Gi',
                 'tidbcloud/tiflash-cse': '100Gi',
@@ -55,6 +57,7 @@ spec:
                 'pingcap/tiflow': '8',
                 'pingcap/tidb-dashboard': '2',
                 'pingcap/tiproxy': '4',
+                'pingcap/tidb-operator': '2',
                 'tikv/pd': '8',
                 'tikv/tikv': '16',
                 'tidbcloud/tiflash-cse': '16',
@@ -69,6 +72,7 @@ spec:
                 'pingcap/tiflow': '32Gi',
                 'pingcap/tidb-dashboard': '4Gi',
                 'pingcap/tiproxy': '16Gi',
+                'pingcap/tidb-operator': '8Gi',
                 'tikv/pd': '32Gi',
                 'tikv/tikv': '64Gi',
                 'tidbcloud/tiflash-cse': '64Gi',

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create.yaml
@@ -11,7 +11,7 @@ spec:
       params:
         - name: filter
           value: >-
-            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
+            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'pingcap/tidb-operator', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
             &&
             body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+(-(alpha|beta|rc)([.][0-9]+)?)?$')
             &&
@@ -27,6 +27,7 @@ spec:
                 'pingcap/tiflow': '40m',
                 'pingcap/tidb-dashboard': '40m',
                 'pingcap/tiproxy': '30m',
+                'pingcap/tidb-operator': '30m',
                 'tikv/pd': '40m',
                 'tikv/tikv': '2h30m',
                 'tidbcloud/tiflash-cse': '2h',
@@ -41,6 +42,7 @@ spec:
                 'pingcap/tiflow': '50Gi',
                 'pingcap/tidb-dashboard': '8Gi',
                 'pingcap/tiproxy': '10Gi',
+                'pingcap/tidb-operator': '10Gi',
                 'tikv/pd': '50Gi',
                 'tikv/tikv': '100Gi',
                 'tidbcloud/tiflash-cse': '100Gi',
@@ -55,6 +57,7 @@ spec:
                 'pingcap/tiflow': '8',
                 'pingcap/tidb-dashboard': '2',
                 'pingcap/tiproxy': '4',
+                'pingcap/tidb-operator': '2',
                 'tikv/pd': '8',
                 'tikv/tikv': '16',
                 'tidbcloud/tiflash-cse': '16',
@@ -69,6 +72,7 @@ spec:
                 'pingcap/tiflow': '32Gi',
                 'pingcap/tidb-dashboard': '4Gi',
                 'pingcap/tiproxy': '16Gi',
+                'pingcap/tidb-operator': '8Gi',
                 'tikv/pd': '32Gi',
                 'tikv/tikv': '64Gi',
                 'tidbcloud/tiflash-cse': '64Gi',


### PR DESCRIPTION
This pull request updates several Tekton trigger configurations to include support for the `pingcap/tidb-operator` repository. Changes have been made across multiple files to add `pingcap/tidb-operator` to the repository filters and specify its resource requirements and timeout values.

### Repository Inclusion Updates:
* Added `pingcap/tidb-operator` to the list of repositories in the `filter` parameter across multiple trigger configurations, ensuring it is processed by the relevant pipelines. (`fake-github-branch-push-single-platform.yaml`: [[1]](diffhunk://#diff-9f6aafe661ca69015d119375f5de54fd57e71c13bff121900c949b7da4e4ea44L14-R14) `fake-github-branch-push.yaml`: [[2]](diffhunk://#diff-568be39468441f09f11d91d4c71d77c96952fb478d3695735af6b02f24cb8969L14-R14) `fake-github-pr-single-platform.yaml`: [[3]](diffhunk://#diff-f47ef76783868fa5903469faff959797e265e6527a0b39896da5063fc6025f74L14-R14) `fake-github-pr.yaml`: [[4]](diffhunk://#diff-16116bc799a164aec2da92871c9b9f6e55fc88587d954afb5d13c261f014fefcL14-R14) `fake-github-tag-create-single-platform.yaml`: [[5]](diffhunk://#diff-c5ec0b4a95dd4fb6387063bec2c95619e03db865759f992808360bc4d539cf6dL14-R14) `fake-github-tag-create.yaml`: [[6]](diffhunk://#diff-91cd5bc58ced2d97dfd4052e5009edbe7fffbe44f7427f2bb0a0d084636dc615L14-R14)

### Timeout Configuration:
* Set the timeout for `pingcap/tidb-operator` to `30m` in all relevant trigger configurations. (`fake-github-branch-push-single-platform.yaml`: [[1]](diffhunk://#diff-9f6aafe661ca69015d119375f5de54fd57e71c13bff121900c949b7da4e4ea44R28) `fake-github-branch-push.yaml`: [[2]](diffhunk://#diff-568be39468441f09f11d91d4c71d77c96952fb478d3695735af6b02f24cb8969R28) `fake-github-pr-single-platform.yaml`: [[3]](diffhunk://#diff-f47ef76783868fa5903469faff959797e265e6527a0b39896da5063fc6025f74R28) `fake-github-pr.yaml`: [[4]](diffhunk://#diff-16116bc799a164aec2da92871c9b9f6e55fc88587d954afb5d13c261f014fefcR28) `fake-github-tag-create-single-platform.yaml`: [[5]](diffhunk://#diff-c5ec0b4a95dd4fb6387063bec2c95619e03db865759f992808360bc4d539cf6dR30) `fake-github-tag-create.yaml`: [[6]](diffhunk://#diff-91cd5bc58ced2d97dfd4052e5009edbe7fffbe44f7427f2bb0a0d084636dc615R30)

### Resource Requirements:
* Allocated `10Gi` disk space for `pingcap/tidb-operator` in all configurations. (`fake-github-branch-push-single-platform.yaml`: [[1]](diffhunk://#diff-9f6aafe661ca69015d119375f5de54fd57e71c13bff121900c949b7da4e4ea44R43) `fake-github-branch-push.yaml`: [[2]](diffhunk://#diff-568be39468441f09f11d91d4c71d77c96952fb478d3695735af6b02f24cb8969R43) `fake-github-pr-single-platform.yaml`: [[3]](diffhunk://#diff-f47ef76783868fa5903469faff959797e265e6527a0b39896da5063fc6025f74R43) `fake-github-pr.yaml`: [[4]](diffhunk://#diff-16116bc799a164aec2da92871c9b9f6e55fc88587d954afb5d13c261f014fefcR43) `fake-github-tag-create-single-platform.yaml`: [[5]](diffhunk://#diff-c5ec0b4a95dd4fb6387063bec2c95619e03db865759f992808360bc4d539cf6dR45) `fake-github-tag-create.yaml`: [[6]](diffhunk://#diff-91cd5bc58ced2d97dfd4052e5009edbe7fffbe44f7427f2bb0a0d084636dc615R45)
* Allocated `2` CPUs for `pingcap/tidb-operator` in all configurations. (`fake-github-branch-push-single-platform.yaml`: [[1]](diffhunk://#diff-9f6aafe661ca69015d119375f5de54fd57e71c13bff121900c949b7da4e4ea44R58) `fake-github-branch-push.yaml`: [[2]](diffhunk://#diff-568be39468441f09f11d91d4c71d77c96952fb478d3695735af6b02f24cb8969R58) `fake-github-pr-single-platform.yaml`: [[3]](diffhunk://#diff-f47ef76783868fa5903469faff959797e265e6527a0b39896da5063fc6025f74R58) `fake-github-pr.yaml`: [[4]](diffhunk://#diff-16116bc799a164aec2da92871c9b9f6e55fc88587d954afb5d13c261f014fefcR58) `fake-github-tag-create-single-platform.yaml`: [[5]](diffhunk://#diff-c5ec0b4a95dd4fb6387063bec2c95619e03db865759f992808360bc4d539cf6dR60) `fake-github-tag-create.yaml`: [[6]](diffhunk://#diff-91cd5bc58ced2d97dfd4052e5009edbe7fffbe44f7427f2bb0a0d084636dc615R60)
* Allocated `8Gi` memory for `pingcap/tidb-operator` in all configurations. (`fake-github-branch-push-single-platform.yaml`: [[1]](diffhunk://#diff-9f6aafe661ca69015d119375f5de54fd57e71c13bff121900c949b7da4e4ea44R73) `fake-github-branch-push.yaml`: [[2]](diffhunk://#diff-568be39468441f09f11d91d4c71d77c96952fb478d3695735af6b02f24cb8969R73) `fake-github-pr-single-platform.yaml`: [[3]](diffhunk://#diff-f47ef76783868fa5903469faff959797e265e6527a0b39896da5063fc6025f74R73) `fake-github-pr.yaml`: [[4]](diffhunk://#diff-16116bc799a164aec2da92871c9b9f6e55fc88587d954afb5d13c261f014fefcR73) `fake-github-tag-create-single-platform.yaml`: [[5]](diffhunk://#diff-c5ec0b4a95dd4fb6387063bec2c95619e03db865759f992808360bc4d539cf6dR75) `fake-github-tag-create.yaml`: [[6]](diffhunk://#diff-91cd5bc58ced2d97dfd4052e5009edbe7fffbe44f7427f2bb0a0d084636dc615R75)