### PR TITLE
chore(apps/gcp,apps/prod): update release utility image to v2025.8.17-13-ga5750d9

### DIFF
--- a/apps/gcp/tekton/configs/tasks/pingcap-build-binaries-darwin.yaml
+++ b/apps/gcp/tekton/configs/tasks/pingcap-build-binaries-darwin.yaml
@@ -34,7 +34,7 @@ spec:
     - name: git-ref
     - name: git-sha
     - name: builder-image
-      default: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      default: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
     - name: release-dir
       default: build
     - name: push
@@ -47,7 +47,7 @@ spec:
       default: "http://boskos.test-pods.svc.cluster.local"
   steps:
     - name: generate-build-script
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
       script: |
         git clone --depth=1 --branch=main https://github.com/PingCAP-QE/artifacts.git /workspace/artifacts
 
@@ -130,7 +130,7 @@ spec:
           --boskos.owner $(context.taskRun.name) \
           --releaseDir $(params.release-dir)
     - name: publish
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
       workingDir: $(workspaces.source.path)/$(params.component)
       script: |
         script="/workspace/build-package-artifacts.sh"

--- a/apps/gcp/tekton/configs/tasks/pingcap-build-binaries-linux.yaml
+++ b/apps/gcp/tekton/configs/tasks/pingcap-build-binaries-linux.yaml
@@ -40,7 +40,7 @@ spec:
     - name: git-ref
     - name: git-sha
     - name: builder-image
-      default: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      default: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
     - name: release-dir
       default: build
     - name: push
@@ -50,7 +50,7 @@ spec:
       default: hub.pingcap.net
   steps:
     - name: generate-build-script
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
       script: |
         git clone --depth=1 --branch=main https://github.com/PingCAP-QE/artifacts.git /workspace/artifacts
 
@@ -106,7 +106,7 @@ spec:
 
         "$script" -b -a -w "$(params.release-dir)"
     - name: publish
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
       workingDir: $(workspaces.source.path)/$(params.component)
       script: |
         script="/workspace/build-package-artifacts.sh"

--- a/apps/gcp/tekton/configs/tasks/pingcap-build-images.yaml
+++ b/apps/gcp/tekton/configs/tasks/pingcap-build-images.yaml
@@ -47,7 +47,7 @@ spec:
       default: hub.pingcap.net
   steps:
     - name: generate
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.5.11-2-gfd3e259
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
       script: |
         git clone --depth=1 --branch=main https://github.com/PingCAP-QE/artifacts.git /workspace/artifacts
 
@@ -106,7 +106,7 @@ spec:
           "$script" -w "$(params.release-dir)" -k ${KANIKO_EXECUTOR} -o $(results.pushed.path)
         fi
     - name: add-more-tags
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
       script: |
         script="/workspace/build-package-images.sh"
         if [ ! -f "$script" ]; then

--- a/apps/gcp/tekton/configs/tasks/pingcap-get-builder-image.yaml
+++ b/apps/gcp/tekton/configs/tasks/pingcap-get-builder-image.yaml
@@ -36,7 +36,7 @@ spec:
       default: ""
   steps:
     - name: get
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
       script: |
         if [ -n "$(params.force-builder-image)" ]; then
           echo "use force builder image: $(params.force-builder-image)"

--- a/apps/prod/tekton/configs/tasks/gen-build-binaries-scripts.yaml
+++ b/apps/prod/tekton/configs/tasks/gen-build-binaries-scripts.yaml
@@ -26,7 +26,7 @@ spec:
     - name: git-ref
     - name: git-sha
     - name: build-image
-      default: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      default: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
     - name: save-file
       default: build-package-artifacts.sh
   steps:

--- a/apps/prod/tekton/configs/tasks/gen-build-images-scripts.yaml
+++ b/apps/prod/tekton/configs/tasks/gen-build-images-scripts.yaml
@@ -26,7 +26,7 @@ spec:
     - name: git-ref
     - name: git-sha
     - name: build-image
-      default: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      default: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
     - name: save-file
       default: build-package-images.sh
   steps:

--- a/apps/prod/tekton/configs/tasks/multi-arch-image-collect.yaml
+++ b/apps/prod/tekton/configs/tasks/multi-arch-image-collect.yaml
@@ -29,7 +29,7 @@ spec:
       description: tags pushed
   steps:
     - name: prepare-manifest
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
       workingDir: /workspace
       script: |
         #! /usr/bin/env bash

