### PR TITLE
fix(apps/gcp/prow): update prow-controller-manager image to v20250905-a0cfed255

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -111,8 +111,8 @@ spec:
             tikv/tikv
     pcm:
       image:
-        repository: gcr.io/k8s-prow/prow-controller-manager
-        tag: v20240805-533a2035d
+        repository: ghcr.io/ti-community-infra/prow/prow-controller-manager
+        tag: v20250905-a0cfed255
       kubeconfigSecret: prow-kubeconfig
       additionalArgs:
         - --kubeconfig=/etc/kubeconfig/config


### PR DESCRIPTION
Update prow-controller-manager image to ghcr.io/ti-community-infra/prow/prow-controller-manager:v20250905-a0cfed255. 

Ref  https://github.com/ti-community-infra/prow/pull/21,  fix this error:
```shell
{"component":"prow-controller-manager","error":"invalid presubmit job pull-e2e: pod spec may not use init containers","file":"sigs.k8s.io/prow/pkg/config/agent.go:371","func":"sigs.k8s.io/prow/pkg/config.(*Agent).Start.func1","jobConfig":"/etc/prow-jobs","level":"error","msg":"Error loading config.","prowConfig":"/etc/prow-config/config.yaml","severity":"error","time":"2025-09-05T03:36:32Z"}
```