### PR TITLE
feat(triggers/fake-github): add overlays for ng-monitoring, tidb-binlog, and tidb-tools to all triggers

### DIFF
--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push-single-platform.yaml
@@ -28,7 +28,12 @@ spec:
               'tikv/tikv'
             ]
             &&
-            header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64']
+            header.canonical('ce-paramPlatform') in [
+              'linux/amd64',
+              'linux/arm64',
+              'darwin/amd64',
+              'darwin/arm64'
+            ]
         - name: overlays
           value:
             - key: timeout

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push-single-platform.yaml
@@ -11,7 +11,22 @@ spec:
       params:
         - name: filter
           value: >-
-            body.repository.full_name in ['pingcap/ng-monitoring', 'pingcap/tidb', 'pingcap/tidb-binlog', 'pingcap/tidb-dashboard', 'pingcap/tidb-operator', 'pingcap/tidb-tools', 'pingcap/ticdc', 'pingcap/tiflash', 'pingcap/tiflow', 'pingcap/tiproxy', 'tidbcloud/cloud-storage-engine', 'tidbcloud/tiflash-cse', 'tikv/pd', 'tikv/tikv']
+            body.repository.full_name in [
+              'pingcap/ng-monitoring',
+              'pingcap/tidb',
+              'pingcap/tidb-binlog',
+              'pingcap/tidb-dashboard',
+              'pingcap/tidb-operator',
+              'pingcap/tidb-tools',
+              'pingcap/ticdc',
+              'pingcap/tiflash',
+              'pingcap/tiflow',
+              'pingcap/tiproxy',
+              'tidbcloud/cloud-storage-engine',
+              'tidbcloud/tiflash-cse',
+              'tikv/pd',
+              'tikv/tikv'
+            ]
             &&
             header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64']
         - name: overlays

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push-single-platform.yaml
@@ -11,7 +11,7 @@ spec:
       params:
         - name: filter
           value: >-
-            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'pingcap/tidb-operator', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
+            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'pingcap/tidb-operator', 'pingcap/ng-monitoring', 'pingcap/tidb-binlog', 'pingcap/tidb-tools', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
             &&
             header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64']
         - name: overlays
@@ -26,6 +26,9 @@ spec:
                 'pingcap/tidb-dashboard': '40m',
                 'pingcap/tiproxy': '30m',
                 'pingcap/tidb-operator': '30m',
+                'pingcap/ng-monitoring': '30m',
+                'pingcap/tidb-binlog': '2h',
+                'pingcap/tidb-tools': '1h',
                 'tikv/pd': '40m',
                 'tikv/tikv': '2h30m',
                 'tidbcloud/tiflash-cse': '2h',
@@ -41,6 +44,9 @@ spec:
                 'pingcap/tidb-dashboard': '8Gi',
                 'pingcap/tiproxy': '10Gi',
                 'pingcap/tidb-operator': '10Gi',
+                'pingcap/ng-monitoring': '8Gi',
+                'pingcap/tidb-binlog': '100Gi',
+                'pingcap/tidb-tools': '10Gi',
                 'tikv/pd': '50Gi',
                 'tikv/tikv': '100Gi',
                 'tidbcloud/tiflash-cse': '100Gi',
@@ -56,6 +62,9 @@ spec:
                 'pingcap/tidb-dashboard': '2',
                 'pingcap/tiproxy': '4',
                 'pingcap/tidb-operator': '2',
+                'pingcap/ng-monitoring': '2',
+                'pingcap/tidb-binlog': '8',
+                'pingcap/tidb-tools': '4',
                 'tikv/pd': '8',
                 'tikv/tikv': '16',
                 'tidbcloud/tiflash-cse': '16',
@@ -71,6 +80,9 @@ spec:
                 'pingcap/tidb-dashboard': '4Gi',
                 'pingcap/tiproxy': '16Gi',
                 'pingcap/tidb-operator': '8Gi',
+                'pingcap/ng-monitoring': '4Gi',
+                'pingcap/tidb-binlog': '32Gi',
+                'pingcap/tidb-tools': '16Gi',
                 'tikv/pd': '32Gi',
                 'tikv/tikv': '64Gi',
                 'tidbcloud/tiflash-cse': '64Gi',

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push-single-platform.yaml
@@ -11,7 +11,7 @@ spec:
       params:
         - name: filter
           value: >-
-            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'pingcap/tidb-operator', 'pingcap/ng-monitoring', 'pingcap/tidb-binlog', 'pingcap/tidb-tools', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
+            body.repository.full_name in ['pingcap/ng-monitoring', 'pingcap/tidb', 'pingcap/tidb-binlog', 'pingcap/tidb-dashboard', 'pingcap/tidb-operator', 'pingcap/tidb-tools', 'pingcap/ticdc', 'pingcap/tiflash', 'pingcap/tiflow', 'pingcap/tiproxy', 'tidbcloud/cloud-storage-engine', 'tidbcloud/tiflash-cse', 'tikv/pd', 'tikv/tikv']
             &&
             header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64']
         - name: overlays
