### PR TITLE
refactor(apps/prod, apps/gcp): update Tekton templates to use tasks timeout param

### DIFF
--- a/apps/gcp/tekton/configs/triggers/templates/_/build-component-all-platforms.yaml
+++ b/apps/gcp/tekton/configs/triggers/templates/_/build-component-all-platforms.yaml
@@ -87,7 +87,7 @@ spec:
               nodeSelector:
                 kubernetes.io/arch: amd64
         timeouts:
-          pipeline: $(tt.params.timeout)
+          tasks: $(tt.params.timeout)
         workspaces:
           - name: dockerconfig
             secret:
@@ -162,7 +162,7 @@ spec:
               nodeSelector:
                 kubernetes.io/arch: arm64
         timeouts:
-          pipeline: $(tt.params.timeout)
+          tasks: $(tt.params.timeout)
         workspaces:
           - name: dockerconfig
             secret:
@@ -224,7 +224,7 @@ spec:
           - name: boskos-server-url
             value: http://boskos.apps.svc
         timeouts:
-          pipeline: $(tt.params.timeout)
+          tasks: $(tt.params.timeout)
         workspaces:
           - name: dockerconfig
             secret:
@@ -283,7 +283,7 @@ spec:
           - name: boskos-server-url
             value: http://boskos.apps.svc
         timeouts:
-          pipeline: $(tt.params.timeout)
+          tasks: $(tt.params.timeout)
         workspaces:
           - name: dockerconfig
             secret:

--- a/apps/gcp/tekton/configs/triggers/templates/_/build-component-single-platform.yaml
+++ b/apps/gcp/tekton/configs/triggers/templates/_/build-component-single-platform.yaml
@@ -93,7 +93,7 @@ spec:
               nodeSelector:
                 kubernetes.io/arch: $(tt.params.arch)
         timeouts:
-          pipeline: $(tt.params.timeout)
+          tasks: $(tt.params.timeout)
         workspaces:
           - name: dockerconfig
             secret:

--- a/apps/gcp/tekton/configs/triggers/templates/_/build-component.yaml
+++ b/apps/gcp/tekton/configs/triggers/templates/_/build-component.yaml
@@ -33,7 +33,7 @@ spec:
       default: "4"
     - name: ce-context
       description: cloud event context.
-      default: '{}'
+      default: "{}"
   resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
@@ -85,7 +85,7 @@ spec:
               nodeSelector:
                 kubernetes.io/arch: amd64
         timeouts:
-          pipeline: $(tt.params.timeout)
+          tasks: $(tt.params.timeout)
         workspaces:
           - name: dockerconfig
             secret:
@@ -158,7 +158,7 @@ spec:
               nodeSelector:
                 kubernetes.io/arch: arm64
         timeouts:
-          pipeline: $(tt.params.timeout)
+          tasks: $(tt.params.timeout)
         workspaces:
           - name: dockerconfig
             secret:

--- a/apps/prod/tekton/configs/triggers/templates/_/build-component-all-platforms.yaml
+++ b/apps/prod/tekton/configs/triggers/templates/_/build-component-all-platforms.yaml
@@ -87,7 +87,7 @@ spec:
               nodeSelector:
                 kubernetes.io/arch: amd64
         timeouts:
-          pipeline: $(tt.params.timeout)
+          tasks: $(tt.params.timeout)
         workspaces:
           - name: dockerconfig
             secret:
@@ -162,7 +162,7 @@ spec:
               nodeSelector:
                 kubernetes.io/arch: arm64
         timeouts:
-          pipeline: $(tt.params.timeout)
+          tasks: $(tt.params.timeout)
         workspaces:
           - name: dockerconfig
             secret:
@@ -224,7 +224,7 @@ spec:
           - name: boskos-server-url
             value: http://boskos.apps.svc
         timeouts:
-          pipeline: $(tt.params.timeout)
+          tasks: $(tt.params.timeout)
         workspaces:
           - name: dockerconfig
             secret:
@@ -283,7 +283,7 @@ spec:
           - name: boskos-server-url
             value: http://boskos.apps.svc
         timeouts:
-          pipeline: $(tt.params.timeout)
+          tasks: $(tt.params.timeout)
         workspaces:
           - name: dockerconfig
             secret:

--- a/apps/prod/tekton/configs/triggers/templates/_/build-component-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/templates/_/build-component-single-platform.yaml
@@ -93,7 +93,7 @@ spec:
               nodeSelector:
                 kubernetes.io/arch: $(tt.params.arch)
         timeouts:
-          pipeline: $(tt.params.timeout)
+          tasks: $(tt.params.timeout)
         workspaces:
           - name: dockerconfig
             secret:

--- a/apps/prod/tekton/configs/triggers/templates/_/build-component.yaml
+++ b/apps/prod/tekton/configs/triggers/templates/_/build-component.yaml
@@ -33,7 +33,7 @@ spec:
       default: "4"
     - name: ce-context
       description: cloud event context.
-      default: '{}'
+      default: "{}"
   resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
@@ -85,7 +85,7 @@ spec:
               nodeSelector:
                 kubernetes.io/arch: amd64
         timeouts:
-          pipeline: $(tt.params.timeout)
+          tasks: $(tt.params.timeout)
         workspaces:
           - name: dockerconfig
             secret:
@@ -158,7 +158,7 @@ spec:
               nodeSelector:
                 kubernetes.io/arch: arm64
         timeouts:
-          pipeline: $(tt.params.timeout)
+          tasks: $(tt.params.timeout)
         workspaces:
           - name: dockerconfig
             secret:

--- a/apps/prod/tekton/configs/triggers/templates/_/ctl/build-component-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/templates/_/ctl/build-component-single-platform.yaml
@@ -91,7 +91,7 @@ spec:
               nodeSelector:
                 kubernetes.io/arch: $(tt.params.arch)
         timeouts:
-          pipeline: $(tt.params.timeout)
+          tasks: $(tt.params.timeout)
         workspaces:
           - name: dockerconfig
             secret:


### PR DESCRIPTION

Ref:
https://github.com/tektoncd/pipeline/blob/v0.39.0/docs/pipelineruns.md#configuring-a-failure-timeout