### PR TITLE
feat(apps/gcp/tekton, apps/prod/tekton): support release-nextgen-* branches in tekton triggers

### DIFF
--- a/apps/gcp/tekton/configs/triggers/triggers/pingcap/tidb/git-push-branch-build.yaml
+++ b/apps/gcp/tekton/configs/triggers/triggers/pingcap/tidb/git-push-branch-build.yaml
@@ -15,7 +15,7 @@ spec:
           value: >-
             body.repository.full_name == 'pingcap/tidb'
             &&
-            body.ref.matches('^refs/heads/(master)$')
+            body.ref.matches('^refs/heads/(master|release-nextgen-[0-9]+)$')
 
   bindings:
     - ref: github-branch-push

--- a/apps/gcp/tekton/configs/triggers/triggers/pingcap/tiflash/git-push-branch-build.yaml
+++ b/apps/gcp/tekton/configs/triggers/triggers/pingcap/tiflash/git-push-branch-build.yaml
@@ -15,7 +15,7 @@ spec:
           value: >-
             body.repository.full_name == 'pingcap/tiflash'
             &&
-            body.ref.matches('^refs/heads/(master)$')
+            body.ref.matches('^refs/heads/(master|release-nextgen-[0-9]+)$')
 
   bindings:
     - ref: github-branch-push

--- a/apps/gcp/tekton/configs/triggers/triggers/tidbcloud/cloud-storage-engine/git-push-branch-build.yaml
+++ b/apps/gcp/tekton/configs/triggers/triggers/tidbcloud/cloud-storage-engine/git-push-branch-build.yaml
@@ -15,7 +15,7 @@ spec:
           value: >-
             body.repository.full_name == 'tidbcloud/cloud-storage-engine'
             &&
-            body.ref.matches('^refs/heads/(dedicated)$')
+            body.ref.matches('^refs/heads/(dedicated|release-nextgen-[0-9]+)$')
 
   bindings:
     - ref: github-branch-push

--- a/apps/gcp/tekton/configs/triggers/triggers/tikv/pd/git-push-branch-build.yaml
+++ b/apps/gcp/tekton/configs/triggers/triggers/tikv/pd/git-push-branch-build.yaml
@@ -15,7 +15,7 @@ spec:
           value: >-
             body.repository.full_name == 'tikv/pd'
             &&
-            body.ref.matches('^refs/heads/(master)$')
+            body.ref.matches('^refs/heads/(master|release-nextgen-[0-9]+)$')
 
   bindings:
     - ref: github-branch-push