@@ -19,74 +19,74 @@ spec:
             - key: timeout
               expression: >-
                 {
-                'pingcap/ticdc': '20m',
+                'pingcap/ng-monitoring': '30m',
                 'pingcap/tidb': '40m',
+                'pingcap/tidb-binlog': '2h',
+                'pingcap/tidb-dashboard': '40m',
+                'pingcap/tidb-operator': '30m',
+                'pingcap/tidb-tools': '1h',
+                'pingcap/ticdc': '20m',
                 'pingcap/tiflash': '2h',
                 'pingcap/tiflow': '40m',
-                'pingcap/tidb-dashboard': '40m',
                 'pingcap/tiproxy': '30m',
-                'pingcap/tidb-operator': '30m',
-                'pingcap/ng-monitoring': '30m',
-                'pingcap/tidb-binlog': '2h',
-                'pingcap/tidb-tools': '1h',
+                'tidbcloud/cloud-storage-engine': '2h30m',
+                'tidbcloud/tiflash-cse': '2h',
                 'tikv/pd': '40m',
                 'tikv/tikv': '2h30m',
-                'tidbcloud/tiflash-cse': '2h',
-                'tidbcloud/cloud-storage-engine': '2h30m',
                 }[body.repository.full_name]
             - key: source-ws-size
               expression: >-
                 {
-                'pingcap/ticdc': '50Gi',
+                'pingcap/ng-monitoring': '8Gi',
                 'pingcap/tidb': '50Gi',
+                'pingcap/tidb-binlog': '100Gi',
+                'pingcap/tidb-dashboard': '8Gi',
+                'pingcap/tidb-operator': '10Gi',
+                'pingcap/tidb-tools': '10Gi',
+                'pingcap/ticdc': '50Gi',
                 'pingcap/tiflash': '100Gi',
                 'pingcap/tiflow': '50Gi',
-                'pingcap/tidb-dashboard': '8Gi',
                 'pingcap/tiproxy': '10Gi',
-                'pingcap/tidb-operator': '10Gi',
-                'pingcap/ng-monitoring': '8Gi',
-                'pingcap/tidb-binlog': '100Gi',
-                'pingcap/tidb-tools': '10Gi',
+                'tidbcloud/cloud-storage-engine': '100Gi',
+                'tidbcloud/tiflash-cse': '100Gi',
                 'tikv/pd': '50Gi',
                 'tikv/tikv': '100Gi',
-                'tidbcloud/tiflash-cse': '100Gi',
-                'tidbcloud/cloud-storage-engine': '100Gi',
                 }[body.repository.full_name]
             - key: builder-resources-cpu
               expression: >-
                 {
-                'pingcap/ticdc': '4',
+                'pingcap/ng-monitoring': '2',
                 'pingcap/tidb': '8',
+                'pingcap/tidb-binlog': '8',
+                'pingcap/tidb-dashboard': '2',
+                'pingcap/tidb-operator': '2',
+                'pingcap/tidb-tools': '4',
+                'pingcap/ticdc': '4',
                 'pingcap/tiflash': '16',
                 'pingcap/tiflow': '8',
-                'pingcap/tidb-dashboard': '2',
                 'pingcap/tiproxy': '4',
-                'pingcap/tidb-operator': '2',
-                'pingcap/ng-monitoring': '2',
-                'pingcap/tidb-binlog': '8',
-                'pingcap/tidb-tools': '4',
+                'tidbcloud/cloud-storage-engine': '16',
+                'tidbcloud/tiflash-cse': '16',
                 'tikv/pd': '8',
                 'tikv/tikv': '16',
-                'tidbcloud/tiflash-cse': '16',
-                'tidbcloud/cloud-storage-engine': '16',
                 }[body.repository.full_name]
             - key: builder-resources-memory
               expression: >-
                 {
-                'pingcap/ticdc': '16Gi',
+                'pingcap/ng-monitoring': '4Gi',
                 'pingcap/tidb': '32Gi',
+                'pingcap/tidb-binlog': '32Gi',
+                'pingcap/tidb-dashboard': '4Gi',
+                'pingcap/tidb-operator': '8Gi',
+                'pingcap/tidb-tools': '16Gi',
+                'pingcap/ticdc': '16Gi',
                 'pingcap/tiflash': '64Gi',
                 'pingcap/tiflow': '32Gi',
-                'pingcap/tidb-dashboard': '4Gi',
                 'pingcap/tiproxy': '16Gi',
-                'pingcap/tidb-operator': '8Gi',
-                'pingcap/ng-monitoring': '4Gi',
-                'pingcap/tidb-binlog': '32Gi',
-                'pingcap/tidb-tools': '16Gi',
+                'tidbcloud/cloud-storage-engine': '64Gi',
+                'tidbcloud/tiflash-cse': '64Gi',
                 'tikv/pd': '32Gi',
                 'tikv/tikv': '64Gi',
-                'tidbcloud/tiflash-cse': '64Gi',
-                'tidbcloud/cloud-storage-engine': '64Gi',
                 }[body.repository.full_name]
             - key: custom-params
               expression: >-

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml
@@ -11,7 +11,7 @@ spec:
       params:
         - name: filter
           value: >-
-            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'pingcap/tidb-operator', 'pingcap/ng-monitoring', 'pingcap/tidb-binlog', 'pingcap/tidb-tools', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
+            body.repository.full_name in ['pingcap/ng-monitoring', 'pingcap/tidb', 'pingcap/tidb-binlog', 'pingcap/tidb-dashboard', 'pingcap/tidb-operator', 'pingcap/tidb-tools', 'pingcap/ticdc', 'pingcap/tiflash', 'pingcap/tiflow', 'pingcap/tiproxy', 'tidbcloud/cloud-storage-engine', 'tidbcloud/tiflash-cse', 'tikv/pd', 'tikv/tikv']
             &&
             ! (header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64'])
         - name: overlays
@@ -19,74 +19,74 @@ spec:
             - key: timeout
               expression: >-
                 {
-                'pingcap/ticdc': '20m',
+                'pingcap/ng-monitoring': '30m',
                 'pingcap/tidb': '40m',
+                'pingcap/tidb-binlog': '2h',
+                'pingcap/tidb-dashboard': '40m',
+                'pingcap/tidb-operator': '30m',
+                'pingcap/tidb-tools': '1h',
+                'pingcap/ticdc': '20m',
                 'pingcap/tiflash': '2h',
                 'pingcap/tiflow': '40m',
-                'pingcap/tidb-dashboard': '40m',
                 'pingcap/tiproxy': '30m',
-                'pingcap/tidb-operator': '30m',
-                'pingcap/ng-monitoring': '30m',
-                'pingcap/tidb-binlog': '2h',
-                'pingcap/tidb-tools': '1h',
+                'tidbcloud/cloud-storage-engine': '2h30m',
+                'tidbcloud/tiflash-cse': '2h',
                 'tikv/pd': '40m',
                 'tikv/tikv': '2h30m',
-                'tidbcloud/tiflash-cse': '2h',
-                'tidbcloud/cloud-storage-engine': '2h30m',
                 }[body.repository.full_name]
             - key: source-ws-size
               expression: >-
                 {
-                'pingcap/ticdc': '50Gi',
+                'pingcap/ng-monitoring': '8Gi',
                 'pingcap/tidb': '50Gi',
+                'pingcap/tidb-binlog': '100Gi',
+                'pingcap/tidb-dashboard': '8Gi',
+                'pingcap/tidb-operator': '10Gi',
+                'pingcap/tidb-tools': '10Gi',
+                'pingcap/ticdc': '50Gi',
                 'pingcap/tiflash': '100Gi',
                 'pingcap/tiflow': '50Gi',
-                'pingcap/tidb-dashboard': '8Gi',
                 'pingcap/tiproxy': '10Gi',
-                'pingcap/tidb-operator': '10Gi',
-                'pingcap/ng-monitoring': '8Gi',
-                'pingcap/tidb-binlog': '100Gi',
-                'pingcap/tidb-tools': '10Gi',
+                'tidbcloud/cloud-storage-engine': '100Gi',
+                'tidbcloud/tiflash-cse': '100Gi',
                 'tikv/pd': '50Gi',
                 'tikv/tikv': '100Gi',
-                'tidbcloud/tiflash-cse': '100Gi',
-                'tidbcloud/cloud-storage-engine': '100Gi',
                 }[body.repository.full_name]
             - key: builder-resources-cpu
               expression: >-
                 {
-                'pingcap/ticdc': '4',
+                'pingcap/ng-monitoring': '2',
                 'pingcap/tidb': '8',
+                'pingcap/tidb-binlog': '8',
+                'pingcap/tidb-dashboard': '2',
+                'pingcap/tidb-operator': '2',
+                'pingcap/tidb-tools': '4',
+                'pingcap/ticdc': '4',
                 'pingcap/tiflash': '16',
                 'pingcap/tiflow': '8',
-                'pingcap/tidb-dashboard': '2',
                 'pingcap/tiproxy': '4',
-                'pingcap/tidb-operator': '2',
-                'pingcap/ng-monitoring': '2',
-                'pingcap/tidb-binlog': '8',
-                'pingcap/tidb-tools': '4',
+                'tidbcloud/cloud-storage-engine': '16',
+                'tidbcloud/tiflash-cse': '16',
                 'tikv/pd': '8',
                 'tikv/tikv': '16',
-                'tidbcloud/tiflash-cse': '16',
-                'tidbcloud/cloud-storage-engine': '16',
                 }[body.repository.full_name]
             - key: builder-resources-memory
               expression: >-
                 {
-                'pingcap/ticdc': '16Gi',
+                'pingcap/ng-monitoring': '4Gi',
                 'pingcap/tidb': '32Gi',
+                'pingcap/tidb-binlog': '32Gi',
+                'pingcap/tidb-dashboard': '4Gi',
+                'pingcap/tidb-operator': '8Gi',
+                'pingcap/tidb-tools': '16Gi',
+                'pingcap/ticdc': '16Gi',
                 'pingcap/tiflash': '64Gi',
                 'pingcap/tiflow': '32Gi',
-                'pingcap/tidb-dashboard': '4Gi',
                 'pingcap/tiproxy': '16Gi',
-                'pingcap/tidb-operator': '8Gi',
-                'pingcap/ng-monitoring': '4Gi',
-                'pingcap/tidb-binlog': '32Gi',
-                'pingcap/tidb-tools': '16Gi',
+                'tidbcloud/cloud-storage-engine': '64Gi',
+                'tidbcloud/tiflash-cse': '64Gi',
                 'tikv/pd': '32Gi',
                 'tikv/tikv': '64Gi',
-                'tidbcloud/tiflash-cse': '64Gi',
-                'tidbcloud/cloud-storage-engine': '64Gi',
                 }[body.repository.full_name]
             - key: custom-params
               expression: >-

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml
@@ -28,7 +28,12 @@ spec:
               'tikv/tikv'
             ]
             &&
