### PR TITLE
opt(apps/prod/tekton/configs): remove the trigger for collecting multi-arch image for migrated items

### DIFF
--- a/apps/prod/tekton/configs/tasks/build/pingcap-build-binaries-darwin.yaml
+++ b/apps/prod/tekton/configs/tasks/build/pingcap-build-binaries-darwin.yaml
@@ -79,6 +79,7 @@ spec:
           cat "$out_script"
         else
           echo "🤷 no output script generated!"
+          printf '"{}"' > $(results.pushed.path)
         fi
     - name: prepare-remote-env-file
       image: "$(params.builder-image)"
@@ -140,7 +141,6 @@ spec:
         script="/workspace/build-package-artifacts.sh"
         if [ ! -f "$script" ]; then
           echo "No build script, skip it."
-          printf '"{}"' > $(results.pushed.path)
           exit 0
         fi
 

--- a/apps/prod/tekton/configs/tasks/build/pingcap-build-binaries-linux.yaml
+++ b/apps/prod/tekton/configs/tasks/build/pingcap-build-binaries-linux.yaml
@@ -82,6 +82,7 @@ spec:
           cat "$out_script"
         else
           echo "🤷 no output script generated!"
+          printf '"{}"' > $(results.pushed.path)
         fi
     - name: build
       image: "$(params.builder-image)"
@@ -116,7 +117,6 @@ spec:
         script="/workspace/build-package-artifacts.sh"
         if [ ! -f "$script" ]; then
           echo "No build script, skip it."
-          printf '"{}"' > $(results.pushed.path)
           exit 0
         fi
 

--- a/apps/prod/tekton/configs/triggers/triggers/_/harbor/image-push-on-harbor.yaml
+++ b/apps/prod/tekton/configs/triggers/triggers/_/harbor/image-push-on-harbor.yaml
@@ -13,7 +13,7 @@ spec:
         - name: filter
           value: >-
             (
-            body.event_data.repository.repo_full_name.matches('^(pingcap|tikv|pingcap_enterprise|devbuild/pingcap|devbuild/tikv)/')
+            body.event_data.repository.repo_full_name.matches('^(pingcap_enterprise)/')
             && !
             body.event_data.repository.repo_full_name.matches('/(package|offline-package)(s)?')
             )


### PR DESCRIPTION
This pull request updates Tekton build task configurations for both Darwin and Linux platforms, improving how the build output is handled when no output script or build script is present. Additionally, it restricts the scope of a Harbor image push trigger to only the `pingcap_enterprise` repository, tightening its filtering logic.

Build output handling improvements:

* In `pingcap-build-binaries-darwin.yaml` and `pingcap-build-binaries-linux.yaml`, ensures that `$(results.pushed.path)` is always populated with an empty JSON object (`"{}"`) when no output script is generated, preventing potential issues with downstream steps that expect this result. [[1]](diffhunk://#diff-6c378dc6436b0b42a90339c734e063ce27ae58531d31b9833b005d31dc07b3e7R82) [[2]](diffhunk://#diff-fac626e9f362396370088211e733b7a482fbb945a4c8e1aef971cf6de6f88c56R85)
* Removes redundant code that wrote `"{}"` to `$(results.pushed.path)` if the build script was missing, centralizing this logic to the output script check for better maintainability. [[1]](diffhunk://#diff-6c378dc6436b0b42a90339c734e063ce27ae58531d31b9833b005d31dc07b3e7L143) [[2]](diffhunk://#diff-fac626e9f362396370088211e733b7a482fbb945a4c8e1aef971cf6de6f88c56L119)

Trigger filtering refinement:

* In `image-push-on-harbor.yaml`, narrows the trigger filter to only match the `pingcap_enterprise` repository, excluding other repositories such as `pingcap`, `tikv`, and related devbuilds, which reduces unnecessary trigger executions.