### PR TITLE
fix(apps/gcp/tekton/configs): switch from workspace for auth to service account methods

### DIFF
--- a/apps/gcp/tekton/configs/kustomization.yaml
+++ b/apps/gcp/tekton/configs/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: ee-cd
 resources:
   - namespace.yaml
+  - rbac
   - tasks
-  - pipelines
   - triggers
+  - pipelines

--- a/apps/gcp/tekton/configs/pipelines/kaniko-build.yaml
+++ b/apps/gcp/tekton/configs/pipelines/kaniko-build.yaml
@@ -56,8 +56,6 @@ spec:
       workspaces:
         - name: source
           workspace: git-source
-        - name: dockerconfig
-          workspace: dockerconfig
     - name: build-arm64
       runAfter:
         - fetch-from-git
@@ -77,8 +75,6 @@ spec:
       workspaces:
         - name: source
           workspace: git-source
-        - name: dockerconfig
-          workspace: dockerconfig
     - name: mult-arch-push
       runAfter:
         - "build-amd64"
@@ -94,10 +90,5 @@ spec:
           value:
             - linux/amd64 => $(tasks.build-amd64.results.IMAGE_DIGEST)
             - linux/arm64 => $(tasks.build-arm64.results.IMAGE_DIGEST)
-      workspaces:
-        - name: dockerconfig
-          workspace: dockerconfig
   workspaces:
     - name: git-source
-    - name: dockerconfig # contains file: config.json
-      optional: true

--- a/apps/gcp/tekton/configs/pipelines/pingcap-build-package-darwin.yaml
+++ b/apps/gcp/tekton/configs/pipelines/pingcap-build-package-darwin.yaml
@@ -60,9 +60,6 @@ spec:
       description: The workspace where the git repo will be cloned.
     - name: dockerconfig
       description: Includes a docker `config.json`
-    - name: git-basic-auth
-      description: secret containing a .gitconfig and .git-credentials file.
-      optional: true
     - name: mac-ssh-credentials
       description: secret contains ssh private key in `id_rsa` key for login mac
   tasks:
@@ -84,8 +81,6 @@ spec:
       workspaces:
         - name: output
           workspace: source
-        - name: basic-auth
-          workspace: git-basic-auth
     - name: checkout-ext
       runAfter:
         - checkout
@@ -101,8 +96,6 @@ spec:
       workspaces:
         - name: output
           workspace: source
-        - name: basic-auth
-          workspace: git-basic-auth
     - name: get-release-ver
       runAfter:
         - checkout

--- a/apps/gcp/tekton/configs/pipelines/pingcap-build-package-darwin.yaml
+++ b/apps/gcp/tekton/configs/pipelines/pingcap-build-package-darwin.yaml
@@ -58,8 +58,6 @@ spec:
   workspaces:
     - name: source
       description: The workspace where the git repo will be cloned.
-    - name: dockerconfig
-      description: Includes a docker `config.json`
     - name: mac-ssh-credentials
       description: secret contains ssh private key in `id_rsa` key for login mac
   tasks:
@@ -154,8 +152,6 @@ spec:
       workspaces:
         - name: source
           workspace: source
-        - name: dockerconfig
-          workspace: dockerconfig
         - name: ssh-directory
           workspace: mac-ssh-credentials
     - name: build-images

--- a/apps/gcp/tekton/configs/pipelines/pingcap-build-package-linux.yaml
+++ b/apps/gcp/tekton/configs/pipelines/pingcap-build-package-linux.yaml
@@ -57,9 +57,6 @@ spec:
       description: The workspace where the git repo will be cloned.
     - name: dockerconfig
       description: Includes a docker `config.json`
-    - name: git-basic-auth
-      description: secret containing a .gitconfig and .git-credentials file.
-      optional: true
     - name: cargo-home
       description: cache for cargo packages when build binaries
       optional: true
@@ -85,8 +82,6 @@ spec:
       workspaces:
         - name: output
           workspace: source
-        - name: basic-auth
-          workspace: git-basic-auth
     - name: checkout-ext
       runAfter:
         - checkout
@@ -102,8 +97,6 @@ spec:
       workspaces:
         - name: output
           workspace: source