--- a/apps/prod/tekton/configs/triggers/triggers/_/harbor/image-push-on-harbor.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/harbor/image-push-on-harbor.yaml
@@ -49,7 +49,7 @@ spec:
             ) && (
             body.event_data.resources[0].tag.matches('^(master|main|release-[0-9]+[.][0-9]+(-beta[.][0-9]+)?|v[0-9]+[.][0-9]+[.][0-9]+(-(beta|rc)[.][0-9]+)?([-.]pre)?)(-[0-9a-f]+)?(-(enterprise|failpoint))?$')
             ||
-            body.event_data.resources[0].tag.matches('^(master|dedicated|feature-next-gen.*)(-.*)?-next-gen$')
+            body.event_data.resources[0].tag.matches('^(master|release-nextgen-[0-9]+|dedicated|feature-next-gen.*)(-.*)?-next-gen$')
             ||
             (
             body.event_data.repository.repo_full_name.matches('^pingcap/tidb-operator/')

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb/git-push-branch-build.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tidb/git-push-branch-build.yaml
@@ -15,7 +15,7 @@ spec:
           value: >-
             body.repository.full_name == 'pingcap/tidb'
             &&
-            body.ref.matches('^refs/heads/(master|feature/next-gen.*)$')
+            body.ref.matches('^refs/heads/(master|release-nextgen-[0-9]+|feature/next-gen.*)$')
 
   bindings:
     - ref: github-branch-push

--- a/apps/prod/tekton/configs/triggers/triggers/pingcap/tiflash/git-push-branch-build.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/pingcap/tiflash/git-push-branch-build.yaml
@@ -15,7 +15,7 @@ spec:
           value: >-
             body.repository.full_name == 'pingcap/tiflash'
             &&
-            body.ref.matches('^refs/heads/(master|feature/next-gen.*)$')
+            body.ref.matches('^refs/heads/(master|release-nextgen-[0-9]+|feature/next-gen.*)$')
 
   bindings:
     - ref: github-branch-push

--- a/apps/prod/tekton/configs/triggers/triggers/tidbcloud/cloud-storage-engine/git-push-branch-build.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/tidbcloud/cloud-storage-engine/git-push-branch-build.yaml
@@ -15,7 +15,7 @@ spec:
           value: >-
             body.repository.full_name == 'tidbcloud/cloud-storage-engine'
             &&
-            body.ref.matches('^refs/heads/(dedicated)$')
+            body.ref.matches('^refs/heads/(dedicated|release-nextgen-[0-9]+)$')
 
   bindings:
     - ref: github-branch-push

--- a/apps/prod/tekton/configs/triggers/triggers/tikv/pd/git-push-branch-build.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/tikv/pd/git-push-branch-build.yaml
@@ -15,7 +15,7 @@ spec:
           value: >-
             body.repository.full_name == 'tikv/pd'
             &&
-            body.ref.matches('^refs/heads/(master)$')
+            body.ref.matches('^refs/heads/(master|release-nextgen-[0-9]+)$')
 
   bindings:
     - ref: github-branch-push


### PR DESCRIPTION
This pull request introduces updates to the branch matching patterns in multiple Tekton trigger configurations to support the new `release-nextgen-[0-9]+` branch naming convention. These changes ensure that pipelines are triggered for the newly introduced branch pattern across various repositories and environments.

### Updates to branch matching patterns:

* **Development Environment:**
  - Updated branch matching in `pingcap/tidb` to include `release-nextgen-[0-9]+` (`apps/gcp/tekton/configs/triggers/triggers/pingcap/tidb/git-push-branch-build.yaml`).
  - Updated branch matching in `pingcap/tiflash` to include `release-nextgen-[0-9]+` (`apps/gcp/tekton/configs/triggers/triggers/pingcap/tiflash/git-push-branch-build.yaml`).
  - Updated branch matching in `tidbcloud/cloud-storage-engine` to include `release-nextgen-[0-9]+` (`apps/gcp/tekton/configs/triggers/triggers/tidbcloud/cloud-storage-engine/git-push-branch-build.yaml`).
  - Updated branch matching in `tikv/pd` to include `release-nextgen-[0-9]+` (`apps/gcp/tekton/configs/triggers/triggers/tikv/pd/git-push-branch-build.yaml`).

* **Production Environment:**
  - Extended branch matching in `pingcap/tidb` to include `release-nextgen-[0-9]+` alongside `feature/next-gen.*` (`apps/prod/tekton/configs/triggers/triggers/pingcap/tidb/git-push-branch-build.yaml`).
  - Extended branch matching in `pingcap/tiflash` to include `release-nextgen-[0-9]+` alongside `feature/next-gen.*` (`apps/prod/tekton/configs/triggers/triggers/pingcap/tiflash/git-push-branch-build.yaml`).
  - Updated branch matching in `tidbcloud/cloud-storage-engine` to include `release-nextgen-[0-9]+` (`apps/prod/tekton/configs/triggers/triggers/tidbcloud/cloud-storage-engine/git-push-branch-build.yaml`).
  - Updated branch matching in `tikv/pd` to include `release-nextgen-[0-9]+` (`apps/prod/tekton/configs/triggers/triggers/tikv/pd/git-push-branch-build.yaml`).

* **Harbor Image Push Trigger:**
  - Added support for `release-nextgen-[0-9]+` in tag matching for image push events (`apps/prod/tekton/configs/triggers/triggers/_/harbor/image-push-on-harbor.yaml`).