### PR TITLE
[zizmor] harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/charts_lint-test.yaml
+++ b/.github/workflows/charts_lint-test.yaml
@@ -9,30 +9,35 @@ on:
 jobs:
   chart-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@bf6a7d304bc2fdb57e0331155b7ebf2c504acf0a # v4
         with:
           version: v3.8.1
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: 3.13
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.8.0
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          changed=$(ct list-changed --target-branch "$DEFAULT_BRANCH")
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run chart-testing (lint)

--- a/.github/workflows/charts_release.yaml
+++ b/.github/workflows/charts_release.yaml
@@ -17,9 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Configure Git
         run: |
@@ -27,20 +28,22 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@bf6a7d304bc2fdb57e0331155b7ebf2c504acf0a # v4
         with:
           version: v3.8.1
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.7.0
+        uses: helm/chart-releaser-action@a0d2dc62c5e491af8ef6ba64a2e02bcf3fb33aa1 # v1.7.0
         with:
           skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Publish Artifact Hub repository metadata
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
-          git fetch origin gh-pages
+          git -c http.https://github.com/.extraheader="AUTHORIZATION: bearer ${GITHUB_TOKEN}" fetch origin gh-pages
           worktree="$(mktemp -d)"
           git worktree add -B gh-pages "${worktree}" origin/gh-pages
           cp artifacthub-repo.yml "${worktree}/artifacthub-repo.yml"
@@ -52,5 +55,5 @@ jobs:
 
             git add artifacthub-repo.yml
             git commit -m "chore(charts): publish artifact hub repo metadata"
-            git push origin HEAD:gh-pages
+            git -c http.https://github.com/.extraheader="AUTHORIZATION: bearer ${GITHUB_TOKEN}" push origin HEAD:gh-pages
           popd

--- a/.github/workflows/charts_test-bazel-remote.yaml
+++ b/.github/workflows/charts_test-bazel-remote.yaml
@@ -9,26 +9,29 @@ on:
 jobs:
   chart-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@bf6a7d304bc2fdb57e0331155b7ebf2c504acf0a # v4
         with:
           version: v3.8.1
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: 3.13
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.8.0
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
 
       - name: Setup Kubernetes
-        uses: engineerd/setup-kind@v0.5.0
+        uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0 # v0.5.0
         with:
           # renovate: datasource=go depName=sigs.k8s.io/kind
           version: v0.12.0

--- a/.github/workflows/charts_test-prow.yaml
+++ b/.github/workflows/charts_test-prow.yaml
@@ -9,31 +9,36 @@ on:
 jobs:
   chart-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@bf6a7d304bc2fdb57e0331155b7ebf2c504acf0a # v4
         with:
           version: v3.8.1
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: 3.13
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.8.0
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
 
       - name: Setup Kubernetes
-        uses: engineerd/setup-kind@v0.5.0
+        uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0 # v0.5.0
         with:
           # renovate: datasource=go depName=sigs.k8s.io/kind
           version: v0.12.0
 
       - name: Add test optional files for charts/prow
+        env:
+          ORG_NAME: ${{ github.event.repository.owner.login }}
         run: |
           ns=prow && kubectl create ns $ns
 
@@ -77,7 +82,7 @@ jobs:
           kubectl -n $ns create secret generic prow-oauth-cookie --from-literal secret="$(openssl rand -base64 32)"
 
           # setup configMaps
-          orgName=${{ github.event.repository.owner.login }}
+          orgName="$ORG_NAME"
           sed -iE "s/exampleOrg/${orgName}/g" .github/workflows/test-data/prow/configs/config.yaml
           sed -iE "s/exampleOrg/${orgName}/g" .github/workflows/test-data/prow/configs/plugins.yaml
           kubectl -n $ns create cm prow-config --from-file .github/workflows/test-data/prow/configs/config.yaml

--- a/.github/workflows/gitops_test.yaml
+++ b/.github/workflows/gitops_test.yaml
@@ -8,13 +8,17 @@ on:
 jobs:
   Verify-manifests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: true
       matrix:
         path: [infrastructure, clusters, apps]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Setup tools
         uses: ./.github/actions/flux2/tools
       - name: Validate ${{ matrix.path }} manifests


### PR DESCRIPTION
## Summary
This PR completes the remediation plan from PingCAP-QE/ee-ops#1888 and hardens GitHub Actions workflows flagged by zizmor.

- Pin third-party actions to immutable commit SHAs in 5 workflows.
- Add explicit least-privilege `permissions` at job level.
- Set `persist-credentials: false` for `actions/checkout`.
- Replace 2 template-injection-prone shell interpolations with env-based usage.
- Keep release publishing flow working with token-scoped authenticated fetch/push.

## Validation
- Ran: `zizmor .github/workflows --format plain`
- Result: `No findings to report`
- Note: 25 existing suppressed baseline findings remain unchanged.

## Risk / Remaining Items
- `charts_release` keeps `contents: write` by design for `gh-pages` publishing.
- Existing suppression baseline should be reviewed periodically.

Refs: https://github.com/PingCAP-QE/ee-ops/issues/1888