-            ! (header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64'])
+            ! (header.canonical('ce-paramPlatform') in [
+              'linux/amd64',
+              'linux/arm64',
+              'darwin/amd64',
+              'darwin/arm64'
+            ])
         - name: overlays
           value:
             - key: timeout

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml
@@ -11,7 +11,7 @@ spec:
       params:
         - name: filter
           value: >-
-            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'pingcap/tidb-operator', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
+            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'pingcap/tidb-operator', 'pingcap/ng-monitoring', 'pingcap/tidb-binlog', 'pingcap/tidb-tools', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
             &&
             ! (header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64'])
         - name: overlays
@@ -26,6 +26,9 @@ spec:
                 'pingcap/tidb-dashboard': '40m',
                 'pingcap/tiproxy': '30m',
                 'pingcap/tidb-operator': '30m',
+                'pingcap/ng-monitoring': '30m',
+                'pingcap/tidb-binlog': '2h',
+                'pingcap/tidb-tools': '1h',
                 'tikv/pd': '40m',
                 'tikv/tikv': '2h30m',
                 'tidbcloud/tiflash-cse': '2h',
@@ -41,6 +44,9 @@ spec:
                 'pingcap/tidb-dashboard': '8Gi',
                 'pingcap/tiproxy': '10Gi',
                 'pingcap/tidb-operator': '10Gi',
+                'pingcap/ng-monitoring': '8Gi',
+                'pingcap/tidb-binlog': '100Gi',
+                'pingcap/tidb-tools': '10Gi',
                 'tikv/pd': '50Gi',
                 'tikv/tikv': '100Gi',
                 'tidbcloud/tiflash-cse': '100Gi',
@@ -56,6 +62,9 @@ spec:
                 'pingcap/tidb-dashboard': '2',
                 'pingcap/tiproxy': '4',
                 'pingcap/tidb-operator': '2',
+                'pingcap/ng-monitoring': '2',
+                'pingcap/tidb-binlog': '8',
+                'pingcap/tidb-tools': '4',
                 'tikv/pd': '8',
                 'tikv/tikv': '16',
                 'tidbcloud/tiflash-cse': '16',
@@ -71,6 +80,9 @@ spec:
                 'pingcap/tidb-dashboard': '4Gi',
                 'pingcap/tiproxy': '16Gi',
                 'pingcap/tidb-operator': '8Gi',
+                'pingcap/ng-monitoring': '4Gi',
+                'pingcap/tidb-binlog': '32Gi',
+                'pingcap/tidb-tools': '16Gi',
                 'tikv/pd': '32Gi',
                 'tikv/tikv': '64Gi',
                 'tidbcloud/tiflash-cse': '64Gi',

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml
@@ -11,7 +11,22 @@ spec:
       params:
         - name: filter
           value: >-
-            body.repository.full_name in ['pingcap/ng-monitoring', 'pingcap/tidb', 'pingcap/tidb-binlog', 'pingcap/tidb-dashboard', 'pingcap/tidb-operator', 'pingcap/tidb-tools', 'pingcap/ticdc', 'pingcap/tiflash', 'pingcap/tiflow', 'pingcap/tiproxy', 'tidbcloud/cloud-storage-engine', 'tidbcloud/tiflash-cse', 'tikv/pd', 'tikv/tikv']
+            body.repository.full_name in [
+              'pingcap/ng-monitoring',
+              'pingcap/tidb',
+              'pingcap/tidb-binlog',
+              'pingcap/tidb-dashboard',
+              'pingcap/tidb-operator',
+              'pingcap/tidb-tools',
+              'pingcap/ticdc',
+              'pingcap/tiflash',
+              'pingcap/tiflow',
+              'pingcap/tiproxy',
+              'tidbcloud/cloud-storage-engine',
+              'tidbcloud/tiflash-cse',
+              'tikv/pd',
+              'tikv/tikv'
+            ]
             &&
             ! (header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64'])
         - name: overlays

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr-single-platform.yaml
@@ -28,7 +28,12 @@ spec:
               'tikv/tikv'
             ]
             &&
-            header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64']
+            header.canonical('ce-paramPlatform') in [
+              'linux/amd64',
+              'linux/arm64',
+              'darwin/amd64',
+              'darwin/arm64'
+            ]
         - name: overlays
           value:
             - key: timeout

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr-single-platform.yaml
@@ -11,7 +11,7 @@ spec:
       params:
         - name: filter
           value: >-
-            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'pingcap/tidb-operator', 'pingcap/ng-monitoring', 'pingcap/tidb-binlog', 'pingcap/tidb-tools', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
+            body.repository.full_name in ['pingcap/ng-monitoring', 'pingcap/tidb', 'pingcap/tidb-binlog', 'pingcap/tidb-dashboard', 'pingcap/tidb-operator', 'pingcap/tidb-tools', 'pingcap/ticdc', 'pingcap/tiflash', 'pingcap/tiflow', 'pingcap/tiproxy', 'tidbcloud/cloud-storage-engine', 'tidbcloud/tiflash-cse', 'tikv/pd', 'tikv/tikv']
             &&
             header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64']
         - name: overlays
@@ -19,74 +19,74 @@ spec:
             - key: timeout
               expression: >-
                 {
-                'pingcap/ticdc': '20m',
+                'pingcap/ng-monitoring': '30m',
                 'pingcap/tidb': '40m',
+                'pingcap/tidb-binlog': '2h',
+                'pingcap/tidb-dashboard': '40m',
+                'pingcap/tidb-operator': '30m',
+                'pingcap/tidb-tools': '1h',
+                'pingcap/ticdc': '20m',
                 'pingcap/tiflash': '2h',
                 'pingcap/tiflow': '40m',
-                'pingcap/tidb-dashboard': '40m',
                 'pingcap/tiproxy': '30m',
-                'pingcap/tidb-operator': '30m',
-                'pingcap/ng-monitoring': '30m',
-                'pingcap/tidb-binlog': '2h',
-                'pingcap/tidb-tools': '1h',
+                'tidbcloud/cloud-storage-engine': '2h30m',
+                'tidbcloud/tiflash-cse': '2h',
                 'tikv/pd': '40m',
                 'tikv/tikv': '2h30m',
-                'tidbcloud/tiflash-cse': '2h',
-                'tidbcloud/cloud-storage-engine': '2h30m',
                 }[body.repository.full_name]
             - key: source-ws-size
               expression: >-
                 {
+                'pingcap/ng-monitoring': '8Gi',
                 'pingcap/ticdc': '50Gi',
                 'pingcap/tidb': '50Gi',
+                'pingcap/tidb-binlog': '100Gi',
+                'pingcap/tidb-dashboard': '8Gi',
+                'pingcap/tidb-operator': '10Gi',
+                'pingcap/tidb-tools': '10Gi',
                 'pingcap/tiflash': '100Gi',
                 'pingcap/tiflow': '50Gi',
-                'pingcap/tidb-dashboard': '8Gi',
                 'pingcap/tiproxy': '10Gi',
-                'pingcap/tidb-operator': '10Gi',
-                'pingcap/ng-monitoring': '8Gi',
-                'pingcap/tidb-binlog': '100Gi',
-                'pingcap/tidb-tools': '10Gi',
+                'tidbcloud/cloud-storage-engine': '100Gi',
+                'tidbcloud/tiflash-cse': '100Gi',
                 'tikv/pd': '50Gi',
                 'tikv/tikv': '100Gi',
-                'tidbcloud/tiflash-cse': '100Gi',
-                'tidbcloud/cloud-storage-engine': '100Gi',
                 }[body.repository.full_name]
             - key: builder-resources-cpu
               expression: >-
                 {
+                'pingcap/ng-monitoring': '2',
                 'pingcap/ticdc': '4',
                 'pingcap/tidb': '8',
+                'pingcap/tidb-binlog': '8',
+                'pingcap/tidb-dashboard': '2',
+                'pingcap/tidb-operator': '2',
+                'pingcap/tidb-tools': '4',
                 'pingcap/tiflash': '16',
                 'pingcap/tiflow': '8',
-                'pingcap/tidb-dashboard': '2',
                 'pingcap/tiproxy': '4',
-                'pingcap/tidb-operator': '2',
-                'pingcap/ng-monitoring': '2',
-                'pingcap/tidb-binlog': '8',
-                'pingcap/tidb-tools': '4',
+                'tidbcloud/cloud-storage-engine': '16',
+                'tidbcloud/tiflash-cse': '16',
                 'tikv/pd': '8',
                 'tikv/tikv': '16',
-                'tidbcloud/tiflash-cse': '16',
-                'tidbcloud/cloud-storage-engine': '16',
                 }[body.repository.full_name]
             - key: builder-resources-memory
               expression: >-
                 {
+                'pingcap/ng-monitoring': '4Gi',
                 'pingcap/ticdc': '16Gi',
                 'pingcap/tidb': '32Gi',
+                'pingcap/tidb-binlog': '32Gi',
+                'pingcap/tidb-dashboard': '4Gi',
+                'pingcap/tidb-operator': '8Gi',
+                'pingcap/tidb-tools': '16Gi',
                 'pingcap/tiflash': '64Gi',
                 'pingcap/tiflow': '32Gi',
-                'pingcap/tidb-dashboard': '4Gi',
                 'pingcap/tiproxy': '16Gi',
-                'pingcap/tidb-operator': '8Gi',
-                'pingcap/ng-monitoring': '4Gi',
-                'pingcap/tidb-binlog': '32Gi',
-                'pingcap/tidb-tools': '16Gi',
+                'tidbcloud/cloud-storage-engine': '64Gi',
+                'tidbcloud/tiflash-cse': '64Gi',
                 'tikv/pd': '32Gi',
                 'tikv/tikv': '64Gi',
-                'tidbcloud/tiflash-cse': '64Gi',
-                'tidbcloud/cloud-storage-engine': '64Gi',
                 }[body.repository.full_name]
             - key: custom-params
               expression: >-

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr-single-platform.yaml
@@ -11,7 +11,22 @@ spec:
       params:
         - name: filter
           value: >-
-            body.repository.full_name in ['pingcap/ng-monitoring', 'pingcap/tidb', 'pingcap/tidb-binlog', 'pingcap/tidb-dashboard', 'pingcap/tidb-operator', 'pingcap/tidb-tools', 'pingcap/ticdc', 'pingcap/tiflash', 'pingcap/tiflow', 'pingcap/tiproxy', 'tidbcloud/cloud-storage-engine', 'tidbcloud/tiflash-cse', 'tikv/pd', 'tikv/tikv']
+            body.repository.full_name in [
+              'pingcap/ng-monitoring',
+              'pingcap/tidb',
+              'pingcap/tidb-binlog',
+              'pingcap/tidb-dashboard',
+              'pingcap/tidb-operator',
+              'pingcap/tidb-tools',
+              'pingcap/ticdc',
+              'pingcap/tiflash',
+              'pingcap/tiflow',
+              'pingcap/tiproxy',
+              'tidbcloud/cloud-storage-engine',
+              'tidbcloud/tiflash-cse',
+              'tikv/pd',
+              'tikv/tikv'
+            ]
             &&
             header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64']
         - name: overlays

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr-single-platform.yaml
@@ -11,7 +11,7 @@ spec:
       params:
         - name: filter
           value: >-
-            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'pingcap/tidb-operator', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
+            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'pingcap/tidb-operator', 'pingcap/ng-monitoring', 'pingcap/tidb-binlog', 'pingcap/tidb-tools', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
             &&
             header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64']
         - name: overlays
@@ -26,6 +26,9 @@ spec:
                 'pingcap/tidb-dashboard': '40m',
                 'pingcap/tiproxy': '30m',
                 'pingcap/tidb-operator': '30m',
+                'pingcap/ng-monitoring': '30m',
+                'pingcap/tidb-binlog': '2h',
+                'pingcap/tidb-tools': '1h',
                 'tikv/pd': '40m',
                 'tikv/tikv': '2h30m',
                 'tidbcloud/tiflash-cse': '2h',
@@ -41,6 +44,9 @@ spec:
                 'pingcap/tidb-dashboard': '8Gi',
                 'pingcap/tiproxy': '10Gi',
                 'pingcap/tidb-operator': '10Gi',
+                'pingcap/ng-monitoring': '8Gi',
+                'pingcap/tidb-binlog': '100Gi',
+                'pingcap/tidb-tools': '10Gi',
                 'tikv/pd': '50Gi',
                 'tikv/tikv': '100Gi',
                 'tidbcloud/tiflash-cse': '100Gi',
@@ -56,6 +62,9 @@ spec:
                 'pingcap/tidb-dashboard': '2',
                 'pingcap/tiproxy': '4',
                 'pingcap/tidb-operator': '2',
+                'pingcap/ng-monitoring': '2',
+                'pingcap/tidb-binlog': '8',
+                'pingcap/tidb-tools': '4',
                 'tikv/pd': '8',
                 'tikv/tikv': '16',
                 'tidbcloud/tiflash-cse': '16',
@@ -71,6 +80,9 @@ spec:
                 'pingcap/tidb-dashboard': '4Gi',
                 'pingcap/tiproxy': '16Gi',
                 'pingcap/tidb-operator': '8Gi',
+                'pingcap/ng-monitoring': '4Gi',
+                'pingcap/tidb-binlog': '32Gi',
+                'pingcap/tidb-tools': '16Gi',
                 'tikv/pd': '32Gi',
                 'tikv/tikv': '64Gi',
                 'tidbcloud/tiflash-cse': '64Gi',

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr.yaml
@@ -11,7 +11,7 @@ spec:
       params:
         - name: filter
           value: >-
-            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'pingcap/tidb-operator', 'pingcap/ng-monitoring', 'pingcap/tidb-binlog', 'pingcap/tidb-tools', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
+            body.repository.full_name in ['pingcap/ng-monitoring', 'pingcap/tidb', 'pingcap/tidb-binlog', 'pingcap/tidb-dashboard', 'pingcap/tidb-operator', 'pingcap/tidb-tools', 'pingcap/ticdc', 'pingcap/tiflash', 'pingcap/tiflow', 'pingcap/tiproxy', 'tidbcloud/cloud-storage-engine', 'tidbcloud/tiflash-cse', 'tikv/pd', 'tikv/tikv']
             &&
             ! (header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64'])
         - name: overlays
@@ -23,16 +23,20 @@ spec:
                 'pingcap/tidb': '40m',
                 'pingcap/tiflash': '2h',
                 'pingcap/tiflow': '40m',
-                'pingcap/tidb-dashboard': '40m',
-                'pingcap/tiproxy': '30m',
-                'pingcap/tidb-operator': '30m',
                 'pingcap/ng-monitoring': '30m',
+                'pingcap/tidb': '40m',
                 'pingcap/tidb-binlog': '2h',
+                'pingcap/tidb-dashboard': '40m',
+                'pingcap/tidb-operator': '30m',
                 'pingcap/tidb-tools': '1h',
+                'pingcap/ticdc': '20m',
+                'pingcap/tiflash': '2h',
+                'pingcap/tiflow': '40m',
+                'pingcap/tiproxy': '30m',
+                'tidbcloud/cloud-storage-engine': '2h30m',
+                'tidbcloud/tiflash-cse': '2h',
                 'tikv/pd': '40m',
                 'tikv/tikv': '2h30m',
-                'tidbcloud/tiflash-cse': '2h',
-                'tidbcloud/cloud-storage-engine': '2h30m',
                 }[body.repository.full_name]
             - key: source-ws-size
               expression: >-
@@ -41,16 +45,20 @@ spec:
                 'pingcap/tidb': '50Gi',
                 'pingcap/tiflash': '100Gi',
                 'pingcap/tiflow': '50Gi',
-                'pingcap/tidb-dashboard': '8Gi',
-                'pingcap/tiproxy': '10Gi',
-                'pingcap/tidb-operator': '10Gi',
                 'pingcap/ng-monitoring': '8Gi',
+                'pingcap/tidb': '50Gi',
                 'pingcap/tidb-binlog': '100Gi',
+                'pingcap/tidb-dashboard': '8Gi',
+                'pingcap/tidb-operator': '10Gi',
                 'pingcap/tidb-tools': '10Gi',
+                'pingcap/ticdc': '50Gi',
+                'pingcap/tiflash': '100Gi',
+                'pingcap/tiflow': '50Gi',
+                'pingcap/tiproxy': '10Gi',
+                'tidbcloud/cloud-storage-engine': '100Gi',
+                'tidbcloud/tiflash-cse': '100Gi',
                 'tikv/pd': '50Gi',
                 'tikv/tikv': '100Gi',
-                'tidbcloud/tiflash-cse': '100Gi',
-                'tidbcloud/cloud-storage-engine': '100Gi',
                 }[body.repository.full_name]
             - key: builder-resources-cpu
               expression: >-
@@ -59,16 +67,20 @@ spec:
                 'pingcap/tidb': '8',
                 'pingcap/tiflash': '16',
                 'pingcap/tiflow': '8',
-                'pingcap/tidb-dashboard': '2',
-                'pingcap/tiproxy': '4',
-                'pingcap/tidb-operator': '2',
                 'pingcap/ng-monitoring': '2',
+                'pingcap/tidb': '8',
                 'pingcap/tidb-binlog': '8',
+                'pingcap/tidb-dashboard': '2',
+                'pingcap/tidb-operator': '2',
                 'pingcap/tidb-tools': '4',
+                'pingcap/ticdc': '4',
+                'pingcap/tiflash': '16',
+                'pingcap/tiflow': '8',
+                'pingcap/tiproxy': '4',
+                'tidbcloud/cloud-storage-engine': '16',
+                'tidbcloud/tiflash-cse': '16',
                 'tikv/pd': '8',
                 'tikv/tikv': '16',
-                'tidbcloud/tiflash-cse': '16',
-                'tidbcloud/cloud-storage-engine': '16',
                 }[body.repository.full_name]
             - key: builder-resources-memory
               expression: >-
