### PR TITLE
chore(apps/gcp/prow): update docker image of chatgpt plugin to `v20250812-57374e9b9`

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -143,7 +143,7 @@ spec:
         replicaCount: 1
         image:
           repository: ghcr.io/ti-community-infra/prow/chatgpt
-          tag: v20250728-3eb01d86a
+          tag: v20250812-57374e9b9
         ports:
           http: 8888
         args:


### PR DESCRIPTION
This pull request updates the deployment configuration for the `chatgpt` image in the `release.yaml` file. The main change is updating the image tag to use a newer version.

Deployment configuration update:

* Updated the `chatgpt` container image tag from `v20250728-3eb01d86a` to `v20250812-57374e9b9` in `apps/gcp/prow/release/release.yaml` to deploy the latest version.