### PR TITLE
feat(apps/prod/tekton,apps/gcp/tekton): add pushed-multi-arch result to build-images tasks and pipelines

### DIFF
--- a/apps/gcp/tekton/configs/pipelines/pingcap-build-package-linux.yaml
+++ b/apps/gcp/tekton/configs/pipelines/pingcap-build-package-linux.yaml
@@ -50,8 +50,11 @@ spec:
       description: pushed binaries.
       value: "$(tasks.build-binaries.results.pushed)"
     - name: pushed-images
-      description: pushed images.
+      description: pushed single images.
       value: "$(tasks.build-images.results.pushed)"
+    - name: pushed-multi-arch-images
+      description: pushed multi-arch images.
+      value: "$(tasks.build-images.results.pushed-multi-arch)"
   workspaces:
     - name: source
       description: The workspace where the git repo will be cloned.

--- a/apps/gcp/tekton/configs/tasks/pingcap-build-images.yaml
+++ b/apps/gcp/tekton/configs/tasks/pingcap-build-images.yaml
@@ -19,8 +19,11 @@ spec:
   workspaces:
     - name: source
   results:
-    - description: Just built and pushed images, it will be a yaml content.
+    - description: Just built and pushed single-arch images, it will be a yaml content.
       name: pushed
+      type: string
+    - description: Just built and pushed single-arch images, it will be a yaml content.
+      name: pushed-multi-arch
       type: string
   params:
     - name: component
@@ -80,6 +83,7 @@ spec:
           echo -n "false" > $(step.results.generated.path)
           echo "🤷 no output script generated!"
           printf '"{}"' > $(task.results.pushed.path)
+          printf '"{}"' > $(results.pushed-multi-arch.path)
         fi
     - name: build-and-publish
       image: gcr.io/kaniko-project/executor:v1.24.0-debug
@@ -133,10 +137,5 @@ spec:
           values: ["true"]
       script: |
         script="/workspace/build-package-images.sh"
-        if [ ! -f "$script" ]; then
-          echo "No build script, skip it."
-          exit 0
-        fi
 
-        oras version
-        "$script" -P -m || true # -P means disable build and push the image.
+        "$script" -P -m -M $(results.pushed-multi-arch.path) || true # -P means disable build and push the image.

--- a/apps/gcp/tekton/configs/tasks/pingcap-build-images.yaml
+++ b/apps/gcp/tekton/configs/tasks/pingcap-build-images.yaml
@@ -22,7 +22,7 @@ spec:
     - description: Just built and pushed single-arch images, it will be a yaml content.
       name: pushed
       type: string
-    - description: Just built and pushed single-arch images, it will be a yaml content.
+    - description: Just pushed multi-arch images, it will be a yaml content.
       name: pushed-multi-arch
       type: string
   params:

--- a/apps/prod/tekton/configs/pipelines/pingcap-build-package-linux.yaml
+++ b/apps/prod/tekton/configs/pipelines/pingcap-build-package-linux.yaml
@@ -52,6 +52,9 @@ spec:
     - name: pushed-images
       description: pushed images.
       value: "$(tasks.build-images.results.pushed)"
+    - name: pushed-multi-arch-images
+      description: pushed multi-arch images.
+      value: "$(tasks.build-images.results.pushed-multi-arch)"
   workspaces:
     - name: source
       description: The workspace where the git repo will be cloned.
@@ -179,7 +182,6 @@ spec:
         name: pingcap-build-images
       runAfter:
         - build-binaries
-      # TODO: currently matrix feature is not support in v0.32.x, we need upgrade the K8S cluster and then upgrade Tekton.
       params:
         - name: os
           value: "$(params.os)"

--- a/apps/prod/tekton/configs/tasks/pingcap-build-images.yaml
+++ b/apps/prod/tekton/configs/tasks/pingcap-build-images.yaml
@@ -19,7 +19,7 @@ spec:
     - description: Just built and pushed single-arch images, it will be a yaml content.
       name: pushed
       type: string
