### PR TITLE
feat(apps/prod2): add zot deployment manifests for prod2 environment

### DIFF
--- a/apps/prod2/zot/kustomization.yaml
+++ b/apps/prod2/zot/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: zot
+resources:
+  - namespace.yaml
+  - source.yaml
+  - redis-release.yaml
+  - release.yaml

--- a/apps/prod2/zot/namespace.yaml
+++ b/apps/prod2/zot/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: zot
+  annotations:
+    scheduler.alpha.kubernetes.io/node-selector: kubernetes.io/arch=amd64

--- a/apps/prod2/zot/redis-release.yaml
+++ b/apps/prod2/zot/redis-release.yaml
@@ -1,0 +1,22 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: redis
+spec:
+  chart:
+    spec:
+      chart: redis
+      version: 20.2.1
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: bitnami
+        namespace: flux-system
+  interval: 1h
+  values:
+    global:
+      storageClass: openebs-single-replica
+    master:
+      resourcesPreset: nano #  nano < micro < small < medium < large < xlarge < 2xlarge
+    replica:
+      resourcesPreset: nano

--- a/apps/prod2/zot/release.yaml
+++ b/apps/prod2/zot/release.yaml
@@ -1,0 +1,43 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: zot
+spec:
+  chart:
+    spec:
+      chart: zot
+      version: 0.1.74
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: project-zot
+  dependsOn:
+    - name: redis
+  interval: 1h
+  values:
+    mountSecrets: true
+    secretFiles: {} # We are in charge of managing it.
+    mountConfig: true
+    configFiles: {} # We are in charge of managing it.
+    ingress:
+      annotations:
+        kubernetes.io/tls-acme: "true"
+        nginx.ingress.kubernetes.io/proxy-body-size: "0"
+        nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+        nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+      className: nginx
+      enabled: true
+      hosts:
+        - host: hub-zot.pingcap.net
+          paths:
+            - path: /
+      pathtype: ImplementationSpecific
+    persistence: true
+    pvc:
+      accessMode: ReadWriteOnce
+      create: true
+      storage: 8Gi
+      storageClassName: openebs-3-replicas
+    replicaCount: 1
+    service:
+      type: ClusterIP

--- a/apps/prod2/zot/source.yaml
+++ b/apps/prod2/zot/source.yaml
@@ -1,0 +1,7 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: project-zot
+spec:
+  interval: 24h0m0s
+  url: http://zotregistry.dev/helm-charts


### PR DESCRIPTION
This pull request introduces configuration files for deploying the `zot` application in the `prod2` environment using Kubernetes and FluxCD. It includes the creation of a namespace, HelmRepository, and HelmRelease resources for `zot` and its dependency, `redis`. The changes ensure proper resource management, ingress configuration, and persistence settings for the application.

### Kubernetes Configuration:

* [`apps/prod2/zot/kustomization.yaml`](diffhunk://#diff-157989a6caf6e2e2f6ac034ed289e893a435f5b3fb5b60352dc1b01108c2c26dR1-R8): Added a `Kustomization` file to manage resources for the `zot` application, including namespace, source, and HelmRelease configurations.
* [`apps/prod2/zot/namespace.yaml`](diffhunk://#diff-29fee16c514bf40b4d83cef58d10ab9e9f91c666aa010b03b65b83dcff29cf34R1-R6): Created a `Namespace` resource named `zot` with annotations specifying node selector constraints for scheduling.

### HelmRepository Setup:

* [`apps/prod2/zot/source.yaml`](diffhunk://#diff-798ccfcd5255931424b37bf2446131fac91f19c6adc1a0604e26464e2656bc7bR1-R7): Defined a `HelmRepository` resource for `zot` with a URL pointing to the `zotregistry.dev` Helm charts repository and a sync interval of 24 hours.

### Application Deployment:

* [`apps/prod2/zot/release.yaml`](diffhunk://#diff-2e556271ae8b53b6860d3146c3fe9945eff9dec998cf654312fefee233672de8R1-R43): Configured a `HelmRelease` for the `zot` application, specifying chart details, dependencies (on `redis`), ingress settings, persistence options, and service type.

### Redis Dependency:

* [`apps/prod2/zot/redis-release.yaml`](diffhunk://#diff-db1e54e61b32d14b7989a1b231065be7ab5a2f162124704f24034be245115d83R1-R22): Added a `HelmRelease` for the `redis` dependency, with resource presets set to `nano` and storage class configured for single replica.