### PR TITLE
fix(apps/gcp/tekton/setup): add Tekton log access ClusterRole and ClusterRoleBinding

### DIFF
--- a/apps/gcp/tekton/setup/kustomization.yaml
+++ b/apps/gcp/tekton/setup/kustomization.yaml
@@ -6,4 +6,7 @@ resources:
   - https://storage.googleapis.com/tekton-releases/operator/previous/v0.77.0/release.yaml
   - operator-config.yaml
   - http-route.yaml
+  # renovate: datasource=github-releases depName=tektoncd/operator versioning=semver
+  - https://github.com/tektoncd/pipeline/raw/refs/tags/v1.3.1/optional_config/enable-log-access-to-controller/clusterrole.yaml
+  - https://github.com/tektoncd/pipeline/raw/refs/tags/v1.3.1/optional_config/enable-log-access-to-controller/clusterrolebinding.yaml
   # - https://storage.googleapis.com/tekton-releases-nightly/pipelines-in-pipelines/latest/release.yaml


### PR DESCRIPTION
This pull request updates the Tekton setup configuration by adding new resources to enable log access for the controller. These changes improve the observability and debugging capabilities of the Tekton controller by granting necessary permissions.

Log access enhancements:

* Added `clusterrole.yaml` and `clusterrolebinding.yaml` from Tekton Pipeline v1.3.1 to enable log access to the controller (`apps/gcp/tekton/setup/kustomization.yaml`).

Ref: https://tekton.dev/docs/pipelines/additional-configs/#enabling-larger-results-using-sidecar-logs