### PR TITLE
chore: update Prow hook image tag to v20250905-a0cfed255

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -87,7 +87,7 @@ spec:
         enabled: false
       image:
         repository: ghcr.io/ti-community-infra/prow/hook
-        tag: v20250903-f07f5145d
+        tag: v20250905-a0cfed255
       kubeconfigSecret: prow-kubeconfig
       additionalArgs:
         - --kubeconfig=/etc/kubeconfig/config


### PR DESCRIPTION
update Prow hook image tag to v20250905-a0cfed255.

Ref  https://github.com/ti-community-infra/prow/pull/21,  fix this error:
```shell
{"component":"prow-controller-manager","error":"invalid presubmit job pull-e2e: pod spec may not use init containers","file":"sigs.k8s.io/prow/pkg/config/agent.go:371","func":"sigs.k8s.io/prow/pkg/config.(*Agent).Start.func1","jobConfig":"/etc/prow-jobs","level":"error","msg":"Error loading config.","prowConfig":"/etc/prow-config/config.yaml","severity":"error","time":"2025-09-05T03:36:32Z"}
```