### PR TITLE
feat(prod2): add NFS PVC provisioner and update namespaces in prod2 infra

### DIFF
--- a/.ci/OWNERS
+++ b/.ci/OWNERS
@@ -1,7 +1,2 @@
-reviewers:
-  - purelind
-  - wuhuizuo
-approvers:
-  - wuhuizuo
 labels:
   - area/ci

--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,4 @@
-reviewers:
-  - purelind
 approvers:
-  - wuhuizuo
-
-emeritus_reviewers:
-  - lijie0123
+  - sig-root-approvers
+reviewers:
+  - sig-root-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,13 @@
+aliases:
+  # for whole repo.
+  sig-root-approvers:
+    - wuhuizuo
+  sig-root-reviewers:
+    - purelind
+
+  sig-apps-prod-approvers:
+    - purelind
+    - wuhuizuo
+
+  emeritus_reviewers:
+    - lijie0123

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,5 +9,5 @@ aliases:
     - purelind
     - wuhuizuo
 
-  emeritus_reviewers:
-    - lijie0123
+  # emeritus_reviewers:
+  #   - lijie0123

--- a/apps/OWNERS
+++ b/apps/OWNERS
@@ -1,6 +1,2 @@
-reviewers:
-  - purelind
-approvers:
-  - wuhuizuo
 labels:
   - area/apps

--- a/apps/prod2/kustomization.yaml
+++ b/apps/prod2/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources:
-  - coder
+resources: []
+  # - coder

--- a/charts/OWNERS
+++ b/charts/OWNERS
@@ -1,6 +1,2 @@
-reviewers:
-  - purelind
-approvers:
-  - wuhuizuo
 labels:
   - area/charts

--- a/clusters/OWNERS
+++ b/clusters/OWNERS
@@ -1,6 +1,2 @@
-reviewers:
-  - purelind
-approvers:
-  - wuhuizuo
 labels:
   - area/clusters

--- a/infrastructure/OWNERS
+++ b/infrastructure/OWNERS
@@ -1,6 +1,2 @@
-reviewers:
-  - purelind
-approvers:
-  - wuhuizuo
 labels:
   - area/infrastructure

--- a/infrastructure/prod2/OWNERS
+++ b/infrastructure/prod2/OWNERS
@@ -1,4 +1,2 @@
 labels:
   - env/prod2
-approvers:
-  - wuhuizuo

--- a/infrastructure/prod2/OWNERS
+++ b/infrastructure/prod2/OWNERS
@@ -1,2 +1,4 @@
 labels:
   - env/prod2
+approvers:
+  - wuhuizuo

--- a/infrastructure/prod2/kustomization.yaml
+++ b/infrastructure/prod2/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 resources:
   - ../_base
   - openebs
+  - nfs-pvc-provisioner
   - nginx
   - secret-generator

--- a/infrastructure/prod2/nfs-pvc-provisioner/kustomization.yaml
+++ b/infrastructure/prod2/nfs-pvc-provisioner/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: secret-generator
+namespace: nfs
 resources:
   - namespace.yaml
+  - pvc.yaml
   - release.yaml

--- a/infrastructure/prod2/nfs-pvc-provisioner/namespace.yaml
+++ b/infrastructure/prod2/nfs-pvc-provisioner/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nfs

--- a/infrastructure/prod2/nfs-pvc-provisioner/pvc.yaml
+++ b/infrastructure/prod2/nfs-pvc-provisioner/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nfs-server-provisioner-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+  storageClassName: openebs-3-replicas

--- a/infrastructure/prod2/nfs-pvc-provisioner/release.yaml
+++ b/infrastructure/prod2/nfs-pvc-provisioner/release.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: nfs-server-provisioner
 spec:
-  dependsOn: [{ name: openobs, namespace: openobs }]
+  dependsOn: [{ name: openebs, namespace: openebs }]
   chart:
     spec:
       chart: nfs-server-provisioner