-        - name: basic-auth
-          workspace: git-basic-auth
     - name: get-release-ver
       runAfter:
         - checkout

--- a/apps/gcp/tekton/configs/pipelines/pingcap-build-package-linux.yaml
+++ b/apps/gcp/tekton/configs/pipelines/pingcap-build-package-linux.yaml
@@ -55,8 +55,6 @@ spec:
   workspaces:
     - name: source
       description: The workspace where the git repo will be cloned.
-    - name: dockerconfig
-      description: Includes a docker `config.json`
     - name: cargo-home
       description: cache for cargo packages when build binaries
       optional: true
@@ -153,8 +151,6 @@ spec:
       workspaces:
         - name: source
           workspace: source
-        - name: dockerconfig
-          workspace: dockerconfig
         - name: cargo-home
           workspace: cargo-home
         - name: cypress-cache
@@ -193,5 +189,3 @@ spec:
       workspaces:
         - name: source
           workspace: source
-        - name: dockerconfig
-          workspace: dockerconfig

--- a/apps/gcp/tekton/configs/rbac/github-bot.yaml
+++ b/apps/gcp/tekton/configs/rbac/github-bot.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: github-bot
+secrets:
+  - name: github-pat-secret

--- a/apps/gcp/tekton/configs/rbac/kustomization.yaml
+++ b/apps/gcp/tekton/configs/rbac/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - github-bot.yaml
+  - releaser.yaml

--- a/apps/gcp/tekton/configs/rbac/releaser.yaml
+++ b/apps/gcp/tekton/configs/rbac/releaser.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: image-releaser
+secrets:
+  - name: image-release-cred

--- a/apps/gcp/tekton/configs/tasks/multi-arch-image-push.yaml
+++ b/apps/gcp/tekton/configs/tasks/multi-arch-image-push.yaml
@@ -58,8 +58,3 @@ spec:
         - mountPath: /workspace
           name: manifest
       workingDir: /workspace
-  workspaces:
-    - description: Includes a docker `config.json`
-      mountPath: /root/.docker
-      name: dockerconfig
-      optional: true

--- a/apps/gcp/tekton/configs/tasks/pingcap-build-binaries-darwin.yaml
+++ b/apps/gcp/tekton/configs/tasks/pingcap-build-binaries-darwin.yaml
@@ -12,10 +12,6 @@ spec:
   workspaces:
     - name: source
       description: source code.
-    - name: dockerconfig
-      description: Includes a docker `config.json`
-      mountPath: /root/.docker
-      optional: true
     - name: ssh-directory
       description: ssh credential for remote building on mac.
   results:

--- a/apps/gcp/tekton/configs/tasks/pingcap-build-binaries-linux.yaml
+++ b/apps/gcp/tekton/configs/tasks/pingcap-build-binaries-linux.yaml
@@ -12,10 +12,6 @@ spec:
   workspaces:
     - name: source
       description: source code.
-    - name: dockerconfig
-      description: Includes a docker `config.json`
-      mountPath: /root/.docker
-      optional: true
     - name: cargo-home
       description: Cache for cargo packages.
       mountPath: /workspace/.cargo

--- a/apps/gcp/tekton/configs/tasks/pingcap-build-images.yaml
+++ b/apps/gcp/tekton/configs/tasks/pingcap-build-images.yaml
@@ -11,10 +11,6 @@ spec:
     This task builds images for pingcap components.
   workspaces:
     - name: source
-    - name: dockerconfig
-      description: Includes a docker `config.json`
-      mountPath: /kaniko/.docker
-      optional: true
   results:
     - description: Just built and pushed images, it will be a yaml content.
       name: pushed
@@ -111,5 +107,4 @@ spec:
         fi
 
         oras version
-        cp -r $(workspaces.dockerconfig.path) ~/.docker # need the credentials.
         "$script" -P -t || true # -P means disable build and push the image.

--- a/apps/gcp/tekton/configs/triggers/templates/_/build-component-all-platforms.yaml
+++ b/apps/gcp/tekton/configs/triggers/templates/_/build-component-all-platforms.yaml
@@ -72,6 +72,10 @@ spec:
           - name: force-builder-image
             value: $(tt.params.force-builder-image)
         taskRunSpecs:
