### PR TITLE
Only push tagged operator image

### DIFF
--- a/apps/prod/tekton/configs/triggers/triggers/_/harbor/image-push-on-harbor.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/harbor/image-push-on-harbor.yaml
@@ -54,7 +54,7 @@ spec:
             (
             body.event_data.repository.repo_full_name.matches('^pingcap/tidb-operator/')
             &&
-            body.event_data.resources[0].tag.matches('^v2[.][0-9]+[.][0-9]+')
+            body.event_data.resources[0].tag.matches('^v2[.][0-9]+[.][0-9]+(-(alpha|beta)[.][0-9]+)?$')
             )
             ||
             (


### PR DESCRIPTION
Only support
- alpha version: e.g. v2.0.0-alpha.1
- beta version: e.g. v2.0.0-beta.2
- stable version: e.g. v2.0.1