--- a/apps/prod/tekton/configs/tasks/pingcap-auto-add-image-major-tag.yaml
+++ b/apps/prod/tekton/configs/tasks/pingcap-auto-add-image-major-tag.yaml
@@ -11,7 +11,7 @@ spec:
     - name: image_url
       description: The image full url for pull
   stepTemplate:
-    image: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+    image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
   steps:
     - name: add-nightly-tag
       script: |

--- a/apps/prod/tekton/configs/tasks/pingcap-build-binaries-darwin.yaml
+++ b/apps/prod/tekton/configs/tasks/pingcap-build-binaries-darwin.yaml
@@ -38,7 +38,7 @@ spec:
     - name: git-ref
     - name: git-sha
     - name: builder-image
-      default: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      default: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
     - name: release-dir
       default: build
     - name: push
@@ -51,7 +51,7 @@ spec:
       default: "http://boskos.test-pods.svc.cluster.local"
   steps:
     - name: generate-build-script
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
       script: |
         git clone --depth=1 --branch=main https://github.com/PingCAP-QE/artifacts.git /workspace/artifacts
 
@@ -134,7 +134,7 @@ spec:
           --boskos.owner $(context.taskRun.name) \
           --releaseDir $(params.release-dir)
     - name: publish
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
       workingDir: $(workspaces.source.path)/$(params.component)
       script: |
         script="/workspace/build-package-artifacts.sh"

--- a/apps/prod/tekton/configs/tasks/pingcap-build-binaries-linux.yaml
+++ b/apps/prod/tekton/configs/tasks/pingcap-build-binaries-linux.yaml
@@ -44,7 +44,7 @@ spec:
     - name: git-ref
     - name: git-sha
     - name: builder-image
-      default: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      default: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
     - name: release-dir
       default: build
     - name: push
@@ -54,7 +54,7 @@ spec:
       default: hub.pingcap.net
   steps:
     - name: generate-build-script
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
       script: |
         git clone --depth=1 --branch=main https://github.com/PingCAP-QE/artifacts.git /workspace/artifacts
 
@@ -110,7 +110,7 @@ spec:
 
         "$script" -b -a -w "$(params.release-dir)"
     - name: publish
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
       workingDir: $(workspaces.source.path)/$(params.component)
       script: |
         script="/workspace/build-package-artifacts.sh"

--- a/apps/prod/tekton/configs/tasks/pingcap-build-images.yaml
+++ b/apps/prod/tekton/configs/tasks/pingcap-build-images.yaml
@@ -44,7 +44,7 @@ spec:
       default: hub.pingcap.net
   steps:
     - name: generate
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
       script: |
         git clone --depth=1 --branch=main https://github.com/PingCAP-QE/artifacts.git /workspace/artifacts
 
@@ -102,7 +102,7 @@ spec:
           "$script" -w "$(params.release-dir)" -k ${KANIKO_EXECUTOR} -o $(results.pushed.path)
         fi
     - name: add-more-tags
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
       script: |
         script="/workspace/build-package-images.sh"
         if [ ! -f "$script" ]; then

--- a/apps/prod/tekton/configs/tasks/pingcap-compose-offline-pkgs.yaml
+++ b/apps/prod/tekton/configs/tasks/pingcap-compose-offline-pkgs.yaml
@@ -35,7 +35,7 @@ spec:
       description: Product is http://tiup.pingcap.net:8987, Staging is http://tiup.pingcap.net:8988,
       default: http://tiup.pingcap.net:8988
   stepTemplate:
-    image: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+    image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
     env:
       - name: OUT_SCRIPT
         value: /workspace/compose-offline-packages-artifacts.sh

--- a/apps/prod/tekton/configs/tasks/pingcap-get-builder-image.yaml
+++ b/apps/prod/tekton/configs/tasks/pingcap-get-builder-image.yaml
@@ -36,7 +36,7 @@ spec:
       default: ""
   steps:
     - name: get
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
       script: |
         if [ -n "$(params.force-builder-image)" ]; then
           echo "use force builder image: $(params.force-builder-image)"

--- a/apps/prod/tekton/configs/tasks/pingcap-upload-enterprise-plugins.yaml
+++ b/apps/prod/tekton/configs/tasks/pingcap-upload-enterprise-plugins.yaml
@@ -24,7 +24,7 @@ spec:
     - name: aws-secrets-tencent
   steps:
     - name: uploads
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
       workingDir: /workspace
       script: |
         #!/usr/bin/env bash