--- a/infrastructure/prod2/nfs-pvc-provisioner/release.yaml
+++ b/infrastructure/prod2/nfs-pvc-provisioner/release.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://github.com/fluxcd-community/flux2-schemas/raw/refs/heads/main/helmrelease-helm-v2beta1.json
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: nfs-server-provisioner
+spec:
+  dependsOn: [{ name: openobs, namespace: openobs }]
+  chart:
+    spec:
+      chart: nfs-server-provisioner
+      sourceRef:
+        kind: HelmRepository
+        name: nfs-server-provisioner
+        namespace: flux-system
+      version: "1.8.0"
+  interval: 5m0s
+  install:
+    remediation:
+      retries: 3
+  values:
+    # Ref: https://github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner/tree/master/charts/nfs-server-provisioner
+    replicaCount: 2
+    image:
+      repository: registry.k8s.io/sig-storage/nfs-provisioner
+      tag: v4.0.8
+    persistence:
+      existingClaim: nfs-server-provisioner-claim
+    storageClass:
+      name: nfs
+      defaultClass: true
+      mountOptions: []
+    resources:
+      limits:
+        cpu: "1"
+        memory: 4Gi

--- a/infrastructure/prod2/nginx/kustomization.yaml
+++ b/infrastructure/prod2/nginx/kustomization.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: nginx
 resources:
   - namespace.yaml
   - release.yaml

--- a/infrastructure/prod2/nginx/release.yaml
+++ b/infrastructure/prod2/nginx/release.yaml
@@ -3,7 +3,6 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: ingress-nginx
-  namespace: nginx
 spec:
   releaseName: ingress-nginx
   targetNamespace: nginx

--- a/infrastructure/prod2/openebs/diskpools.yaml
+++ b/infrastructure/prod2/openebs/diskpools.yaml
@@ -2,7 +2,6 @@ apiVersion: "openebs.io/v1beta2"
 kind: DiskPool
 metadata:
   name: pool1-on-node-12-130
-  namespace: openebs
 spec:
   node: 10.2.12.130 # internal ip
   disks: ["aio:///dev/disk/by-id/nvme-eui.ace42e001637a9da"]
@@ -11,7 +10,6 @@ apiVersion: "openebs.io/v1beta2"
 kind: DiskPool
 metadata:
   name: pool2-on-node-12-130
-  namespace: openebs
 spec:
   node: 10.2.12.130 # internal ip
   disks: ["aio:///dev/disk/by-id/nvme-eui.ace42e001637a9dc"]
@@ -20,7 +18,6 @@ apiVersion: "openebs.io/v1beta2"
 kind: DiskPool
 metadata:
   name: pool3-on-node-12-130
-  namespace: openebs
 spec:
   node: 10.2.12.130 # internal ip
   disks: ["aio:///dev/disk/by-id/nvme-eui.ace42e001637a9d8"]
@@ -29,7 +26,6 @@ apiVersion: "openebs.io/v1beta2"
 kind: DiskPool
 metadata:
   name: pool1-on-node-13-34
-  namespace: openebs
 spec:
   node: 10.2.13.34 # internal ip
   disks: ["aio:///dev/disk/by-id/nvme-eui.01000000010000005cd2e47ab9905451"]
@@ -38,7 +34,6 @@ apiVersion: "openebs.io/v1beta2"
 kind: DiskPool
 metadata:
   name: pool2-on-node-13-34
-  namespace: openebs
 spec:
   node: 10.2.13.34 # internal ip
   disks: ["aio:///dev/disk/by-id/nvme-eui.01000000010000005cd2e4d5b8905451"]
@@ -47,7 +42,6 @@ apiVersion: "openebs.io/v1beta2"
 kind: DiskPool
 metadata:
   name: pool3-on-node-13-34
-  namespace: openebs
 spec:
   node: 10.2.13.34 # internal ip
   disks: ["aio:///dev/disk/by-id/nvme-eui.01000000010000005cd2e499b9905451"]
@@ -56,7 +50,6 @@ apiVersion: "openebs.io/v1beta2"
 kind: DiskPool
 metadata:
   name: pool1-on-node-14-108
