### PR TITLE
feat(chatops-lark): update image to v2025.9.21-1-g66dd614

### DIFF
--- a/apps/prod/chatops-lark/release.yaml
+++ b/apps/prod/chatops-lark/release.yaml
@@ -38,7 +38,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/chatops-lark
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/chatops-lark versioning=semver
-      tag: v2025.6.8-1-g78867b3
+      tag: v2025.9.21-1-g66dd614
     server:
       secretName: chatops-lark
       appIdSecretKey: app-id


### PR DESCRIPTION
Update chatops-lark image to v2025.9.21-1-g66dd614. This image contains a new feature which adds a new /repo-admins command that directly calls the GitHub API to return repository administrators.