### PR TITLE
fix(apps/gcp/tekton/configs): comment out unused volume and secret mounts in trigger templates

### DIFF
--- a/apps/gcp/tekton/configs/triggers/templates/_/build-component-all-platforms.yaml
+++ b/apps/gcp/tekton/configs/triggers/templates/_/build-component-all-platforms.yaml
@@ -104,15 +104,15 @@ spec:
                 resources:
                   requests:
                     storage: $(tt.params.source-ws-size)
-          - name: git-basic-auth # fetch with git-cdn.
-            secret:
-              secretName: git-credentials-basic
-          - name: cargo-home
-            persistentVolumeClaim:
-              claimName: cargo-home
-          - name: cypress-cache
-            persistentVolumeClaim:
-              claimName: cypress-cache
+          # - name: git-basic-auth # fetch with git-cdn.
+          #   secret:
+          #     secretName: git-credentials-basic
+          # - name: cargo-home
+          #   persistentVolumeClaim:
+          #     claimName: cargo-home
+          # - name: cypress-cache
+          #   persistentVolumeClaim:
+          #     claimName: cypress-cache
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
       metadata:
@@ -182,15 +182,15 @@ spec:
                 resources:
                   requests:
                     storage: $(tt.params.source-ws-size)
-          - name: git-basic-auth # fetch with git-cdn.
-            secret:
-              secretName: git-credentials-basic
-          - name: cargo-home
-            persistentVolumeClaim:
-              claimName: cargo-home
-          - name: cypress-cache
-            persistentVolumeClaim:
-              claimName: cypress-cache
+          # - name: git-basic-auth # fetch with git-cdn.
+          #   secret:
+          #     secretName: git-credentials-basic
+          # - name: cargo-home
+          #   persistentVolumeClaim:
+          #     claimName: cargo-home
+          # - name: cypress-cache
+          #   persistentVolumeClaim:
+          #     claimName: cypress-cache
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
       metadata:
@@ -241,9 +241,9 @@ spec:
                 resources:
                   requests:
                     storage: $(tt.params.source-ws-size)
-          - name: git-basic-auth # fetch with git-cdn.
-            secret:
-              secretName: git-credentials-basic
+          # - name: git-basic-auth # fetch with git-cdn.
+          #   secret:
+          #     secretName: git-credentials-basic
           - name: mac-ssh-credentials
             secret:
               secretName: mac-ssh-credentials
@@ -297,9 +297,9 @@ spec:
                 resources:
                   requests:
                     storage: $(tt.params.source-ws-size)
-          - name: git-basic-auth # fetch with git-cdn.
-            secret:
-              secretName: git-credentials-basic
+          # - name: git-basic-auth # fetch with git-cdn.
+          #   secret:
+          #     secretName: git-credentials-basic
           - name: mac-ssh-credentials
             secret:
               secretName: mac-ssh-credentials

--- a/apps/gcp/tekton/configs/triggers/templates/_/build-component-single-platform.yaml
+++ b/apps/gcp/tekton/configs/triggers/templates/_/build-component-single-platform.yaml
@@ -110,15 +110,15 @@ spec:
                 resources:
                   requests:
                     storage: $(tt.params.source-ws-size)
-          - name: git-basic-auth # fetch with git-cdn.
-            secret:
-              secretName: git-credentials-basic
-          - name: cargo-home # for linux platforms
-            persistentVolumeClaim:
-              claimName: cargo-home
-          - name: cypress-cache # for linux platforms
-            persistentVolumeClaim:
-              claimName: cypress-cache
+          # - name: git-basic-auth # fetch with git-cdn.
+          #   secret:
+          #     secretName: git-credentials-basic
+          # - name: cargo-home # for linux platforms
+          #   persistentVolumeClaim:
+          #     claimName: cargo-home
+          # - name: cypress-cache # for linux platforms
+          #   persistentVolumeClaim:
+          #     claimName: cypress-cache
           - name: mac-ssh-credentials # for darwin platforms
             secret:
               secretName: mac-ssh-credentials

--- a/apps/gcp/tekton/configs/triggers/templates/_/build-component.yaml
+++ b/apps/gcp/tekton/configs/triggers/templates/_/build-component.yaml
@@ -102,15 +102,15 @@ spec:
                 resources:
                   requests:
                     storage: $(tt.params.source-ws-size)
