### PR TITLE
feat(apps/gcp): add ExternalSecret configs for GitHub and Mac SSH credentials

### DIFF
--- a/apps/gcp/tekton/configs/kustomization.yaml
+++ b/apps/gcp/tekton/configs/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - namespace.yaml
   - policies.yaml
   - rbac
+  - secrets
   - tasks
   - triggers
   - pipelines

--- a/apps/gcp/tekton/configs/secrets/github.yaml
+++ b/apps/gcp/tekton/configs/secrets/github.yaml
@@ -1,0 +1,14 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: github
+spec:
+  secretStoreRef:
+    name: ee-gcp-sm
+    kind: ClusterSecretStore
+  target:
+    name: github
+  data:
+    - secretKey: token
+      remoteRef:
+        key: github-bot-token

--- a/apps/gcp/tekton/configs/secrets/kustomization.yaml
+++ b/apps/gcp/tekton/configs/secrets/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - github.yaml
+  - mac-ssh-credentials.yaml

--- a/apps/gcp/tekton/configs/secrets/mac-ssh-credentials.yaml
+++ b/apps/gcp/tekton/configs/secrets/mac-ssh-credentials.yaml
@@ -1,0 +1,13 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: mac-ssh-credentials
+spec:
+  secretStoreRef:
+    name: ee-gcp-sm
+    kind: ClusterSecretStore
+  target:
+    name: mac-ssh-credentials
+  dataFrom:
+    - extract: # inner keys: username, id_rsa, id_rsa.pub, hosts.yaml
+        key: mac-ssh-credentials


### PR DESCRIPTION
This pull request introduces support for managing secrets in the Tekton GCP deployment by adding new configuration files and updating existing kustomization manifests. The main changes group around adding external secrets for GitHub and Mac SSH credentials, and ensuring these are included in the deployment process.

**Secrets management:**

* Added a new `secrets` directory to the `resources` list in `apps/gcp/tekton/configs/kustomization.yaml` to include secrets in the deployment.
* Created a new `kustomization.yaml` in `apps/gcp/tekton/configs/secrets/` to manage secret resources.

**External secrets configuration:**

* Added `github.yaml` to define an `ExternalSecret` for the GitHub bot token, referencing the `github-bot-token` secret from the secret store.
* Added `mac-ssh-credentials.yaml` to define an `ExternalSecret` for Mac SSH credentials, extracting multiple keys from the `mac-ssh-credentials` secret in the secret store.