-  namespace: openebs
 spec:
   node: 10.2.14.108 # internal ip
   disks: ["aio:///dev/disk/by-id/nvme-eui.01000000010000005cd2e43184935251"]
@@ -65,7 +58,6 @@ apiVersion: "openebs.io/v1beta2"
 kind: DiskPool
 metadata:
   name: pool2-on-node-14-108
-  namespace: openebs
 spec:
   node: 10.2.14.108 # internal ip
   disks: ["aio:///dev/disk/by-id/nvme-eui.01000000010000005cd2e4355a705451"]
@@ -74,7 +66,6 @@ apiVersion: "openebs.io/v1beta2"
 kind: DiskPool
 metadata:
   name: pool3-on-node-14-108
-  namespace: openebs
 spec:
   node: 10.2.14.108 # internal ip
   disks: ["aio:///dev/disk/by-id/nvme-eui.01000000010000005cd2e4a56d715451"]

--- a/infrastructure/prod2/openebs/release.yaml
+++ b/infrastructure/prod2/openebs/release.yaml
@@ -1,9 +1,8 @@
----
+# yaml-language-server: $schema=https://github.com/fluxcd-community/flux2-schemas/raw/refs/heads/main/helmrelease-helm-v2beta1.json
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: openebs
-  namespace: openebs
 spec:
   releaseName: openebs
   chart:
@@ -12,7 +11,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: openebs
-        namespace: openebs
       version: "4.2.0"
   interval: 10m0s
   install:

--- a/infrastructure/prod2/openebs/source.yaml
+++ b/infrastructure/prod2/openebs/source.yaml
@@ -3,7 +3,6 @@ apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
 metadata:
   name: openebs
-  namespace: openebs
 spec:
   interval: 30m
   url: https://openebs.github.io/openebs

--- a/infrastructure/prod2/secret-generator/release.yaml
+++ b/infrastructure/prod2/secret-generator/release.yaml
@@ -3,7 +3,6 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: secret-generator
-  namespace: secret-generator
 spec:
   chart:
     spec:


### PR DESCRIPTION
This pull request includes updates to ownership files and infrastructure configurations, with notable changes to the `OWNERS` structure and enhancements to Kubernetes resource definitions. The most significant updates involve restructuring ownership aliases, adding new resources for provisioning, and modifying namespace configurations for Helm releases.

### Ownership Updates:
* Restructured `OWNERS` and `OWNERS_ALIASES` files to introduce aliases for reviewers and approvers, such as `sig-root-approvers` and `sig-root-reviewers`. Emeritus reviewers were also added as aliases. (`[[1]](diffhunk://#diff-c393dd2b18a8a597d895940893e574d6895122c4bf3ce6e2a78dbd9ca0cdd66fL1-R4)`, `[[2]](diffhunk://#diff-4985b733677adf9dda6b5187397d4700868248ef646d64aecfb66c1ced575499R1-R13)`)
* Removed individual reviewer and approver assignments from various ownership files (`.ci/OWNERS`, `apps/OWNERS`, `charts/OWNERS`, `clusters/OWNERS`, `infrastructure/OWNERS`) while retaining labels for categorization. (`[[1]](diffhunk://#diff-ff1350fbe318607e416dbb6dec44e0362c5f0acc67561560633755ad856aa4ccL1-L5)`, `[[2]](diffhunk://#diff-b91b955930e64f546edc0198b32b341d981a755abfeb62d94b7faa86b2462658L1-L4)`, `[[3]](diffhunk://#diff-29397b20c2d5171675dd0c3aa29ee3ce07f63c79b28fd11c5690603a9cb5a588L1-L4)`, `[[4]](diffhunk://#diff-635092b509a3bb5c4e1e5c358da6d7e3d87e5e2028762cc34703df93a1bcc7c6L1-L4)`, `[[5]](diffhunk://#diff-6c0ecb3f5a610b88c785b06b772e3698d36fb8c56ab16224378a2dadeaaefbcfL1-L4)`)

