### PR TITLE
feat(apps/prod2/zot): add community image mirror cronjob and update existing

### DIFF
--- a/apps/prod2/zot/post/cronjob-fetch-branch-tags-mirror-community.yaml
+++ b/apps/prod2/zot/post/cronjob-fetch-branch-tags-mirror-community.yaml
@@ -1,9 +1,9 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: cronjob-fetch-branch-tags-mirror-tidbx-binaries
+  name: cronjob-fetch-branch-tags-mirror-community
 spec:
-  schedule: "10 * * * *"
+  schedule: "30 * * * *"
   jobTemplate:
     spec:
       template:
@@ -21,7 +21,7 @@ spec:
                   memory: 256Mi
               env:
                 - name: DST_REPO_PREFIX
-                  value: "hub-zot.pingcap.net/mirrors/tidbx"
+                  value: "hub-zot.pingcap.net/mirrors/hub"
               command:
                 - /bin/bash
                 - -c
@@ -31,19 +31,15 @@ spec:
                   set -euo pipefail
 
                   ocis=(
-                    pingcap/ticdc/package:master-next-gen_linux_amd64
-                    pingcap/tidb/package:master-next-gen_linux_amd64
-                    pingcap/tiflash/package:master-next-gen_linux_amd64
-                    pingcap/tiflow/package:master-next-gen_linux_amd64
-                    tikv/pd/package:master-next-gen_linux_amd64
-                    tikv/tikv/package:cloud-engine-next-gen_linux_amd64
-
-                    pingcap/ticdc/package:release-nextgen-202603_linux_amd64
-                    pingcap/tidb/package:release-nextgen-202603_linux_amd64
-                    pingcap/tiflash/package:release-nextgen-202603_linux_amd64
-                    pingcap/tiflow/package:release-nextgen-202603_linux_amd64
-                    tikv/pd/package:release-nextgen-202603_linux_amd64
-                    tikv/tikv/package:release-nextgen-202603_linux_amd64
+                    pingcap/ticdc/image:master
+                    pingcap/tidb/images/br:master
+                    pingcap/tidb/images/dumpling:master
+                    pingcap/tidb/images/tidb-lightning:master
+                    pingcap/tidb/images/tidb-server:master
+                    pingcap/tiflash/image:master
+                    pingcap/tiflow/images/dm:master
+                    tikv/pd/image:master
+                    tikv/tikv/image:master
                   )
 
                   any_failed=false

--- a/apps/prod2/zot/post/cronjob-fetch-branch-tags-mirror-tidbx.yaml
+++ b/apps/prod2/zot/post/cronjob-fetch-branch-tags-mirror-tidbx.yaml
@@ -11,7 +11,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: fetch-tags
-              image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.26-7-geb77a69
+              image: ghcr.io/pingcap-qe/cd/utils/release:v2026.3.29-14-g90ae7ef
               resources:
                 requests:
                   cpu: 100m
@@ -37,17 +37,19 @@ spec:
                     pingcap/tidb/images/tidb-lightning:master-next-gen
                     pingcap/tidb/images/tidb-server:master-next-gen
                     pingcap/tiflash/image:master-next-gen
+                    pingcap/tiflow/images/dm:master-next-gen
                     tikv/pd/image:master-next-gen
-                    tikv/tikv/image:dedicated-next-gen
+                    tikv/tikv/image:cloud-engine-next-gen
 
-                    pingcap/ticdc/image:release-nextgen-20251011
-                    pingcap/tidb/images/br:release-nextgen-20251011
-                    pingcap/tidb/images/dumpling:release-nextgen-20251011
-                    pingcap/tidb/images/tidb-lightning:release-nextgen-20251011
-                    pingcap/tidb/images/tidb-server:release-nextgen-20251011
-                    pingcap/tiflash/image:release-nextgen-20251011
-                    tikv/pd/image:release-nextgen-20251011
-                    tikv/tikv/image:release-nextgen-20251011
+                    pingcap/ticdc/image:release-nextgen-202603
+                    pingcap/tidb/images/br:release-nextgen-202603
+                    pingcap/tidb/images/dumpling:release-nextgen-202603
+                    pingcap/tidb/images/tidb-lightning:release-nextgen-202603
+                    pingcap/tidb/images/tidb-server:release-nextgen-202603
+                    pingcap/tiflash/image:release-nextgen-202603
+                    pingcap/tiflow/images/dm:release-nextgen-202603
+                    tikv/pd/image:release-nextgen-202603
+                    tikv/tikv/image:release-nextgen-202603
 
                     pingcap/tidb/images/br:feature-fts-next-gen
                     pingcap/tidb/images/dumpling:feature-fts-next-gen

--- a/apps/prod2/zot/post/kustomization.yaml
+++ b/apps/prod2/zot/post/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - cronjob-fetch-branch-tags-mirror-tidbx.yaml
   - cronjob-fetch-branch-tags-mirror-tidbx-binaries.yaml
+  - cronjob-fetch-branch-tags-mirror-community.yaml


### PR DESCRIPTION
- Add new cronjob for community image mirroring (ticdc, tidb, tiflash,
  tiflow, pd, tikv)
- Update existing cronjobs with new image tag v2026.3.29-14-g90ae7ef
- Adjust schedules to avoid overlap (10, 30 minutes past hour)
- Update tag naming from 20251011 to 202603 and dedicated-next-gen to
  cloud-engine-next-gen
- Add tiflow/dm to both image and binary mirroring
