### PR TITLE
feat(chatops-lark): update image to v2025.9.21-3-g9e88d3d

### DIFF
--- a/apps/prod/chatops-lark/release.yaml
+++ b/apps/prod/chatops-lark/release.yaml
@@ -38,7 +38,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/chatops-lark
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/chatops-lark versioning=semver
-      tag: v2025.9.21-1-g66dd614
+      tag: v2025.9.21-3-g9e88d3d
     server:
       secretName: chatops-lark
       appIdSecretKey: app-id


### PR DESCRIPTION
This image standardized the help feedback format for chatOps commands.