### Infrastructure Enhancements:
* Added `nfs-pvc-provisioner` resource to `infrastructure/prod2/kustomization.yaml` and created its corresponding configuration files (`kustomization.yaml`, `namespace.yaml`, `pvc.yaml`, `release.yaml`) for provisioning NFS-based persistent volumes. (`[[1]](diffhunk://#diff-e014b6c5f90c7e7a092ac7b70e6f40f811e08108901cbf4755bed3996f714c6fR6)`, `[[2]](diffhunk://#diff-a6688663de194671462efe65b34a7ac16750a4d7646c15e3d9d8c3b538714d0eR1-R7)`, `[[3]](diffhunk://#diff-a048f40fb226070537e2fc7240f98996db04358e785aac62d674d579bf1828a5R1-R5)`, `[[4]](diffhunk://#diff-c99a3bad87c5daef248595397b1a8fa07505d1a6a9b08aaf94f2826688af16c8R1-R11)`, `[[5]](diffhunk://#diff-73d51a5ae18168d85c4d806076ee5e7fd69e44a88b87f23b7172b382206c1efdR1-R35)`)
* Updated `infrastructure/prod2/openebs/diskpools.yaml` to remove `namespace` fields from multiple `DiskPool` definitions, streamlining their configuration. (`[[1]](diffhunk://#diff-d001a6f0307a16b58dc81882379c0234d30330fa3d136df0b5afe435eb829251L5)`, `[[2]](diffhunk://#diff-d001a6f0307a16b58dc81882379c0234d30330fa3d136df0b5afe435eb829251L14)`, `[[3]](diffhunk://#diff-d001a6f0307a16b58dc81882379c0234d30330fa3d136df0b5afe435eb829251L23)`, `[[4]](diffhunk://#diff-d001a6f0307a16b58dc81882379c0234d30330fa3d136df0b5afe435eb829251L32)`, `[[5]](diffhunk://#diff-d001a6f0307a16b58dc81882379c0234d30330fa3d136df0b5afe435eb829251L41)`, `[[6]](diffhunk://#diff-d001a6f0307a16b58dc81882379c0234d30330fa3d136df0b5afe435eb829251L50)`, `[[7]](diffhunk://#diff-d001a6f0307a16b58dc81882379c0234d30330fa3d136df0b5afe435eb829251L59)`, `[[8]](diffhunk://#diff-d001a6f0307a16b58dc81882379c0234d30330fa3d136df0b5afe435eb829251L68)`, `[[9]](diffhunk://#diff-d001a6f0307a16b58dc81882379c0234d30330fa3d136df0b5afe435eb829251L77)`)
* Removed `namespace` fields from `HelmRelease` and `HelmRepository` definitions in `infrastructure/prod2/openebs/release.yaml` and `source.yaml`. (`[[1]](diffhunk://#diff-c2b8ebc9548b53a4eb28bf875a4ccadc9888c02152451fa25096659f71370798L1-L6)`, `[[2]](diffhunk://#diff-c2b8ebc9548b53a4eb28bf875a4ccadc9888c02152451fa25096659f71370798L15)`, `[[3]](diffhunk://#diff-77a5749653c550222f89630245ab9b59d39b23bd09e320122ccf586e0c3e6de8L6)`)

### Namespace Adjustments:
* Added `namespace` fields to `kustomization.yaml` files for `nginx`, `secret-generator`, and other resources to explicitly define their target namespaces. (`[[1]](diffhunk://#diff-61ac5d79f703562fac122f83acf4a7f414f142d841a9f803309c0b1dab45cb33R4)`, `[[2]](diffhunk://#diff-3cbaf93bbf88e1e8fe1036e5c13c0747f559903f81d7813d940fcf1b131cdb61R3)`)
* Removed redundant `namespace` fields from `HelmRelease` definitions for `nginx` and `secret-generator`. (`[[1]](diffhunk://#diff-9fd33c086546c48dd1c011c9ad1569b3ab87c98086fd523f10c47b99bddb8c35L6)`, `[[2]](diffhunk://#diff-724611891e3973761a69cae6a0f76345f6116f6d805cad1aae0408643d1481e6L6)`)