+          - pipelineTaskName: checkout
+            taskServiceAccountName: github-bot
+          - pipelineTaskName: checkout-ext
+            taskServiceAccountName: github-bot
           - pipelineTaskName: build-binaries
             taskPodTemplate:
               nodeSelector:
@@ -147,6 +151,10 @@ spec:
           - name: force-builder-image
             value: $(tt.params.force-builder-image)
         taskRunSpecs:
+          - pipelineTaskName: checkout
+            taskServiceAccountName: github-bot
+          - pipelineTaskName: checkout-ext
+            taskServiceAccountName: github-bot
           - pipelineTaskName: build-binaries
             taskPodTemplate:
               nodeSelector:

--- a/apps/gcp/tekton/configs/triggers/templates/_/build-component-all-platforms.yaml
+++ b/apps/gcp/tekton/configs/triggers/templates/_/build-component-all-platforms.yaml
@@ -77,6 +77,7 @@ spec:
           - pipelineTaskName: checkout-ext
             taskServiceAccountName: github-bot
           - pipelineTaskName: build-binaries
+            taskServiceAccountName: image-releaser
             taskPodTemplate:
               nodeSelector:
                 kubernetes.io/arch: amd64
@@ -87,15 +88,13 @@ spec:
                     memory: $(tt.params.builder-resources-memory)
                     cpu: $(tt.params.builder-resources-cpu)
           - pipelineTaskName: build-images
+            taskServiceAccountName: image-releaser
             taskPodTemplate:
               nodeSelector:
                 kubernetes.io/arch: amd64
         timeouts:
           tasks: $(tt.params.timeout)
         workspaces:
-          - name: dockerconfig
-            secret:
-              secretName: hub-pingcap-net-ee
           - name: source
             volumeClaimTemplate:
               spec:
@@ -156,6 +155,7 @@ spec:
           - pipelineTaskName: checkout-ext
             taskServiceAccountName: github-bot
           - pipelineTaskName: build-binaries
+            taskServiceAccountName: image-releaser
             taskPodTemplate:
               nodeSelector:
                 kubernetes.io/arch: arm64
@@ -166,15 +166,13 @@ spec:
                     memory: $(tt.params.builder-resources-memory)
                     cpu: $(tt.params.builder-resources-cpu)
           - pipelineTaskName: build-images
+            taskServiceAccountName: image-releaser
             taskPodTemplate:
               nodeSelector:
                 kubernetes.io/arch: arm64
         timeouts:
           tasks: $(tt.params.timeout)
         workspaces:
-          - name: dockerconfig
-            secret:
-              secretName: hub-pingcap-net-ee
           - name: source
             volumeClaimTemplate:
               spec:
@@ -234,9 +232,6 @@ spec:
         timeouts:
           tasks: $(tt.params.timeout)
         workspaces:
-          - name: dockerconfig
-            secret:
-              secretName: hub-pingcap-net-ee
           - name: source
             volumeClaimTemplate:
               spec:
@@ -293,9 +288,6 @@ spec:
         timeouts:
           tasks: $(tt.params.timeout)
         workspaces:
-          - name: dockerconfig
-            secret:
-              secretName: hub-pingcap-net-ee
           - name: source
             volumeClaimTemplate:
               spec:

--- a/apps/gcp/tekton/configs/triggers/templates/_/build-component-single-platform.yaml
+++ b/apps/gcp/tekton/configs/triggers/templates/_/build-component-single-platform.yaml
@@ -83,6 +83,7 @@ spec:
           - pipelineTaskName: checkout-ext
             taskServiceAccountName: github-bot
           - pipelineTaskName: build-binaries
+            taskServiceAccountName: image-releaser
             taskPodTemplate:
               nodeSelector:
                 kubernetes.io/arch: $(tt.params.arch)
@@ -93,15 +94,13 @@ spec:
                     memory: $(tt.params.builder-resources-memory)
                     cpu: $(tt.params.builder-resources-cpu)
           - pipelineTaskName: build-images
+            taskServiceAccountName: image-releaser
             taskPodTemplate:
               nodeSelector:
                 kubernetes.io/arch: $(tt.params.arch)
         timeouts:
           tasks: $(tt.params.timeout)
         workspaces:
-          - name: dockerconfig
-            secret:
-              secretName: hub-pingcap-net-ee
           - name: source
             volumeClaimTemplate:
               spec:

--- a/apps/gcp/tekton/configs/triggers/templates/_/build-component-single-platform.yaml
+++ b/apps/gcp/tekton/configs/triggers/templates/_/build-component-single-platform.yaml
@@ -78,6 +78,10 @@ spec:
           - name: boskos-server-url # for darwin platforms
             value: http://boskos.apps.svc
         taskRunSpecs:
+          - pipelineTaskName: checkout
+            taskServiceAccountName: github-bot
+          - pipelineTaskName: checkout-ext
+            taskServiceAccountName: github-bot
           - pipelineTaskName: build-binaries
             taskPodTemplate:
               nodeSelector:

--- a/apps/gcp/tekton/configs/triggers/templates/_/build-component.yaml
+++ b/apps/gcp/tekton/configs/triggers/templates/_/build-component.yaml
@@ -70,6 +70,10 @@ spec:
           - name: registry
             value: $(tt.params.registry)
         taskRunSpecs:
+          - pipelineTaskName: checkout
+            taskServiceAccountName: github-bot
+          - pipelineTaskName: checkout-ext
+            taskServiceAccountName: github-bot
           - pipelineTaskName: build-binaries
             taskPodTemplate:
               nodeSelector:
@@ -143,6 +147,10 @@ spec:
           - name: registry
             value: $(tt.params.registry)
         taskRunSpecs:
+          - pipelineTaskName: checkout
+            taskServiceAccountName: github-bot
+          - pipelineTaskName: checkout-ext
+            taskServiceAccountName: github-bot
           - pipelineTaskName: build-binaries
             taskPodTemplate:
               nodeSelector:

--- a/apps/gcp/tekton/configs/triggers/templates/_/build-component.yaml
+++ b/apps/gcp/tekton/configs/triggers/templates/_/build-component.yaml
@@ -75,6 +75,7 @@ spec:
           - pipelineTaskName: checkout-ext
             taskServiceAccountName: github-bot
           - pipelineTaskName: build-binaries
+            taskServiceAccountName: image-releaser
             taskPodTemplate:
               nodeSelector:
                 kubernetes.io/arch: amd64
@@ -85,15 +86,13 @@ spec:
                     memory: $(tt.params.builder-resources-memory)
                     cpu: $(tt.params.builder-resources-cpu)
           - pipelineTaskName: build-images
+            taskServiceAccountName: image-releaser
             taskPodTemplate:
               nodeSelector:
                 kubernetes.io/arch: amd64
         timeouts:
           tasks: $(tt.params.timeout)
         workspaces:
-          - name: dockerconfig
-            secret:
-              secretName: hub-pingcap-net-ee
           - name: source
             volumeClaimTemplate:
               spec:
@@ -152,6 +151,7 @@ spec:
           - pipelineTaskName: checkout-ext
             taskServiceAccountName: github-bot
           - pipelineTaskName: build-binaries
+            taskServiceAccountName: image-releaser
             taskPodTemplate:
               nodeSelector:
                 kubernetes.io/arch: arm64
@@ -162,15 +162,13 @@ spec:
                     memory: $(tt.params.builder-resources-memory)
                     cpu: $(tt.params.builder-resources-cpu)
           - pipelineTaskName: build-images
+            taskServiceAccountName: image-releaser
             taskPodTemplate:
               nodeSelector:
                 kubernetes.io/arch: arm64
         timeouts:
           tasks: $(tt.params.timeout)
         workspaces:
-          - name: dockerconfig
-            secret:
-              secretName: hub-pingcap-net-ee
           - name: source
             volumeClaimTemplate:
               spec:

--- a/infrastructure/prod2/openebs/test.yaml.example
+++ b/infrastructure/prod2/openebs/test.yaml.example
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ms-volume-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: openebs-3-replicas
+---
+kind: Pod
+apiVersion: v1
+metadata:
+  name: fio
+spec:
+  volumes:
+    - name: ms-volume
+      persistentVolumeClaim:
+        claimName: ms-volume-claim
+  containers:
+    - name: fio
+      image: nixery.dev/shell/fio
+      args:
+        - sleep
+        - "1000000"
+      volumeMounts:
+        - mountPath: "/volume"
+          name: ms-volume


