### PR TITLE
refactor(apps/gcp/tekton,apps/prod/tekton): append multi-arch tags and major tags into the result for image building

### DIFF
--- a/apps/gcp/tekton/configs/tasks/pingcap-build-images.yaml
+++ b/apps/gcp/tekton/configs/tasks/pingcap-build-images.yaml
@@ -19,12 +19,9 @@ spec:
   workspaces:
     - name: source
   results:
-    - description: Just built and pushed single-arch images, it will be a yaml content.
+    - description: Built and pushed images, it will be a yaml content.
       name: pushed
       type: string
-    # - description: Just pushed multi-arch images, it will be a yaml content.
-    #   name: pushed-multi-arch
-    #   type: string
   params:
     - name: component
     - name: os
@@ -121,13 +118,8 @@ spec:
           values: ["true"]
       script: |
         script="/workspace/build-package-images.sh"
-        if [ ! -f "$script" ]; then
-          echo "No build script, skip it."
-          exit 0
-        fi
-
         oras version
-        "$script" -P -t || true # -P means disable build and push the image.
+        "$script" -P -t -o $(results.pushed.path) # -P means disable build and push the image.
     - name: collect-multi-arch
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
       when:
@@ -136,7 +128,4 @@ spec:
           values: ["true"]
       script: |
         script="/workspace/build-package-images.sh"
-
-        "$script" -P -m -M multi-arch-images.yaml
-        echo "📃results:"
-        cat multi-arch-images.yaml
+        "$script" -P -m -o $(results.pushed.path) # -P means disable build and push the image.

--- a/apps/prod/tekton/configs/tasks/build/pingcap-build-images.yaml
+++ b/apps/prod/tekton/configs/tasks/build/pingcap-build-images.yaml
@@ -16,12 +16,9 @@ spec:
       mountPath: /kaniko/.docker
       optional: true
   results:
-    - description: Just built and pushed single-arch images, it will be a yaml content.
+    - description: Built and pushed images, it will be a yaml content.
       name: pushed
       type: string
-    # - description: Just pushed multi-arch images, it will be a yaml content.
-    #   name: pushed-multi-arch
-    #   type: string
   params:
     - name: component
     - name: os
@@ -74,6 +71,7 @@ spec:
           cat "$out_script"
         else
           echo "🤷 no output script generated!"
+          printf '"{}"' > $(results.pushed.path)
         fi
     - name: build-and-publish
       image: gcr.io/kaniko-project/executor:v1.24.0-debug
@@ -91,7 +89,6 @@ spec:
         script="/workspace/build-package-images.sh"
         if [ ! -f "$script" ]; then
           echo "No build script, skip it."
-          printf '"{}"' > $(results.pushed.path)
           exit 0
         fi
 
@@ -115,7 +112,7 @@ spec:
 
         oras version
         cp -r $(workspaces.dockerconfig.path) ~/.docker # need the credentials.
-        "$script" -P -t || true # -P means disable build and push the image.
+        "$script" -P -t -o $(results.pushed.path) # -P means disable build and push the image.
     - name: collect-multi-arch
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.8.17-13-ga5750d9
       script: |
@@ -126,6 +123,4 @@ spec:
         fi
 
         cp -r $(workspaces.dockerconfig.path) ~/.docker # need the credentials.
-        "$script" -P -m -M multi-arch-images.yaml
-        echo "📃results:"
-        cat multi-arch-images.yaml
+        "$script" -P -m -o $(results.pushed.path) # -P means disable build and push the image.


### PR DESCRIPTION

- Change result description from "Just built and pushed" to "Built and pushed"
- Remove commented multi-arch result definition
- Directly output build results to $(results.pushed.path) instead of manual file handling
- Remove redundant echo statements and conditional checks
- Add default empty JSON output when no script exists in prod environment

depends on https://github.com/PingCAP-QE/artifacts/pull/705