@@ -77,16 +89,20 @@ spec:
                 'pingcap/tidb': '32Gi',
                 'pingcap/tiflash': '64Gi',
                 'pingcap/tiflow': '32Gi',
-                'pingcap/tidb-dashboard': '4Gi',
-                'pingcap/tiproxy': '16Gi',
-                'pingcap/tidb-operator': '8Gi',
                 'pingcap/ng-monitoring': '4Gi',
+                'pingcap/tidb': '32Gi',
                 'pingcap/tidb-binlog': '32Gi',
+                'pingcap/tidb-dashboard': '4Gi',
+                'pingcap/tidb-operator': '8Gi',
                 'pingcap/tidb-tools': '16Gi',
+                'pingcap/ticdc': '16Gi',
+                'pingcap/tiflash': '64Gi',
+                'pingcap/tiflow': '32Gi',
+                'pingcap/tiproxy': '16Gi',
+                'tidbcloud/cloud-storage-engine': '64Gi',
+                'tidbcloud/tiflash-cse': '64Gi',
                 'tikv/pd': '32Gi',
                 'tikv/tikv': '64Gi',
-                'tidbcloud/tiflash-cse': '64Gi',
-                'tidbcloud/cloud-storage-engine': '64Gi',
                 }[body.repository.full_name]
             - key: custom-params
               expression: >-

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr.yaml
@@ -28,7 +28,12 @@ spec:
               'tikv/tikv'
             ]
             &&