-    - description: Just built and pushed single-arch images, it will be a yaml content.
+    - description: Just pushed multi-arch images, it will be a yaml content.
       name: pushed-multi-arch
       type: string
   params:

--- a/apps/prod/tekton/configs/tasks/pingcap-build-images.yaml
+++ b/apps/prod/tekton/configs/tasks/pingcap-build-images.yaml
@@ -16,8 +16,11 @@ spec:
       mountPath: /kaniko/.docker
       optional: true
   results:
-    - description: Just built and pushed images, it will be a yaml content.
+    - description: Just built and pushed single-arch images, it will be a yaml content.
       name: pushed
+      type: string
+    - description: Just built and pushed single-arch images, it will be a yaml content.
+      name: pushed-multi-arch
       type: string
   params:
     - name: component
@@ -89,6 +92,7 @@ spec:
         if [ ! -f "$script" ]; then
           echo "No build script, skip it."
           printf '"{}"' > $(results.pushed.path)
+          printf '"{}"' > $(results.pushed-multi-arch.path)
           exit 0
         fi
 
@@ -113,3 +117,14 @@ spec:
         oras version
         cp -r $(workspaces.dockerconfig.path) ~/.docker # need the credentials.
         "$script" -P -t || true # -P means disable build and push the image.
+    - name: collect-multi-arch
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
+      script: |
+        script="/workspace/build-package-images.sh"
+        if [ ! -f "$script" ]; then
+          echo "No build script, skip it."
+          exit 0
+        fi
+
+        cp -r $(workspaces.dockerconfig.path) ~/.docker # need the credentials.
+        "$script" -P -m -M $(results.pushed-multi-arch.path) || true # -P means disable build and push the image.


### PR DESCRIPTION
This pull request adds support for handling multi-architecture (multi-arch) images in the Tekton pipelines and tasks for both GCP and production environments. The changes introduce new result fields and pipeline outputs to track multi-arch images, and update scripts to generate and collect these results.

**Multi-arch image support:**

* Added a new result field `pushed-multi-arch` in `pingcap-build-images.yaml` tasks to store information about pushed multi-arch images, along with updated descriptions for clarity. [[1]](diffhunk://#diff-441a28f898ce8d8c7d589ac267c0f029009faf4de62296fb55fd577410f1c44dL22-R27) [[2]](diffhunk://#diff-4e6ce54ff92ef3c743849aa118b675f95642e07c52395768fa6823c4bf0ed43bL19-R24)
* Updated task scripts to write empty JSON to `pushed-multi-arch` when no build script is present, ensuring consistent output structure. [[1]](diffhunk://#diff-441a28f898ce8d8c7d589ac267c0f029009faf4de62296fb55fd577410f1c44dR86) [[2]](diffhunk://#diff-4e6ce54ff92ef3c743849aa118b675f95642e07c52395768fa6823c4bf0ed43bR95)
* Modified the build and publish step to invoke the build script with the `-m` and `-M` flags, directing multi-arch output to the new result file. [[1]](diffhunk://#diff-441a28f898ce8d8c7d589ac267c0f029009faf4de62296fb55fd577410f1c44dL136-R141) [[2]](diffhunk://#diff-4e6ce54ff92ef3c743849aa118b675f95642e07c52395768fa6823c4bf0ed43bR120-R130)

**Pipeline output enhancements:**

* Added a new pipeline result/output `pushed-multi-arch-images` to both GCP and production pipeline YAMLs, referencing the new multi-arch result from the build-images task. [[1]](diffhunk://#diff-5af63616e73a4772a327a23b39843d5bf918b820f55da9b276f92c7990773533L53-R57) [[2]](diffhunk://#diff-ce766b7b64adef72b7b3a177ad33e24ec5a6296eaea73fab93e0473927bed22bR55-R57)

**Task step improvements:**

* Introduced a new `collect-multi-arch` step in the production `pingcap-build-images.yaml` task to handle collection and output of multi-arch images.

**General cleanup:**

* Removed an outdated TODO comment about Tekton matrix support in the production pipeline YAML.