### PR TITLE
Refactor secrets management in job-ns with kustomize

### DIFF
--- a/apps/gcp/prow/post/job-ns/kustomization.yaml
+++ b/apps/gcp/prow/post/job-ns/kustomization.yaml
@@ -3,6 +3,4 @@ kind: Kustomization
 namespace: ${TEST_PODS_NAMESPACE}
 resources:
   - rbac.yaml
-  - secrets/ci-job-params-mono.yaml
-  - secrets/ci-smtp.yaml
-  - secrets/gcs-credentials.yaml
+  - secrets

--- a/apps/gcp/prow/post/job-ns/secrets/github-token.yaml
+++ b/apps/gcp/prow/post/job-ns/secrets/github-token.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: github-token
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: ee-gcp-sm
+    kind: ClusterSecretStore
+  target:
+    name: github-token
+    creationPolicy: Owner
+  data:
+    - secretKey: token
+      remoteRef:
+        # Name of the secret in GCP Secret Manager that holds the github private token
+        key: github-bot-token

--- a/apps/gcp/prow/post/job-ns/secrets/kustomization.yaml
+++ b/apps/gcp/prow/post/job-ns/secrets/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ci-job-params-mono.yaml
+  - ci-smtp.yaml
+  - gcs-credentials.yaml
+  - github-token.yaml


### PR DESCRIPTION
Move individual secret manifests into a secrets directory and add github-token secret. Update kustomization.yaml to reference the new secrets directory.