### PR TITLE
fix(aps/gcp/tekton/configs): add GitHub SSH secret to the service account

### DIFF
--- a/apps/gcp/tekton/configs/kustomization.yaml
+++ b/apps/gcp/tekton/configs/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: ee-cd
 resources:
   - namespace.yaml
   - policies.yaml
+  - secrets
   - rbac
   - tasks
   - triggers

--- a/apps/gcp/tekton/configs/rbac/github-bot.yaml
+++ b/apps/gcp/tekton/configs/rbac/github-bot.yaml
@@ -4,3 +4,5 @@ metadata:
   name: github-bot
 secrets:
   - name: github-pat-secret
+  # The public key for this SSH secret must be added to the bot's GitHub account.
+  - name: github-ssh-secret

--- a/apps/gcp/tekton/configs/secrets/git-ssh-rsa.yaml
+++ b/apps/gcp/tekton/configs/secrets/git-ssh-rsa.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-ssh-secret
+  annotations:
+    secret-generator.v1.mittwald.de/type: ssh-keypair
+data: {}

--- a/apps/gcp/tekton/configs/secrets/kustomization.yaml
+++ b/apps/gcp/tekton/configs/secrets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - git-ssh-rsa.yaml


### PR DESCRIPTION
We need it to fetch for the private submodules