### PR TITLE
refactor(apps/gcp/tekton/configs/tasks): add conditional execution for

### DIFF
--- a/apps/gcp/tekton/configs/tasks/pingcap-build-binaries-darwin.yaml
+++ b/apps/gcp/tekton/configs/tasks/pingcap-build-binaries-darwin.yaml
@@ -46,8 +46,11 @@ spec:
       description: The URL of the running boskos server
       default: "http://boskos.test-pods.svc.cluster.local"
   steps:
-    - name: generate-build-script
+    - name: generate
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
+      results:
+        - name: generated
+          type: string
       script: |
         git clone --depth=1 --branch=main https://github.com/PingCAP-QE/artifacts.git /workspace/artifacts
 
@@ -71,13 +74,20 @@ spec:
           $(params.registry)
 
         if [ -f "$out_script" ]; then
+          echo -n "true" > $(step.results.generated.path)
           sed -i 's/fetch_file_from_oci_artifact hub.pingcap.net/fetch_file_from_oci_artifact hub-mig.pingcap.net/g' "$out_script"
           cat "$out_script"
         else
+          echo -n "false" > $(step.results.generated.path)
           echo "🤷 no output script generated!"
+          printf '"{}"' > $(results.pushed.path)
         fi
     - name: prepare-remote-env-file
       image: "$(params.builder-image)"
+      when:
+        - input: "$(steps.generate.results.generated)"
+          operator: in
+          values: ["true"]
       script: |
         :> /workspace/remote.env
 
@@ -100,6 +110,10 @@ spec:
         # echo 'export RUSTUP_UPDATE_ROOT="https://rsproxy.cn/rustup"' >> /workspace/remote.env
     - name: build
       image: docker.io/denoland/deno:alpine-2.1.3
+      when:
+        - input: "$(steps.generate.results.generated)"
+          operator: in
+          values: ["true"]
       env:
         - name: WORKSPACE_SSH_DIRECTORY_BOUND
           value: $(workspaces.ssh-directory.bound)
@@ -131,6 +145,10 @@ spec:
           --releaseDir $(params.release-dir)
     - name: publish
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
+      when:
+        - input: "$(steps.generate.results.generated)"
+          operator: in
+          values: ["true"]
       workingDir: $(workspaces.source.path)/$(params.component)
       script: |
         script="/workspace/build-package-artifacts.sh"

--- a/apps/gcp/tekton/configs/tasks/pingcap-build-binaries-linux.yaml
+++ b/apps/gcp/tekton/configs/tasks/pingcap-build-binaries-linux.yaml
@@ -49,8 +49,11 @@ spec:
     - name: registry
       default: hub.pingcap.net
   steps:
-    - name: generate-build-script
+    - name: generate
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
+      results:
+        - name: generated
+          type: string
       script: |
         git clone --depth=1 --branch=main https://github.com/PingCAP-QE/artifacts.git /workspace/artifacts
 
@@ -74,13 +77,20 @@ spec:
           $(params.registry)
 
         if [ -f "$out_script" ]; then
+          echo -n "true" > $(step.results.generated.path)
           sed -i 's/fetch_file_from_oci_artifact hub.pingcap.net/fetch_file_from_oci_artifact hub-mig.pingcap.net/g' "$out_script"
           cat "$out_script"
         else
+          echo -n "false" > $(step.results.generated.path)
           echo "🤷 no output script generated!"
+          printf '"{}"' > $(results.pushed.path)
         fi
     - name: build
       image: "$(params.builder-image)"
+      when:
+        - input: "$(steps.generate.results.generated)"
+          operator: in
+          values: ["true"]
       workingDir: $(workspaces.source.path)/$(params.component)
       env:
         - name: CARGO_NET_GIT_FETCH_WITH_CLI
@@ -107,6 +117,10 @@ spec:
         "$script" -b -a -w "$(params.release-dir)"
     - name: publish
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
+      when:
+        - input: "$(steps.generate.results.generated)"
+          operator: in
+          values: ["true"]
       workingDir: $(workspaces.source.path)/$(params.component)
       script: |
         script="/workspace/build-package-artifacts.sh"

--- a/apps/gcp/tekton/configs/tasks/pingcap-build-images.yaml
+++ b/apps/gcp/tekton/configs/tasks/pingcap-build-images.yaml
@@ -48,6 +48,9 @@ spec:
   steps:
     - name: generate
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
+      results:
+        - name: generated
+          type: string
       script: |
         git clone --depth=1 --branch=main https://github.com/PingCAP-QE/artifacts.git /workspace/artifacts
 
@@ -71,12 +74,19 @@ spec:
           $(params.registry) || true
 
         if [ -f "$out_script" ]; then
+          echo -n "true" > $(step.results.generated.path)
           cat "$out_script"
         else
+          echo -n "false" > $(step.results.generated.path)
           echo "🤷 no output script generated!"
+          printf '"{}"' > $(results.pushed.path)
         fi
     - name: build-and-publish
       image: gcr.io/kaniko-project/executor:v1.24.0-debug
+      when:
+        - input: "$(steps.generate.results.generated)"
+          operator: in
+          values: ["true"]
       workingDir: $(workspaces.source.path)/$(params.component)
       env:
         - name: KANIKO_EXECUTOR
@@ -107,6 +117,10 @@ spec:
         fi
     - name: add-more-tags
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
+      when:
+        - input: "$(steps.generate.results.generated)"
+          operator: in
+          values: ["true"]
       script: |
         script="/workspace/build-package-images.sh"
         if [ ! -f "$script" ]; then
@@ -116,3 +130,18 @@ spec:
 
         oras version
         "$script" -P -t || true # -P means disable build and push the image.
+    - name: collect-multi-arch
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
+      when:
+        - input: "$(steps.generate.results.generated)"
+          operator: in
+          values: ["true"]
+      script: |
+        script="/workspace/build-package-images.sh"
+        if [ ! -f "$script" ]; then
+          echo "No build script, skip it."
+          exit 0
+        fi
+
+        oras version
+        "$script" -P -m || true # -P means disable build and push the image.


### PR DESCRIPTION
build tasks based on script generation

- Add a 'generated' result to the generate step and conditionally execute subsequent steps only when the build script was successfully generated.
- This prevents failures in downstream steps when no script is produced.
- Also add a new 'collect-multi-arch' step to the image build task.