--- a/apps/prod/tekton/configs/tasks/pingcap-upload-offline-package.yaml
+++ b/apps/prod/tekton/configs/tasks/pingcap-upload-offline-package.yaml
@@ -34,7 +34,7 @@ spec:
     - name: aws-secrets-tencent
   steps:
     - name: upload-offline-tarballs
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
       workingDir: /workspace
       script: |
         #!/usr/bin/env bash
@@ -87,7 +87,7 @@ spec:
         done
         echo "✅ Uploaded for ${tag} ."
     - name: upload-dm-tarballs-to-s3
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
       workingDir: /workspace
       script: |
         #!/usr/bin/env bash

--- a/apps/prod/tekton/configs/tasks/publish-tiup-from-oci-artifact.yaml
+++ b/apps/prod/tekton/configs/tasks/publish-tiup-from-oci-artifact.yaml
@@ -26,7 +26,7 @@ spec:
       default: http://tiup.pingcap.net:8988
   steps:
     - name: analyse
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
       workingDir: /workspace
       env:
         - name: CACHE_READ_SERVER_BASE_URL
@@ -66,7 +66,7 @@ spec:
         echo "✅ Done, the generated script content:"
         cat publish.sh
     - name: publish
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
       workingDir: /workspace
       script: |
         #! /usr/bin/env bash

--- a/apps/prod/tekton/configs/tasks/release/create-pr-to-add-release-anchor-commit.yaml
+++ b/apps/prod/tekton/configs/tasks/release/create-pr-to-add-release-anchor-commit.yaml
@@ -23,7 +23,7 @@ spec:
       default: ""
   steps:
     - name: analyse
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
       workingDir: /workspace
       script: |
         #!/bin/bash

--- a/apps/prod/tekton/configs/tasks/release/create-pr-to-bump-tikv-version.yaml
+++ b/apps/prod/tekton/configs/tasks/release/create-pr-to-bump-tikv-version.yaml
@@ -23,7 +23,7 @@ spec:
       default: ghcr.io/pingcap-qe/cd/builders/tikv:v20231116-e1c4b43
   steps:
     - name: analyse
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
       script: |
         #!/bin/bash
 

--- a/apps/prod/tekton/configs/tasks/release/tag-rc2ga-on-oci-artifacts.yaml
+++ b/apps/prod/tekton/configs/tasks/release/tag-rc2ga-on-oci-artifacts.yaml
@@ -16,7 +16,7 @@ spec:
       description: force to create tag whether it existed or not.
   steps:
     - name: run
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
       script: |
         #! /usr/bin/env bash
         set -ex

--- a/apps/prod/tekton/configs/tasks/release/wait-delivery-images.yaml
+++ b/apps/prod/tekton/configs/tasks/release/wait-delivery-images.yaml
@@ -26,7 +26,7 @@ spec:
           --config="$(params.delivery-config)" \
           --save_to=/workspace/target-images.yaml
     - name: wait
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
       script: |
         cat /workspace/target-images.yaml
 

--- a/apps/prod/tekton/configs/tasks/release/wait-delivery-tiup.yaml
+++ b/apps/prod/tekton/configs/tasks/release/wait-delivery-tiup.yaml
@@ -17,7 +17,7 @@ spec:
       description: The OCI registry stored the origin tarball files.
   steps:
     - name: wait
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2024.10.8-71-gf13e219
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
       env:
         - name: tiup_check_ver
           value: $(params.version)


### PR DESCRIPTION
This pull request updates the Tekton pipeline task configurations to use a newer version of the `ghcr.io/pingcap-qe/cd/utils/release` image (`v2025.8.17-13-ga5750d9`) across both GCP and production environments. This ensures consistency and access to the latest features or fixes in the build and release process.

**Image version upgrade across pipeline tasks:**

