### PR TITLE
feat(apps/prod/chatops-lark): update chatops-lark image tag

### DIFF
--- a/apps/prod/chatops-lark/release.yaml
+++ b/apps/prod/chatops-lark/release.yaml
@@ -38,7 +38,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/chatops-lark
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/chatops-lark versioning=semver
-      tag: v2025.9.21-3-g9e88d3d
+      tag: v2025.10.12-1-gbb56db0
     server:
       secretName: chatops-lark
       appIdSecretKey: app-id


### PR DESCRIPTION
Update chatops-lark image tag to v2025.10.12-1-gbb56db0. This image version is primarily optimized for the chatops new feature (the /repo-admins command), which excludes org owners to direct users to repo-specific admins, and it also add unit tests.