### PR DESCRIPTION
This pull request includes significant updates to streamline Tekton pipeline configurations by removing unused `dockerconfig` and `git-basic-auth` workspaces, introducing new service accounts for specific tasks, and adding new resources for persistent storage and testing. Below is a breakdown of the most important changes:

### Removal of Unused Workspaces
* Removed `dockerconfig` and `git-basic-auth` workspaces across multiple pipeline and task configurations, simplifying workspace definitions and reducing unnecessary dependencies (`kaniko-build.yaml`, `pingcap-build-package-darwin.yaml`, `pingcap-build-package-linux.yaml`, `pingcap-build-images.yaml`, `multi-arch-image-push.yaml`, `pingcap-build-binaries-darwin.yaml`, `pingcap-build-binaries-linux.yaml`). [[1]](diffhunk://#diff-877a19ef785347957bbb69c668434e081b7801dceab412638f1a7d69f75a3e9aL59-L60) [[2]](diffhunk://#diff-d8b985bb66da67a58727588fa8751124c1c9e2d301b9c3abbdb9840d6c29101fL61-L65) [[3]](diffhunk://#diff-5af63616e73a4772a327a23b39843d5bf918b820f55da9b276f92c7990773533L58-L62) [[4]](diffhunk://#diff-7ed72d4c82b84f25675e4ce9df8db5b5960c67332e5f98b0164ba136cf8a1366L61-L65) [[5]](diffhunk://#diff-a09c39ae10681e079c7eb53b981261a1abd64e07e7342660568dc42818f77764L15-L18) [[6]](diffhunk://#diff-67b8e3c7fc78c4dc29be7871e7c87204d5f8e0861f4f48ddcc2b6482f9c3870cL15-L18) [[7]](diffhunk://#diff-441a28f898ce8d8c7d589ac267c0f029009faf4de62296fb55fd577410f1c44dL14-L17)

### Introduction of New Service Accounts
* Added `github-bot` and `image-releaser` service accounts for specific tasks in the pipeline, improving security and task isolation (`github-bot.yaml`, `releaser.yaml`, `build-component-all-platforms.yaml`, `build-component-single-platform.yaml`, `build-component.yaml`). [[1]](diffhunk://#diff-b67007809168d98cba0f567a82bbe6c6edbbee2cf57abc183d82e4972358e81dR1-R6) [[2]](diffhunk://#diff-592d0032e6594dad709d6f781b5176d89bc798005595d2fcce6a73d42a5372b9R1-R6) [[3]](diffhunk://#diff-7eb8a56490fe2a18d7d5d23a2b9583f4c962967a7739af3ec995e79774e6bf83R75-R80) [[4]](diffhunk://#diff-ec3462ad01bb25a6b9c90ab9b45e5678e5dafdfd72e44896adc1b258b8d9c7beR81-R86) [[5]](diffhunk://#diff-4d309818f51c59def3b6c76965ed34a2ebf8e79a392c3f4de9414f5ad40c0188R73-R78)

### Updates to Kustomization Resources
* Updated `kustomization.yaml` to include new resources such as `rbac` and reordered pipelines for better organization (`apps/gcp/tekton/configs/kustomization.yaml`).

### Addition of Persistent Storage Resource
* Added a new example configuration for a PersistentVolumeClaim and a test pod using OpenEBS for storage testing (`test.yaml.example`).

### Cleanup of Deprecated Secrets
* Removed references to deprecated secrets (`hub-pingcap-net-ee`) from trigger templates, further simplifying configurations (`build-component-all-platforms.yaml`, `build-component-single-platform.yaml`, `build-component.yaml`). [[1]](diffhunk://#diff-7eb8a56490fe2a18d7d5d23a2b9583f4c962967a7739af3ec995e79774e6bf83R91-L94) [[2]](diffhunk://#diff-ec3462ad01bb25a6b9c90ab9b45e5678e5dafdfd72e44896adc1b258b8d9c7beR97-L100) [[3]](diffhunk://#diff-4d309818f51c59def3b6c76965ed34a2ebf8e79a392c3f4de9414f5ad40c0188R89-L92)

These changes collectively aim to enhance the maintainability, security, and efficiency of the Tekton pipeline configurations.