### PR TITLE
refactor(apps): move brc deployment from prod to prod2 and update config

### DIFF
--- a/apps/prod/kustomization.yaml
+++ b/apps/prod/kustomization.yaml
@@ -11,7 +11,6 @@ resources:
   - ats
   - goproxy
   - tekton
-  - brc
   - prow-worker
   - kafka
   - cloudevents-server

--- a/apps/prod2/brc/kustomization.yaml
+++ b/apps/prod2/brc/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: brc
 resources:
-  - pvc.yaml
+  - namespace.yaml
+  - pvc-cache.yaml
   - release.yaml

--- a/apps/prod2/brc/namespace.yaml
+++ b/apps/prod2/brc/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: brc
+  annotations:
+    scheduler.alpha.kubernetes.io/node-selector: kubernetes.io/arch=amd64

--- a/apps/prod2/brc/pvc-cache.yaml
+++ b/apps/prod2/brc/pvc-cache.yaml
@@ -1,13 +1,12 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: brc
-  namespace: apps
+  name: brc-cache
 spec:
-  storageClassName: ceph-block
+  accessModes:
+    - ReadWriteOnce
   resources:
     requests:
       storage: 1.1Ti
+  storageClassName: openebs-single-replica
   volumeMode: Filesystem
-  accessModes:
-    - ReadWriteOnce

--- a/apps/prod2/brc/release.yaml
+++ b/apps/prod2/brc/release.yaml
@@ -2,10 +2,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: brc
-  namespace: flux-system
 spec:
-  releaseName: brc
-  targetNamespace: apps
   chart:
     spec:
       chart: bazel-remote
@@ -25,23 +22,29 @@ spec:
     ignoreFailures: false
   values:
     image:
-      repository: buchgr/bazel-remote-cache
-      tag: v2.4.1
+      repository: quay.io/bazel-remote/bazel-remote
+      tag: v2.5.1
     podSecurityContext:
       fsGroup: 1000
     conf: |-
       # https://github.com/buchgr/bazel-remote#example-configuration-file
       dir: /data
-      max_size: 1000
+      max_size: 1000 # The maximum size of bazel-remote's disk cache in GiB.
       experimental_remote_asset_api: true
       access_log_level: all
-      port: 8080
-      grpc_port: 9092
+      http_address: ":8080"
+      grpc_address: ":9092"
+      #s3_proxy:
+      #  endpoint: ks3-endpoint:9000
+      #  bucket: test-bucket
+      #  prefix: test-prefix
+      #  disable_ssl: true
+      #  bucket_lookup_type: auto
     replicaCount: 1
     volumeMounts:
-    - mountPath: /data
-      name: brc-cache
+      - mountPath: /data
+        name: brc-cache
     volumes:
       - name: brc-cache
         persistentVolumeClaim:
-          claimName: brc
+          claimName: brc-cache

--- a/apps/prod2/kustomization.yaml
+++ b/apps/prod2/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../_base
-  - buildbarn
+  - buildbarn # experiment
+  - brc


### PR DESCRIPTION
The `brc` did not serviced for production, we can move it to cluster `prod2` safely.