### PR TITLE
feat(infrastructure/prod2): deploy external secrets operator

### DIFF
--- a/infrastructure/gcp/external-secrets/kustomization.yaml
+++ b/infrastructure/gcp/external-secrets/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: infra
 resources:
   - release.yaml
   - cluster-secret-store-gcp.yaml

--- a/infrastructure/gcp/external-secrets/release.yaml
+++ b/infrastructure/gcp/external-secrets/release.yaml
@@ -3,7 +3,6 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: external-secrets
-  namespace: infra
 spec:
   interval: 5m
   chart:

--- a/infrastructure/gcp/kyverno/kustomization.yaml
+++ b/infrastructure/gcp/kyverno/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: infra
 resources:
   - release.yaml

--- a/infrastructure/gcp/kyverno/release.yaml
+++ b/infrastructure/gcp/kyverno/release.yaml
@@ -3,7 +3,6 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: kyverno
-  namespace: infra
 spec:
   interval: 5m
   chart:

--- a/infrastructure/prod2/external-secrets/cluster-secret-store-gcp.yaml
+++ b/infrastructure/prod2/external-secrets/cluster-secret-store-gcp.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1
+apiVersion: external-secrets.io/v1beta1
 kind: ClusterSecretStore
 metadata:
   name: ee-gcp-sm

--- a/infrastructure/prod2/external-secrets/cluster-secret-store-gcp.yaml
+++ b/infrastructure/prod2/external-secrets/cluster-secret-store-gcp.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: ee-gcp-sm
+spec:
+  provider:
+    gcpsm:
+      auth:
+        secretRef:
+          # you should prepare the secret manually.
+          secretAccessKeySecretRef:
+            namespace: infra
+            name: gcp-sm-sa-secret
+            key: secret-access-credentials
+      projectID: pingcap-testing-account

--- a/infrastructure/prod2/external-secrets/kustomization.yaml
+++ b/infrastructure/prod2/external-secrets/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 namespace: infra
 resources:
   - release.yaml
+  - cluster-secret-store-gcp.yaml

--- a/infrastructure/prod2/external-secrets/release.yaml
+++ b/infrastructure/prod2/external-secrets/release.yaml
@@ -40,6 +40,4 @@ spec:
         memory: 128Mi
     serviceAccount:
       create: true
-    crds:
-      enabled: true
     installCRDs: true

--- a/infrastructure/prod2/external-secrets/release.yaml
+++ b/infrastructure/prod2/external-secrets/release.yaml
@@ -1,0 +1,45 @@
+#yaml-language-server: $schema=https://github.com/fluxcd-community/flux2-schemas/raw/refs/heads/main/helmrelease-helm-v2beta1.json
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: external-secrets
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: external-secrets
+      version: 0.13.0 # it support K8S version: 1.19 ~ 1.31. It only support K8S 1.32+ since 0.14.0
+      sourceRef:
+        kind: HelmRepository
+        name: external-secrets
+        namespace: flux-system
+  values:
+    replicaCount: 2
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
+    webhook:
+      replicaCount: 2
+      requests:
+        cpu: 20m
+        memory: 64Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+    certController:
+      replicaCount: 2
+      requests:
+        cpu: 20m
+        memory: 64Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+    serviceAccount:
+      create: true
+    crds:
+      enabled: true
+    installCRDs: true

--- a/infrastructure/prod2/external-secrets/test.yaml.example
+++ b/infrastructure/prod2/external-secrets/test.yaml.example
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: example-es

--- a/infrastructure/prod2/external-secrets/test.yaml.example
+++ b/infrastructure/prod2/external-secrets/test.yaml.example
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: example-es
+  namespace: apps
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: ee-gcp-sm
+    kind: ClusterSecretStore
+  target:
+    name: example-secret-from-es
+    creationPolicy: Owner
+  data:
+    - secretKey: secret-key-to-be-managed
+      remoteRef:
+        key: key
+  dataFrom:
+    - extract:
+        key: json-key

--- a/infrastructure/prod2/kustomization.yaml
+++ b/infrastructure/prod2/kustomization.yaml
@@ -2,7 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../_base
+  - namespace.yaml
   - openebs
   - nfs-pvc-provisioner
   - nginx
   - secret-generator
+  - external-secrets

--- a/infrastructure/prod2/namespace.yaml
+++ b/infrastructure/prod2/namespace.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: secret-generator
+  name: infra


### PR DESCRIPTION
This pull request introduces the External Secrets Operator to the `prod2` environment, standardizes the use of the `infra` namespace for infrastructure components, and provides example configuration for secret management. The main themes are the addition of external secrets management, namespace standardization, and related configuration updates.

**External Secrets Operator integration:**

* Added manifests for deploying the External Secrets Operator in `prod2`, including `HelmRelease` configuration (`release.yaml`), a `ClusterSecretStore` referencing GCP Secret Manager (`cluster-secret-store-gcp.yaml`), and an example `ExternalSecret` resource (`test.yaml.example`). [[1]](diffhunk://#diff-9c2c04564e056f080b9e2edefd49f9727e9ccb899ea37dfcb7d4ee4e41cc7f90R1-R45) [[2]](diffhunk://#diff-547b99251d0c74c1858da9d27e048bb60870a57cbf8962b42ab80757c181ed4aR1-R15) [[3]](diffhunk://#diff-65dafd802efcb96cebe07f2b7db9b284f664591b3c9805f701d09a39d24a78c6R1-R20)

**Namespace standardization and configuration:**

* Standardized the namespace for infrastructure components to `infra` across `kustomization.yaml` files and resource definitions, including renaming the namespace manifest and updating references in `prod2` and GCP environments. [[1]](diffhunk://#diff-1a628b62e5b5b258805b74af9693898eb186cc4b34f5218ffcf006f8e8a01a2cR3) [[2]](diffhunk://#diff-fd04d4dc54d43e59835b9cb3b666fc2119c767c94378d8313a5999b020aa1c5fR3) [[3]](diffhunk://#diff-3af05120b825c7cd945583e29f56d6746ec7ec1c2f4426a3eb514a7c0ab35908R1-R6) [[4]](diffhunk://#diff-dca3d470e6d2888bac65afe0079c50172f5ac22796515929d7ab7bbfcd613e92L5-R5) [[5]](diffhunk://#diff-fd04d4dc54d43e59835b9cb3b666fc2119c767c94378d8313a5999b020aa1c5fR3) [[6]](diffhunk://#diff-e014b6c5f90c7e7a092ac7b70e6f40f811e08108901cbf4755bed3996f714c6fR5-R10)

**HelmRelease and Kustomization adjustments:**

* Removed hardcoded `namespace` fields from `HelmRelease` manifests for `external-secrets` and `kyverno` to rely on the namespace set in the parent `kustomization.yaml` instead. [[1]](diffhunk://#diff-4653a786ae127f65be22ec2a12b55e76c17777ed9df96f14514233badecb7a95L6) [[2]](diffhunk://#diff-249fed7a1d6301dca520894988224b6148c379123b57cd7a8bc53c47519fb2cbL6)

These changes collectively enable secure, centralized secret management in `prod2` and ensure consistent namespace usage for infrastructure resources.