-          - name: git-basic-auth # fetch with git-cdn.
-            secret:
-              secretName: git-credentials-basic
-          - name: cargo-home
-            persistentVolumeClaim:
-              claimName: cargo-home
-          - name: cypress-cache
-            persistentVolumeClaim:
-              claimName: cypress-cache
+          # - name: git-basic-auth # fetch with git-cdn.
+          #   secret:
+          #     secretName: git-credentials-basic
+          # - name: cargo-home
+          #   persistentVolumeClaim:
+          #     claimName: cargo-home
+          # - name: cypress-cache
+          #   persistentVolumeClaim:
+          #     claimName: cypress-cache
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
       metadata:
@@ -178,12 +178,12 @@ spec:
                 resources:
                   requests:
                     storage: $(tt.params.source-ws-size)
-          - name: git-basic-auth # fetch with git-cdn.
-            secret:
-              secretName: git-credentials-basic
-          - name: cargo-home
-            persistentVolumeClaim:
-              claimName: cargo-home
-          - name: cypress-cache
-            persistentVolumeClaim:
-              claimName: cypress-cache
+          # - name: git-basic-auth # fetch with git-cdn.
+          #   secret:
+          #     secretName: git-credentials-basic
+          # - name: cargo-home
+          #   persistentVolumeClaim:
+          #     claimName: cargo-home
+          # - name: cypress-cache
+          #   persistentVolumeClaim:
+          #     claimName: cypress-cache

--- a/apps/gcp/tekton/configs/triggers/templates/tikv/tikv/bump-tikv-cargo-pkg-version.yaml
+++ b/apps/gcp/tekton/configs/triggers/templates/tikv/tikv/bump-tikv-cargo-pkg-version.yaml
@@ -29,6 +29,6 @@ spec:
           - name: github
             secret:
               secretName: github
-          - name: cargo-home
-            persistentVolumeClaim:
-              claimName: cargo-home
+          # - name: cargo-home
+          #   persistentVolumeClaim:
+          #     claimName: cargo-home


### PR DESCRIPTION
This pull request primarily comments out several resource configurations across multiple Tekton pipeline YAML files. These changes appear to temporarily disable the use of specific secrets and persistent volume claims, such as `git-basic-auth`, `cargo-home`, and `cypress-cache`, while leaving them in the files for potential future use. Below is a categorized summary of the most important changes:

### Commenting Out Resource Configurations:

* In `apps/gcp/tekton/configs/triggers/templates/_/build-component-all-platforms.yaml`, commented out configurations for `git-basic-auth`, `cargo-home`, and `cypress-cache` in multiple sections of the file. These resources are no longer active but remain in the file as comments. [[1]](diffhunk://#diff-7eb8a56490fe2a18d7d5d23a2b9583f4c962967a7739af3ec995e79774e6bf83L107-R115) [[2]](diffhunk://#diff-7eb8a56490fe2a18d7d5d23a2b9583f4c962967a7739af3ec995e79774e6bf83L185-R193) [[3]](diffhunk://#diff-7eb8a56490fe2a18d7d5d23a2b9583f4c962967a7739af3ec995e79774e6bf83L244-R246) [[4]](diffhunk://#diff-7eb8a56490fe2a18d7d5d23a2b9583f4c962967a7739af3ec995e79774e6bf83L300-R302)

* In `apps/gcp/tekton/configs/triggers/templates/_/build-component-single-platform.yaml`, commented out configurations for `git-basic-auth`, `cargo-home`, and `cypress-cache`, leaving only the `mac-ssh-credentials` configuration active.

* In `apps/gcp/tekton/configs/triggers/templates/_/build-component.yaml`, commented out configurations for `git-basic-auth`, `cargo-home`, and `cypress-cache` in two sections of the file. [[1]](diffhunk://#diff-4d309818f51c59def3b6c76965ed34a2ebf8e79a392c3f4de9414f5ad40c0188L105-R113) [[2]](diffhunk://#diff-4d309818f51c59def3b6c76965ed34a2ebf8e79a392c3f4de9414f5ad40c0188L181-R189)

* In `apps/gcp/tekton/configs/triggers/templates/tikv/tikv/bump-tikv-cargo-pkg-version.yaml`, commented out the configuration for `cargo-home`, while leaving other resource configurations unchanged.