### PR TITLE
fix(trigger): support pre-release tags with .pre suffix

### DIFF
--- a/apps/prod/tekton/configs/triggers/triggers/tikv/tikv/git-create-tag.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/tikv/tikv/git-create-tag.yaml
@@ -17,7 +17,7 @@ spec:
             &&
             body.repository.name == 'tikv'
             &&
-            body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+(-(alpha|beta|rc)([.][0-9]+)?)?$')
+            body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+(-(alpha|beta|rc)([.][0-9]+)?([.]pre)?)?$')
 
   bindings:
     - ref: github-tag-create


### PR DESCRIPTION
This PR updates the TiKV tag trigger regex pattern to support tags with `.pre` suffix (e.g., `v9.0.0-beta.2.pre`).

The updated regex pattern now properly matches tags like:
- v9.0.0-alpha.1.pre
- v9.0.0-beta.2.pre
- v9.0.0-rc.3.pre

This ensures that the CI/CD pipeline will be triggered correctly for these tag formats.