### PR TITLE
refactor(apps/prod/tekton/configs/triggers): update registry to `us-docker.pkg.dev` in fake-github triggers

### DIFF
--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push-single-platform.yaml
@@ -138,7 +138,7 @@ spec:
         name: builder-resources-memory,
         value: $(extensions.builder-resources-memory),
       }
-    - { name: registry, value: hub.pingcap.net/devbuild }
+    - { name: registry, value: us-docker.pkg.dev/pingcap-testing-account/dev }
     - {
         name: force-builder-image,
         value: $(extensions.custom-params.builder-image),

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-branch-push.yaml
@@ -136,7 +136,7 @@ spec:
         name: builder-resources-memory,
         value: $(extensions.builder-resources-memory),
       }
-    - { name: registry, value: hub.pingcap.net/devbuild }
+    - { name: registry, value: us-docker.pkg.dev/pingcap-testing-account/dev }
     - {
         name: force-builder-image,
         value: $(extensions.custom-params.builder-image),

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr-single-platform.yaml
@@ -138,7 +138,7 @@ spec:
         name: builder-resources-memory,
         value: $(extensions.builder-resources-memory),
       }
-    - { name: registry, value: hub.pingcap.net/devbuild }
+    - { name: registry, value: us-docker.pkg.dev/pingcap-testing-account/dev }
     - {
         name: force-builder-image,
         value: $(extensions.custom-params.builder-image),

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-pr.yaml
@@ -152,7 +152,7 @@ spec:
         name: builder-resources-memory,
         value: $(extensions.builder-resources-memory),
       }
-    - { name: registry, value: hub.pingcap.net/devbuild }
+    - { name: registry, value: us-docker.pkg.dev/pingcap-testing-account/dev }
     - {
         name: force-builder-image,
         value: $(extensions.custom-params.builder-image),

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create-single-platform.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create-single-platform.yaml
@@ -140,7 +140,7 @@ spec:
         name: builder-resources-memory,
         value: $(extensions.builder-resources-memory),
       }
-    - { name: registry, value: hub.pingcap.net/devbuild }
+    - { name: registry, value: us-docker.pkg.dev/pingcap-testing-account/dev }
     - {
         name: force-builder-image,
         value: $(extensions.custom-params.builder-image),

--- a/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/fake-github/fake-github-tag-create.yaml
@@ -138,7 +138,7 @@ spec:
         name: builder-resources-memory,
         value: $(extensions.builder-resources-memory),
       }
-    - { name: registry, value: hub.pingcap.net/devbuild }
+    - { name: registry, value: us-docker.pkg.dev/pingcap-testing-account/dev }
     - {
         name: force-builder-image,
         value: $(extensions.custom-params.builder-image),


### PR DESCRIPTION
This pull request updates the container image registry used in several Tekton trigger configuration files for the fake GitHub pipelines. The registry is changed from an internal address to a Google Artifact Registry location, which likely improves reliability and aligns with current infrastructure standards.

**Registry update in Tekton trigger configurations:**

* Changed the `registry` parameter value from `hub.pingcap.net/devbuild` to `us-docker.pkg.dev/pingcap-testing-account/dev` in the following files:
  - `fake-github-branch-push.yaml`
  - `fake-github-branch-push-single-platform.yaml`
  - `fake-github-pr.yaml`
  - `fake-github-pr-single-platform.yaml`
  - `fake-github-tag-create.yaml`
  - `fake-github-tag-create-single-platform.yaml`