-            ! (header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64'])
+            ! (header.canonical('ce-paramPlatform') in [
+              'linux/amd64',
+              'linux/arm64',
+              'darwin/amd64',
+              'darwin/arm64'
+            ])
         - name: overlays
           value:
             - key: timeout

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr.yaml
@@ -11,7 +11,7 @@ spec:
       params:
         - name: filter
           value: >-
-            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'pingcap/tidb-operator', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
+            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'pingcap/tidb-operator', 'pingcap/ng-monitoring', 'pingcap/tidb-binlog', 'pingcap/tidb-tools', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
             &&
             ! (header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64'])
         - name: overlays
@@ -26,6 +26,9 @@ spec:
                 'pingcap/tidb-dashboard': '40m',
                 'pingcap/tiproxy': '30m',
                 'pingcap/tidb-operator': '30m',
+                'pingcap/ng-monitoring': '30m',
+                'pingcap/tidb-binlog': '2h',
+                'pingcap/tidb-tools': '1h',
                 'tikv/pd': '40m',
                 'tikv/tikv': '2h30m',
                 'tidbcloud/tiflash-cse': '2h',
@@ -41,6 +44,9 @@ spec:
                 'pingcap/tidb-dashboard': '8Gi',
                 'pingcap/tiproxy': '10Gi',
                 'pingcap/tidb-operator': '10Gi',
+                'pingcap/ng-monitoring': '8Gi',
+                'pingcap/tidb-binlog': '100Gi',
+                'pingcap/tidb-tools': '10Gi',
                 'tikv/pd': '50Gi',
                 'tikv/tikv': '100Gi',
                 'tidbcloud/tiflash-cse': '100Gi',
@@ -56,6 +62,9 @@ spec:
                 'pingcap/tidb-dashboard': '2',
                 'pingcap/tiproxy': '4',
                 'pingcap/tidb-operator': '2',
+                'pingcap/ng-monitoring': '2',
+                'pingcap/tidb-binlog': '8',
+                'pingcap/tidb-tools': '4',
                 'tikv/pd': '8',
                 'tikv/tikv': '16',
                 'tidbcloud/tiflash-cse': '16',
@@ -71,6 +80,9 @@ spec:
                 'pingcap/tidb-dashboard': '4Gi',
                 'pingcap/tiproxy': '16Gi',
                 'pingcap/tidb-operator': '8Gi',
+                'pingcap/ng-monitoring': '4Gi',
+                'pingcap/tidb-binlog': '32Gi',
+                'pingcap/tidb-tools': '16Gi',
                 'tikv/pd': '32Gi',
                 'tikv/tikv': '64Gi',
                 'tidbcloud/tiflash-cse': '64Gi',

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr.yaml
@@ -11,7 +11,22 @@ spec:
       params:
         - name: filter
           value: >-
-            body.repository.full_name in ['pingcap/ng-monitoring', 'pingcap/tidb', 'pingcap/tidb-binlog', 'pingcap/tidb-dashboard', 'pingcap/tidb-operator', 'pingcap/tidb-tools', 'pingcap/ticdc', 'pingcap/tiflash', 'pingcap/tiflow', 'pingcap/tiproxy', 'tidbcloud/cloud-storage-engine', 'tidbcloud/tiflash-cse', 'tikv/pd', 'tikv/tikv']
+            body.repository.full_name in [
+              'pingcap/ng-monitoring',
+              'pingcap/tidb',
+              'pingcap/tidb-binlog',
+              'pingcap/tidb-dashboard',
+              'pingcap/tidb-operator',
+              'pingcap/tidb-tools',
+              'pingcap/ticdc',
+              'pingcap/tiflash',
+              'pingcap/tiflow',
+              'pingcap/tiproxy',
+              'tidbcloud/cloud-storage-engine',
+              'tidbcloud/tiflash-cse',
+              'tikv/pd',
+              'tikv/tikv'
+            ]
             &&
             ! (header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64'])
         - name: overlays

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create-single-platform.yaml
@@ -30,7 +30,12 @@ spec:
             &&
             body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+(-(alpha|beta|rc)([.][0-9]+)?)?$')
             &&
-            header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64']
+            header.canonical('ce-paramPlatform') in [
+              'linux/amd64',
+              'linux/arm64',
+              'darwin/amd64',
+              'darwin/arm64'
+            ]
         - name: overlays
           value:
             - key: timeout

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create-single-platform.yaml
@@ -11,7 +11,7 @@ spec:
       params:
         - name: filter
           value: >-
-            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'pingcap/tidb-operator', 'pingcap/ng-monitoring', 'pingcap/tidb-binlog', 'pingcap/tidb-tools', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
+            body.repository.full_name in ['pingcap/ng-monitoring', 'pingcap/tidb', 'pingcap/tidb-binlog', 'pingcap/tidb-dashboard', 'pingcap/tidb-operator', 'pingcap/tidb-tools', 'pingcap/ticdc', 'pingcap/tiflash', 'pingcap/tiflow', 'pingcap/tiproxy', 'tidbcloud/cloud-storage-engine', 'tidbcloud/tiflash-cse', 'tikv/pd', 'tikv/tikv']
             &&
             body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+(-(alpha|beta|rc)([.][0-9]+)?)?$')
             &&
@@ -21,74 +21,74 @@ spec:
             - key: timeout
               expression: >-
                 {
-                'pingcap/ticdc': '20m',
+                'pingcap/ng-monitoring': '30m',
                 'pingcap/tidb': '40m',
+                'pingcap/tidb-binlog': '2h',
+                'pingcap/tidb-dashboard': '40m',
+                'pingcap/tidb-operator': '30m',
+                'pingcap/tidb-tools': '1h',
+                'pingcap/ticdc': '20m',
                 'pingcap/tiflash': '2h',
                 'pingcap/tiflow': '40m',
-                'pingcap/tidb-dashboard': '40m',
                 'pingcap/tiproxy': '30m',
-                'pingcap/tidb-operator': '30m',
-                'pingcap/ng-monitoring': '30m',
-                'pingcap/tidb-binlog': '2h',
-                'pingcap/tidb-tools': '1h',
+                'tidbcloud/cloud-storage-engine': '2h30m',
+                'tidbcloud/tiflash-cse': '2h',
                 'tikv/pd': '40m',
                 'tikv/tikv': '2h30m',
-                'tidbcloud/tiflash-cse': '2h',
-                'tidbcloud/cloud-storage-engine': '2h30m',
                 }[body.repository.full_name]
             - key: source-ws-size
               expression: >-
                 {
-                'pingcap/ticdc': '50Gi',
+                'pingcap/ng-monitoring': '8Gi',
                 'pingcap/tidb': '50Gi',
+                'pingcap/tidb-binlog': '100Gi',
+                'pingcap/tidb-dashboard': '8Gi',
+                'pingcap/tidb-operator': '10Gi',
+                'pingcap/tidb-tools': '10Gi',
+                'pingcap/ticdc': '50Gi',
                 'pingcap/tiflash': '100Gi',
                 'pingcap/tiflow': '50Gi',
-                'pingcap/tidb-dashboard': '8Gi',
                 'pingcap/tiproxy': '10Gi',
-                'pingcap/tidb-operator': '10Gi',
-                'pingcap/ng-monitoring': '8Gi',
-                'pingcap/tidb-binlog': '100Gi',
-                'pingcap/tidb-tools': '10Gi',
+                'tidbcloud/cloud-storage-engine': '100Gi',
+                'tidbcloud/tiflash-cse': '100Gi',
                 'tikv/pd': '50Gi',
                 'tikv/tikv': '100Gi',
-                'tidbcloud/tiflash-cse': '100Gi',
-                'tidbcloud/cloud-storage-engine': '100Gi',
                 }[body.repository.full_name]
             - key: builder-resources-cpu
               expression: >-
                 {
-                'pingcap/ticdc': '4',
+                'pingcap/ng-monitoring': '2',
                 'pingcap/tidb': '8',
+                'pingcap/tidb-binlog': '8',
+                'pingcap/tidb-dashboard': '2',
+                'pingcap/tidb-operator': '2',
+                'pingcap/tidb-tools': '4',
+                'pingcap/ticdc': '4',
                 'pingcap/tiflash': '16',
                 'pingcap/tiflow': '8',
-                'pingcap/tidb-dashboard': '2',
                 'pingcap/tiproxy': '4',
-                'pingcap/tidb-operator': '2',
-                'pingcap/ng-monitoring': '2',
-                'pingcap/tidb-binlog': '8',
-                'pingcap/tidb-tools': '4',
+                'tidbcloud/cloud-storage-engine': '16',
+                'tidbcloud/tiflash-cse': '16',
                 'tikv/pd': '8',
                 'tikv/tikv': '16',
-                'tidbcloud/tiflash-cse': '16',
-                'tidbcloud/cloud-storage-engine': '16',
                 }[body.repository.full_name]
             - key: builder-resources-memory
               expression: >-
                 {
-                'pingcap/ticdc': '16Gi',
+                'pingcap/ng-monitoring': '4Gi',
                 'pingcap/tidb': '32Gi',
+                'pingcap/tidb-binlog': '32Gi',
+                'pingcap/tidb-dashboard': '4Gi',
+                'pingcap/tidb-operator': '8Gi',
+                'pingcap/tidb-tools': '16Gi',
+                'pingcap/ticdc': '16Gi',
                 'pingcap/tiflash': '64Gi',
                 'pingcap/tiflow': '32Gi',
-                'pingcap/tidb-dashboard': '4Gi',
                 'pingcap/tiproxy': '16Gi',
-                'pingcap/tidb-operator': '8Gi',
-                'pingcap/ng-monitoring': '4Gi',
-                'pingcap/tidb-binlog': '32Gi',
-                'pingcap/tidb-tools': '16Gi',
+                'tidbcloud/cloud-storage-engine': '64Gi',
+                'tidbcloud/tiflash-cse': '64Gi',
                 'tikv/pd': '32Gi',
                 'tikv/tikv': '64Gi',
-                'tidbcloud/tiflash-cse': '64Gi',
-                'tidbcloud/cloud-storage-engine': '64Gi',
                 }[body.repository.full_name]
             - key: custom-params
               expression: >-

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create-single-platform.yaml
@@ -11,7 +11,7 @@ spec:
       params:
         - name: filter
           value: >-
-            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'pingcap/tidb-operator', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
+            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'pingcap/tidb-operator', 'pingcap/ng-monitoring', 'pingcap/tidb-binlog', 'pingcap/tidb-tools', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
             &&
             body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+(-(alpha|beta|rc)([.][0-9]+)?)?$')
             &&
@@ -28,6 +28,9 @@ spec:
                 'pingcap/tidb-dashboard': '40m',
                 'pingcap/tiproxy': '30m',
                 'pingcap/tidb-operator': '30m',
+                'pingcap/ng-monitoring': '30m',
+                'pingcap/tidb-binlog': '2h',
+                'pingcap/tidb-tools': '1h',
                 'tikv/pd': '40m',
                 'tikv/tikv': '2h30m',
                 'tidbcloud/tiflash-cse': '2h',
@@ -43,6 +46,9 @@ spec:
                 'pingcap/tidb-dashboard': '8Gi',
                 'pingcap/tiproxy': '10Gi',
                 'pingcap/tidb-operator': '10Gi',
+                'pingcap/ng-monitoring': '8Gi',
+                'pingcap/tidb-binlog': '100Gi',
+                'pingcap/tidb-tools': '10Gi',
                 'tikv/pd': '50Gi',
                 'tikv/tikv': '100Gi',
                 'tidbcloud/tiflash-cse': '100Gi',
@@ -58,6 +64,9 @@ spec:
                 'pingcap/tidb-dashboard': '2',
                 'pingcap/tiproxy': '4',
                 'pingcap/tidb-operator': '2',
+                'pingcap/ng-monitoring': '2',
+                'pingcap/tidb-binlog': '8',
+                'pingcap/tidb-tools': '4',
                 'tikv/pd': '8',
                 'tikv/tikv': '16',
                 'tidbcloud/tiflash-cse': '16',
@@ -73,6 +82,9 @@ spec:
                 'pingcap/tidb-dashboard': '4Gi',
                 'pingcap/tiproxy': '16Gi',
                 'pingcap/tidb-operator': '8Gi',
+                'pingcap/ng-monitoring': '4Gi',
+                'pingcap/tidb-binlog': '32Gi',
+                'pingcap/tidb-tools': '16Gi',
                 'tikv/pd': '32Gi',
                 'tikv/tikv': '64Gi',
                 'tidbcloud/tiflash-cse': '64Gi',

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create-single-platform.yaml
@@ -11,7 +11,22 @@ spec:
       params:
         - name: filter
           value: >-
-            body.repository.full_name in ['pingcap/ng-monitoring', 'pingcap/tidb', 'pingcap/tidb-binlog', 'pingcap/tidb-dashboard', 'pingcap/tidb-operator', 'pingcap/tidb-tools', 'pingcap/ticdc', 'pingcap/tiflash', 'pingcap/tiflow', 'pingcap/tiproxy', 'tidbcloud/cloud-storage-engine', 'tidbcloud/tiflash-cse', 'tikv/pd', 'tikv/tikv']
+            body.repository.full_name in [
+              'pingcap/ng-monitoring',
+              'pingcap/tidb',
+              'pingcap/tidb-binlog',
+              'pingcap/tidb-dashboard',
+              'pingcap/tidb-operator',
+              'pingcap/tidb-tools',
+              'pingcap/ticdc',
+              'pingcap/tiflash',
+              'pingcap/tiflow',
+              'pingcap/tiproxy',
+              'tidbcloud/cloud-storage-engine',
+              'tidbcloud/tiflash-cse',
+              'tikv/pd',
+              'tikv/tikv'
+            ]
             &&
             body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+(-(alpha|beta|rc)([.][0-9]+)?)?$')
             &&

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create.yaml
@@ -30,7 +30,12 @@ spec:
             &&
             body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+(-(alpha|beta|rc)([.][0-9]+)?)?$')
             &&
-            ! (header.canonical('ce-paramPlatform') in ['linux/amd64', 'linux/arm64', 'darwin/amd64', 'darwin/arm64'])
+            ! (header.canonical('ce-paramPlatform') in [
+              'linux/amd64',
+              'linux/arm64',
+              'darwin/amd64',
+              'darwin/arm64'
+            ])
         - name: overlays
           value:
             - key: timeout

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create.yaml
@@ -11,7 +11,7 @@ spec:
       params:
         - name: filter
           value: >-
-            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'pingcap/tidb-operator', 'pingcap/ng-monitoring', 'pingcap/tidb-binlog', 'pingcap/tidb-tools', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
+            body.repository.full_name in ['pingcap/ng-monitoring', 'pingcap/ticdc', 'pingcap/tidb', 'pingcap/tidb-binlog', 'pingcap/tidb-dashboard', 'pingcap/tidb-operator', 'pingcap/tidb-tools', 'pingcap/tiflash', 'pingcap/tiflow', 'pingcap/tiproxy', 'tidbcloud/cloud-storage-engine', 'tidbcloud/tiflash-cse', 'tikv/pd', 'tikv/tikv']
             &&
             body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+(-(alpha|beta|rc)([.][0-9]+)?)?$')
             &&
@@ -21,74 +21,74 @@ spec:
             - key: timeout
               expression: >-
                 {
+                'pingcap/ng-monitoring': '30m',
                 'pingcap/ticdc': '20m',
                 'pingcap/tidb': '40m',
+                'pingcap/tidb-binlog': '2h',
+                'pingcap/tidb-dashboard': '40m',
+                'pingcap/tidb-operator': '30m',
+                'pingcap/tidb-tools': '1h',
                 'pingcap/tiflash': '2h',
                 'pingcap/tiflow': '40m',
-                'pingcap/tidb-dashboard': '40m',
                 'pingcap/tiproxy': '30m',
-                'pingcap/tidb-operator': '30m',
-                'pingcap/ng-monitoring': '30m',
-                'pingcap/tidb-binlog': '2h',
-                'pingcap/tidb-tools': '1h',
+                'tidbcloud/cloud-storage-engine': '2h30m',
+                'tidbcloud/tiflash-cse': '2h',
                 'tikv/pd': '40m',
                 'tikv/tikv': '2h30m',
-                'tidbcloud/tiflash-cse': '2h',
-                'tidbcloud/cloud-storage-engine': '2h30m',
                 }[body.repository.full_name]
             - key: source-ws-size
               expression: >-
                 {
+                'pingcap/ng-monitoring': '8Gi',
                 'pingcap/ticdc': '50Gi',
                 'pingcap/tidb': '50Gi',
+                'pingcap/tidb-binlog': '100Gi',
+                'pingcap/tidb-dashboard': '8Gi',
+                'pingcap/tidb-operator': '10Gi',
+                'pingcap/tidb-tools': '10Gi',
                 'pingcap/tiflash': '100Gi',
                 'pingcap/tiflow': '50Gi',
-                'pingcap/tidb-dashboard': '8Gi',
                 'pingcap/tiproxy': '10Gi',
-                'pingcap/tidb-operator': '10Gi',
-                'pingcap/ng-monitoring': '8Gi',
-                'pingcap/tidb-binlog': '100Gi',
-                'pingcap/tidb-tools': '10Gi',
+                'tidbcloud/cloud-storage-engine': '100Gi',
+                'tidbcloud/tiflash-cse': '100Gi',
                 'tikv/pd': '50Gi',
                 'tikv/tikv': '100Gi',
-                'tidbcloud/tiflash-cse': '100Gi',
-                'tidbcloud/cloud-storage-engine': '100Gi',
                 }[body.repository.full_name]
             - key: builder-resources-cpu
               expression: >-
                 {
+                'pingcap/ng-monitoring': '2',
                 'pingcap/ticdc': '4',
                 'pingcap/tidb': '8',
+                'pingcap/tidb-binlog': '8',
+                'pingcap/tidb-dashboard': '2',
+                'pingcap/tidb-operator': '2',
+                'pingcap/tidb-tools': '4',
                 'pingcap/tiflash': '16',
                 'pingcap/tiflow': '8',
-                'pingcap/tidb-dashboard': '2',
                 'pingcap/tiproxy': '4',
-                'pingcap/tidb-operator': '2',
-                'pingcap/ng-monitoring': '2',
-                'pingcap/tidb-binlog': '8',
-                'pingcap/tidb-tools': '4',
+                'tidbcloud/cloud-storage-engine': '16',
+                'tidbcloud/tiflash-cse': '16',
                 'tikv/pd': '8',
                 'tikv/tikv': '16',
-                'tidbcloud/tiflash-cse': '16',
-                'tidbcloud/cloud-storage-engine': '16',
                 }[body.repository.full_name]
             - key: builder-resources-memory
               expression: >-
                 {
+                'pingcap/ng-monitoring': '4Gi',
                 'pingcap/ticdc': '16Gi',
                 'pingcap/tidb': '32Gi',
+                'pingcap/tidb-binlog': '32Gi',
+                'pingcap/tidb-dashboard': '4Gi',
+                'pingcap/tidb-operator': '8Gi',
+                'pingcap/tidb-tools': '16Gi',
                 'pingcap/tiflash': '64Gi',
                 'pingcap/tiflow': '32Gi',
-                'pingcap/tidb-dashboard': '4Gi',
                 'pingcap/tiproxy': '16Gi',
-                'pingcap/tidb-operator': '8Gi',
-                'pingcap/ng-monitoring': '4Gi',
-                'pingcap/tidb-binlog': '32Gi',
-                'pingcap/tidb-tools': '16Gi',
+                'tidbcloud/cloud-storage-engine': '64Gi',
+                'tidbcloud/tiflash-cse': '64Gi',
                 'tikv/pd': '32Gi',
                 'tikv/tikv': '64Gi',
-                'tidbcloud/tiflash-cse': '64Gi',
-                'tidbcloud/cloud-storage-engine': '64Gi',
                 }[body.repository.full_name]
             - key: custom-params
               expression: >-

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create.yaml
@@ -11,7 +11,22 @@ spec:
       params:
         - name: filter
           value: >-
-            body.repository.full_name in ['pingcap/ng-monitoring', 'pingcap/ticdc', 'pingcap/tidb', 'pingcap/tidb-binlog', 'pingcap/tidb-dashboard', 'pingcap/tidb-operator', 'pingcap/tidb-tools', 'pingcap/tiflash', 'pingcap/tiflow', 'pingcap/tiproxy', 'tidbcloud/cloud-storage-engine', 'tidbcloud/tiflash-cse', 'tikv/pd', 'tikv/tikv']
+            body.repository.full_name in [
+              'pingcap/ng-monitoring',
+              'pingcap/ticdc',
+              'pingcap/tidb',
+              'pingcap/tidb-binlog',
+              'pingcap/tidb-dashboard',
+              'pingcap/tidb-operator',
+              'pingcap/tidb-tools',
+              'pingcap/tiflash',
+              'pingcap/tiflow',
+              'pingcap/tiproxy',
+              'tidbcloud/cloud-storage-engine',
+              'tidbcloud/tiflash-cse',
+              'tikv/pd',
+              'tikv/tikv'
+            ]
             &&
             body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+(-(alpha|beta|rc)([.][0-9]+)?)?$')
             &&

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create.yaml
@@ -11,7 +11,7 @@ spec:
       params:
         - name: filter
           value: >-
-            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'pingcap/tidb-operator', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
+            body.repository.full_name in ['pingcap/ticdc', 'pingcap/tidb', 'pingcap/tiflow', 'pingcap/tiflash', 'pingcap/tidb-dashboard', 'pingcap/tiproxy', 'pingcap/tidb-operator', 'pingcap/ng-monitoring', 'pingcap/tidb-binlog', 'pingcap/tidb-tools', 'tikv/tikv', 'tikv/pd', 'tidbcloud/tiflash-cse', 'tidbcloud/cloud-storage-engine']
             &&
             body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+(-(alpha|beta|rc)([.][0-9]+)?)?$')
             &&
@@ -28,6 +28,9 @@ spec:
                 'pingcap/tidb-dashboard': '40m',
                 'pingcap/tiproxy': '30m',
                 'pingcap/tidb-operator': '30m',
+                'pingcap/ng-monitoring': '30m',
+                'pingcap/tidb-binlog': '2h',
+                'pingcap/tidb-tools': '1h',
                 'tikv/pd': '40m',
                 'tikv/tikv': '2h30m',
                 'tidbcloud/tiflash-cse': '2h',
@@ -43,6 +46,9 @@ spec:
                 'pingcap/tidb-dashboard': '8Gi',
                 'pingcap/tiproxy': '10Gi',
                 'pingcap/tidb-operator': '10Gi',
+                'pingcap/ng-monitoring': '8Gi',
+                'pingcap/tidb-binlog': '100Gi',
+                'pingcap/tidb-tools': '10Gi',
                 'tikv/pd': '50Gi',
                 'tikv/tikv': '100Gi',
                 'tidbcloud/tiflash-cse': '100Gi',
@@ -58,6 +64,9 @@ spec:
                 'pingcap/tidb-dashboard': '2',
                 'pingcap/tiproxy': '4',
                 'pingcap/tidb-operator': '2',
+                'pingcap/ng-monitoring': '2',
+                'pingcap/tidb-binlog': '8',
+                'pingcap/tidb-tools': '4',
                 'tikv/pd': '8',
                 'tikv/tikv': '16',
                 'tidbcloud/tiflash-cse': '16',
@@ -73,6 +82,9 @@ spec:
                 'pingcap/tidb-dashboard': '4Gi',
                 'pingcap/tiproxy': '16Gi',
                 'pingcap/tidb-operator': '8Gi',
+                'pingcap/ng-monitoring': '4Gi',
+                'pingcap/tidb-binlog': '32Gi',
+                'pingcap/tidb-tools': '16Gi',
                 'tikv/pd': '32Gi',
                 'tikv/tikv': '64Gi',
                 'tidbcloud/tiflash-cse': '64Gi',


### PR DESCRIPTION
This PR adds support for the following repositories to all fake-github triggers (branch-push, tag-create, PR, and single-platform):

- pingcap/ng-monitoring
- pingcap/tidb-binlog
- pingcap/tidb-tools

The overlays and filter lists now include these repos with the correct resource values based on their official triggers.

Also includes previous support for pingcap/tidb-operator overlays.

---

- Adds timeout, ws-size, CPU, and memory overlays for each repo
- Updates all relevant fake-github trigger YAMLs