### PR TITLE
fix(gcp/cla/mongodb): add Docker registry and repository for MongoDB of cla service

### DIFF
--- a/apps/gcp/cla-assistant/mongodb-release.yaml
+++ b/apps/gcp/cla-assistant/mongodb-release.yaml
@@ -24,6 +24,8 @@ spec:
     ignoreFailures: false
   values:
     image:
+      registry: docker.io
+      repository: bitnamilegacy/mongodb
       tag: 4.4.15
     persistence:
       storageClass: premium-rwo # SSD backend.


### PR DESCRIPTION
Add Docker registry and repository for MongoDB of cla service.


<img width="974" height="374" alt="image" src="https://github.com/user-attachments/assets/39f9c6e3-c7c3-4373-938e-21de6905b0ee" />