### PR TITLE
feat(apps/gcp/prow): update sinker image tag and adjust tide image tag to v20250905-a0cfed255

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -53,6 +53,10 @@ spec:
       image:
         repository: ghcr.io/ti-community-infra/prow/crier
         tag: v20241220-cc8d4cf29
+    sinker:
+      image:
+        repository: ghcr.io/ti-community-infra/prow/sinker
+        tag: v20250905-a0cfed255
     deck:
       ingress:
         enabled: false
@@ -71,7 +75,7 @@ spec:
     tide:
       image:
         repository: ghcr.io/ti-community-infra/prow/tide
-        tag: v20250903-f07f5145d
+        tag: v20250905-a0cfed255
       additionalArgs:
         - --sync-hourly-tokens=1200 # default is 800
         - --status-hourly-tokens=600 # default is 400


### PR DESCRIPTION
Ref https://github.com/ti-community-infra/prow/pull/21.

To fix error from tide:
<img width="1986" height="422" alt="img_v3_02q6_8717128d-d99a-4f9b-bd17-a9dc7da2421g" src="https://github.com/user-attachments/assets/08b69663-204a-403a-90db-8fc960892819" />