* Updated the default value of the `builder-image` or `build-image` parameters and the image used in all relevant steps to `ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9` in the following files:
  * `apps/gcp/tekton/configs/tasks/pingcap-build-binaries-darwin.yaml` [[1]](diffhunk://#diff-a09c39ae10681e079c7eb53b981261a1abd64e07e7342660568dc42818f77764L37-R37) [[2]](diffhunk://#diff-a09c39ae10681e079c7eb53b981261a1abd64e07e7342660568dc42818f77764L50-R50) [[3]](diffhunk://#diff-a09c39ae10681e079c7eb53b981261a1abd64e07e7342660568dc42818f77764L133-R133)
  * `apps/gcp/tekton/configs/tasks/pingcap-build-binaries-linux.yaml` [[1]](diffhunk://#diff-67b8e3c7fc78c4dc29be7871e7c87204d5f8e0861f4f48ddcc2b6482f9c3870cL43-R43) [[2]](diffhunk://#diff-67b8e3c7fc78c4dc29be7871e7c87204d5f8e0861f4f48ddcc2b6482f9c3870cL53-R53) [[3]](diffhunk://#diff-67b8e3c7fc78c4dc29be7871e7c87204d5f8e0861f4f48ddcc2b6482f9c3870cL109-R109)
  * `apps/gcp/tekton/configs/tasks/pingcap-build-images.yaml` [[1]](diffhunk://#diff-441a28f898ce8d8c7d589ac267c0f029009faf4de62296fb55fd577410f1c44dL50-R50) [[2]](diffhunk://#diff-441a28f898ce8d8c7d589ac267c0f029009faf4de62296fb55fd577410f1c44dL109-R109)
  * `apps/gcp/tekton/configs/tasks/pingcap-get-builder-image.yaml`
  * `apps/prod/tekton/configs/tasks/gen-build-binaries-scripts.yaml`
  * `apps/prod/tekton/configs/tasks/gen-build-images-scripts.yaml`
  * `apps/prod/tekton/configs/tasks/multi-arch-image-collect.yaml`
  * `apps/prod/tekton/configs/tasks/pingcap-auto-add-image-major-tag.yaml`
  * `apps/prod/tekton/configs/tasks/pingcap-build-binaries-darwin.yaml` [[1]](diffhunk://#diff-57ae23974383ae0301db72c370396316f45f468da874009b88aad5dbfa7a0120L41-R41) [[2]](diffhunk://#diff-57ae23974383ae0301db72c370396316f45f468da874009b88aad5dbfa7a0120L54-R54) [[3]](diffhunk://#diff-57ae23974383ae0301db72c370396316f45f468da874009b88aad5dbfa7a0120L137-R137)
  * `apps/prod/tekton/configs/tasks/pingcap-build-binaries-linux.yaml` [[1]](diffhunk://#diff-e4ba25c3bceeef272ee3180e49dd1df85740bc4cb7e7ab74181be99adbe5f3e6L47-R47) [[2]](diffhunk://#diff-e4ba25c3bceeef272ee3180e49dd1df85740bc4cb7e7ab74181be99adbe5f3e6L57-R57) [[3]](diffhunk://#diff-e4ba25c3bceeef272ee3180e49dd1df85740bc4cb7e7ab74181be99adbe5f3e6L113-R113)
  * `apps/prod/tekton/configs/tasks/pingcap-build-images.yaml` [[1]](diffhunk://#diff-4e6ce54ff92ef3c743849aa118b675f95642e07c52395768fa6823c4bf0ed43bL47-R47) [[2]](diffhunk://#diff-4e6ce54ff92ef3c743849aa118b675f95642e07c52395768fa6823c4bf0ed43bL105-R105)
  * `apps/prod/tekton/configs/tasks/pingcap-compose-offline-pkgs.yaml`
  * `apps/prod/tekton/configs/tasks/pingcap-get-builder-image.yaml`
  * `apps/prod/tekton/configs/tasks/pingcap-upload-enterprise-plugins.yaml`
  * `apps/prod/tekton/configs/tasks/pingcap-upload-offline-package.yaml` [[1]](diffhunk://#diff-d2caa9d1b8bad9a41f40245f95a2cabf1578282602d690cc29c8d604f82933d4L37-R37) [[2]](diffhunk://#diff-d2caa9d1b8bad9a41f40245f95a2cabf1578282602d690cc29c8d604f82933d4L90-R90)
  * `apps/prod/tekton/configs/tasks/publish-tiup-from-oci-artifact.yaml` [[1]](diffhunk://#diff-e25eeac4a20ccf5a8a7e272793d1fa35d11ee3b1524a79014ceda6fcad9eeac9L29-R29) [[2]](diffhunk://#diff-e25eeac4a20ccf5a8a7e272793d1fa35d11ee3b1524a79014ceda6fcad9eeac9L69-R69)
  * `apps/prod/tekton/configs/tasks/release/create-pr-to-add-release-anchor-commit.yaml`
  * `apps/prod/tekton/configs/tasks/release/create-pr-to-bump-tikv-version.yaml`
  * `apps/prod/tekton/configs/tasks/release/tag-rc2ga-on-oci-artifacts.yaml`
  * `apps/prod/tekton/configs/tasks/release/wait-delivery-images.yaml`