### PR TITLE
feat(infrastructure/gcp): add external-secrets Helm release and repository configuration

### DIFF
--- a/infrastructure/_base/sources/helm-repo-external-secrets.yaml
+++ b/infrastructure/_base/sources/helm-repo-external-secrets.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: external-secrets
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://charts.external-secrets.io

--- a/infrastructure/_base/sources/kustomization.yaml
+++ b/infrastructure/_base/sources/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - helm-repo-rook.yaml
   - helm-repo-others.yaml
   - helm-repo-kyverno.yaml
+  - helm-repo-external-secrets.yaml

--- a/infrastructure/gcp/external-secrets/kustomization.yaml
+++ b/infrastructure/gcp/external-secrets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - release.yaml

--- a/infrastructure/gcp/external-secrets/release.yaml
+++ b/infrastructure/gcp/external-secrets/release.yaml
@@ -1,0 +1,27 @@
+#yaml-language-server: $schema=https://github.com/fluxcd-community/flux2-schemas/raw/refs/heads/main/helmrelease-helm-v2beta1.json
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: external-secrets
+  namespace: infra
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: external-secrets
+      version: 0.19.0
+      sourceRef:
+        kind: HelmRepository
+        name: external-secrets
+        namespace: flux-system
+  values:
+    replicaCount: 2
+    webhook:
+      replicaCount: 2
+    certController:
+      replicaCount: 2
+    serviceAccount:
+      create: true
+    crds:
+      enabled: true
+    installCRDs: true

--- a/infrastructure/gcp/kustomization.yaml
+++ b/infrastructure/gcp/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - secret-generator
   - gateways
   - kyverno
+  - external-secrets
   # TODO(wuhuizuo): move the gateway from `apps` folder to here.


### PR DESCRIPTION
This pull request introduces the integration of the External Secrets Helm chart into the infrastructure, enabling automated management of external secrets. Key changes include the addition of a new Helm repository, updates to kustomization files, and the creation of a HelmRelease configuration for deploying External Secrets.

### Integration of External Secrets:

* **Addition of Helm Repository:**
  - Added a new Helm repository for External Secrets in `infrastructure/_base/sources/helm-repo-external-secrets.yaml`. This repository is configured with a 24-hour sync interval and points to `https://charts.external-secrets.io`.
  - Updated `resources:` in `infrastructure/_base/sources/kustomization.yaml` to include the new Helm repository file.

* **Deployment Configuration:**
  - Created a `kustomization.yaml` file in `infrastructure/gcp/external-secrets/` to manage the deployment of External Secrets.
  - Added a `release.yaml` file in `infrastructure/gcp/external-secrets/` for the HelmRelease configuration. This file specifies the chart version (0.19.0), sync interval (5 minutes), and deployment values such as replica counts, service account creation, and CRD installation.

* **Integration into GCP Infrastructure:**
  - Updated `resources:` in `infrastructure/gcp/kustomization.yaml` to include the External Secrets deployment.