### PR TITLE
fix(apps/prod/mongodb): Update MongoDB image repository and tag

### DIFF
--- a/apps/prod/mongodb/release.yaml
+++ b/apps/prod/mongodb/release.yaml
@@ -31,8 +31,8 @@ spec:
       size: 16Gi
     image:
       registry: docker.io
-      repository: bitnamilegacy/mongodb
-      tag: 4.4.15
+      repository: bitnami/mongodb
+      tag: 6.0.0-debian-11-r0
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
Update MongoDB image repository and tag. The last change downgraded the MongoDB version, causing the service to fail to start.