### PR TITLE
feat(apps/gcp/prow): add cherrypicker service

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -180,6 +180,25 @@ spec:
                     items:
                       - key: tasks.yaml
                         path: tasks.yaml
+      cherrypicker:
+        service:
+          type: ClusterIP
+        ports:
+          http: 80
+        serviceAccount:
+          name: prow-hook
+        image:
+          repository: docker pull ghcr.io/ti-community-infra/prow/cherrypicker
+          tag: v20250802-5c303bb37
+        args:
+          - --allow-all
+          - --dry-run=false
+          - --github-app-id=$(GITHUB_APP_ID)
+          - --github-app-private-key-path=/etc/github/app-private-key
+          - --github-endpoint=http://prow-ghproxy
+          - --github-graphql-endpoint=http://prow-ghproxy/graphql
+          - --label-prefix=needs-cherry-pick-
+          - --skip-fork
       needs-rebase:
         replicaCount: 1
         image:


### PR DESCRIPTION
This `cherrypicker` external plugin is lightly hacked from prow's `cherrypicker` plugin.

