### PR TITLE
docs(github-actions-secrets): add central management design

### DIFF
--- a/docs/github-actions-secrets/README.md
+++ b/docs/github-actions-secrets/README.md
@@ -56,12 +56,12 @@ Recommended delivery namespace: `github-actions-secrets`
 The namespace is separate from `infra`:
 
 - `infra` keeps hosting the ESO controllers.
-- `github-actions-secrets` hosts the source `ExternalSecret`, materialized Kubernetes `Secret`, GitHub `SecretStore`, and `PushSecret` objects.
+- `github-actions-secrets` hosts the Workload-Identity-backed Kubernetes service account, source `SecretStore`, source `ExternalSecret`, materialized Kubernetes `Secret`, GitHub `SecretStore`, and `PushSecret` objects.
 
 ```mermaid
 flowchart LR
     A[GCP Secret Manager\nsource of truth]
-    B[ClusterSecretStore\nrestricted to github-actions-secrets]
+    B[Namespaced SecretStore\n+ Workload Identity KSA]
     C[ExternalSecret]
     D[Kubernetes Secret\nin github-actions-secrets]
     E[PushSecret]
@@ -100,13 +100,15 @@ Reasons:
 
 ### 3. Restrict the shared GCP source store
 
-Create a dedicated source `ClusterSecretStore` for GitHub secret delivery, instead of reusing a very broad shared store without restrictions.
+Create a dedicated source `SecretStore` named `gcp-sm-github-actions` in `github-actions-secrets`, instead of reusing a broad shared store.
 
 Recommendation:
 
-- use a separate GCP service account for GitHub secret delivery
+- keep the source store namespaced to `github-actions-secrets`
+- use GKE Workload Identity instead of a static JSON key secret
+- use a dedicated Kubernetes service account and dedicated GCP service account for GitHub secret delivery
 - scope it to only the required GCP secrets or prefixes
-- add `ClusterSecretStore.spec.conditions` so only the `github-actions-secrets` namespace can use it
+- do not keep long-lived GCP credentials in Kubernetes Secrets for this path
 
 ### 4. Use one logical source secret per credential value
 
@@ -166,6 +168,7 @@ Required protections:
 - strict RBAC on `ExternalSecret`, `PushSecret`, `SecretStore`, and `Secret`
 - no application-team write access in the delivery namespace
 - egress-restricted NetworkPolicies for ESO
+- use Workload Identity so the GCP source path does not depend on a static `secret-access-credentials` secret
 
 ### GitHub authentication
 
@@ -187,9 +190,12 @@ This document does not implement the manifests, but the future structure should 
 infrastructure/gcp/github-actions-secrets/
 ├── kustomization.yaml
 ├── namespace.yaml
+├── serviceaccounts/
+│   ├── kustomization.yaml
+│   └── sa-gcp-sm-github-actions.yaml
 ├── source-store/
 │   ├── kustomization.yaml
-│   └── css-ee-gcp-sm-github-actions.yaml
+│   └── ss-gcp-sm-github-actions.yaml
 ├── source-secrets/
 │   ├── kustomization.yaml
 │   ├── es-github-app-private-key.yaml
@@ -219,5 +225,7 @@ infrastructure/gcp/github-actions-secrets/
 - External Secrets Operator GitHub provider: https://external-secrets.io/latest/provider/github/
 - External Secrets Operator PushSecret API: https://external-secrets.io/latest/api/pushsecret/
 - External Secrets Operator security best practices: https://external-secrets.io/latest/guides/security-best-practices/
+- External Secrets Operator Google Secret Manager provider: https://external-secrets.io/latest/provider/google-secrets-manager/
 - GitHub Actions secrets reference: https://docs.github.com/en/actions/reference/security/secrets
 - GitHub App permissions for secrets APIs: https://docs.github.com/en/rest/overview/permissions-required-for-github-apps
+- GKE Workload Identity Federation: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity

--- a/docs/github-actions-secrets/README.md
+++ b/docs/github-actions-secrets/README.md
@@ -1,0 +1,223 @@
+# GitHub Actions Secrets Central Management Design
+
+## Summary
+
+This design uses External Secrets Operator (ESO) to keep GitHub Actions secrets centrally managed from a secret store such as GCP Secret Manager.
+
+The selected model is:
+
+1. Keep the source of truth in GCP Secret Manager.
+2. Materialize source secrets into a dedicated Kubernetes namespace with `ExternalSecret`.
+3. Push those Kubernetes secrets into GitHub Actions secrets with `PushSecret` and the ESO GitHub provider.
+4. Use one active writer cluster for all GitHub secret delivery to avoid concurrent writers.
+
+This design fits the current repository because `ee-ops` already deploys ESO and already uses GCP Secret Manager as a shared secret source.
+
+## Goals
+
+- Manage GitHub Actions secrets centrally for multiple GitHub organizations and repositories.
+- Keep secret values out of Git.
+- Reuse the existing FluxCD + ESO operating model in this repository.
+- Support organization, repository, and environment secrets.
+- Make the delivery path auditable and GitOps-managed.
+
+## Non-goals
+
+- Reading secret values back from GitHub.
+- Using GitHub as a source of truth.
+- Managing GitHub Actions variables.
+- Allowing manual per-repo secret edits as a normal operating path.
+
+## Constraints That Shape the Design
+
+- The ESO GitHub provider is write-only and is intended for creating and updating GitHub Actions secrets, not reading them back.
+- The GitHub provider works with `PushSecret`, so the source secret must first exist as a Kubernetes `Secret`.
+- GitHub target scope is part of the `SecretStore` definition:
+  - organization secret: `organization`
+  - repository secret: `organization` + `repository`
+  - environment secret: `organization` + `repository` + `environment`
+- In current upstream ESO, organization secret visibility can be declared with `orgSecretVisibility` values `all` or `private`.
+- This repository is currently pinned to ESO chart `0.19.0`, and that version does not yet expose `orgSecretVisibility` in the GitHub provider CRD. On that version, new org secrets default to `all`, and updates preserve the visibility of an already existing GitHub org secret.
+- The ESO GitHub provider does not expose a `selected` repository visibility model for organization secrets. If a secret must go to only some repositories in an org, use repository secrets instead.
+
+## Selected Architecture
+
+Recommended active writer cluster: `gcp`
+
+This is an inference from the current repo state:
+
+- `prod` is documented as being deprecated after migration.
+- `gcp` already has ESO deployed.
+- `gcp` is the only cluster that already uses `PushSecret` in this repository today.
+- using `gcp` keeps this outbound GitHub-secret delivery path separate from `prod2` application-platform workloads.
+
+Recommended delivery namespace: `github-actions-secrets`
+
+The namespace is separate from `infra`:
+
+- `infra` keeps hosting the ESO controllers.
+- `github-actions-secrets` hosts the source `ExternalSecret`, materialized Kubernetes `Secret`, GitHub `SecretStore`, and `PushSecret` objects.
+
+```mermaid
+flowchart LR
+    A[GCP Secret Manager\nsource of truth]
+    B[ClusterSecretStore\nrestricted to github-actions-secrets]
+    C[ExternalSecret]
+    D[Kubernetes Secret\nin github-actions-secrets]
+    E[PushSecret]
+    F[GitHub SecretStore\norg/repo/env scoped]
+    G[GitHub Actions Secrets\norg / repo / environment]
+
+    A --> B
+    B --> C
+    C --> D
+    D --> E
+    E --> F
+    F --> G
+```
+
+## Key Decisions
+
+### 1. Use one active writer cluster
+
+GitHub is a global external target, not a cluster-local dependency. Running the same GitHub `PushSecret` workload from multiple clusters creates unnecessary race conditions and makes failures harder to reason about.
+
+Recommendation:
+
+- use only one cluster to push to GitHub
+- keep other clusters on source-side ESO usage only, unless there is a clear failover design
+- if org-level private visibility must be managed declaratively, upgrade ESO before rollout
+
+### 2. Keep GitHub target stores namespaced
+
+Use namespaced `SecretStore` resources for the GitHub provider instead of `ClusterSecretStore`.
+
+Reasons:
+
+- GitHub delivery is a high-exfiltration path
+- only one namespace should own GitHub secret delivery
+- the GitHub App private key can stay local to that namespace
+
+### 3. Restrict the shared GCP source store
+
+Create a dedicated source `ClusterSecretStore` for GitHub secret delivery, instead of reusing a very broad shared store without restrictions.
+
+Recommendation:
+
+- use a separate GCP service account for GitHub secret delivery
+- scope it to only the required GCP secrets or prefixes
+- add `ClusterSecretStore.spec.conditions` so only the `github-actions-secrets` namespace can use it
+
+### 4. Use one logical source secret per credential value
+
+Do not model GCP secrets by GitHub target.
+
+Preferred model:
+
+- one GCP secret per logical credential value
+- separate GitOps delivery mappings decide where that value is pushed
+
+This scales better when the same credential must be shared across many repositories or orgs.
+
+### 5. Use GitHub secret scope intentionally
+
+Recommended scope selection:
+
+| Need | Recommended GitHub scope | Reason |
+| --- | --- | --- |
+| Same secret for many repos in one org | organization secret with `private` visibility | lowest object count, but requires an ESO version that can declare org visibility |
+| Same secret for public and private repos in one org | organization secret with `all` visibility | explicit broad sharing |
+| Same secret for only some repos in one org | repository secrets | ESO does not model org `selected` visibility |
+| Deployment credential for one environment | environment secret | narrowest blast radius |
+| Repo-specific override of an org secret | repository secret with same name | GitHub repo secret overrides org secret |
+| Env-specific override of repo or org secret | environment secret with same name | GitHub env secret overrides repo and org secret |
+
+## GitHub Behavioral Limits To Plan Around
+
+- secret size limit: 48 KB
+- organization secrets: up to 1,000
+- repository secrets: up to 100
+- environment secrets: up to 100
+- if a repository can access more than 100 organization secrets, only the first 100 alphabetically are available to workflows
+- organization and repository secrets are read when a workflow run is queued
+- environment secrets are read when a job referencing the environment starts
+
+Operational consequence:
+
+- keep org-level secrets for broadly shared credentials only
+- do not use org secrets as an unbounded dumping ground
+- prefer repository or environment secrets for narrow use cases and overrides
+
+## Security Model
+
+### Source of truth
+
+- secret values live in GCP Secret Manager
+- Git only stores metadata and delivery mappings
+
+### Materialization in Kubernetes
+
+Because `PushSecret` pushes from a Kubernetes `Secret`, values must exist in the cluster.
+
+Required protections:
+
+- dedicated namespace for GitHub secret delivery
+- Kubernetes secret encryption at rest
+- strict RBAC on `ExternalSecret`, `PushSecret`, `SecretStore`, and `Secret`
+- no application-team write access in the delivery namespace
+- egress-restricted NetworkPolicies for ESO
+
+### GitHub authentication
+
+Use a GitHub App, not a PAT.
+
+Recommended permission set:
+
+- organization permission: `Secrets` write
+- repository permission: `Secrets` write
+- repository permission: `Environments` write if environment secrets are used
+
+Use one company GitHub App installed into each target organization. Each organization installation has its own `installationID`, so each org still needs its own GitHub `SecretStore`.
+
+## Proposed Future Repo Layout
+
+This document does not implement the manifests, but the future structure should look like this:
+
+```text
+infrastructure/gcp/github-actions-secrets/
+├── kustomization.yaml
+├── namespace.yaml
+├── source-store/
+│   ├── kustomization.yaml
+│   └── css-ee-gcp-sm-github-actions.yaml
+├── source-secrets/
+│   ├── kustomization.yaml
+│   ├── es-github-app-private-key.yaml
+│   └── es-*.yaml
+├── target-stores/
+│   ├── kustomization.yaml
+│   ├── gh-org-*.yaml
+│   ├── gh-repo-*.yaml
+│   └── gh-env-*.yaml
+└── deliveries/
+    ├── kustomization.yaml
+    └── ps-*.yaml
+```
+
+## Recommended Operating Rules
+
+- Never edit GitHub Actions secrets manually once a secret is under ESO management.
+- Rotate by updating the secret in GCP Secret Manager.
+- Keep delivery mappings in Git, not in ad hoc scripts.
+- Use organization secrets only for broad sharing.
+- On the current repo-pinned ESO version, do not create new org secrets unless `all` visibility is acceptable or the target org secret already exists with the desired visibility.
+- Use repository secrets for subset targeting because ESO does not model org `selected` repository visibility.
+- Use environment secrets only for deployment-scoped credentials.
+
+## References
+
+- External Secrets Operator GitHub provider: https://external-secrets.io/latest/provider/github/
+- External Secrets Operator PushSecret API: https://external-secrets.io/latest/api/pushsecret/
+- External Secrets Operator security best practices: https://external-secrets.io/latest/guides/security-best-practices/
+- GitHub Actions secrets reference: https://docs.github.com/en/actions/reference/security/secrets
+- GitHub App permissions for secrets APIs: https://docs.github.com/en/rest/overview/permissions-required-for-github-apps

--- a/docs/github-actions-secrets/resource-model.md
+++ b/docs/github-actions-secrets/resource-model.md
@@ -146,7 +146,7 @@ spec:
   data:
     - secretKey: value
       remoteRef:
-        key: projects/pingcap-testing-account/secrets/gha__shared__dockerhub_token/versions/latest
+        key: gha__shared__dockerhub_token
 ```
 
 ## GitHub Target Store Patterns

--- a/docs/github-actions-secrets/resource-model.md
+++ b/docs/github-actions-secrets/resource-model.md
@@ -1,0 +1,373 @@
+# Resource Model And Manifest Patterns
+
+## Design Principles
+
+- Keep secret values in GCP Secret Manager.
+- Materialize only the minimum required Kubernetes secrets in one dedicated namespace.
+- Use namespaced GitHub `SecretStore` objects so only the central delivery namespace can push to GitHub.
+- Keep the source contract stable even if the secret backend changes later.
+
+## Namespace
+
+Recommended namespace:
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: github-actions-secrets
+  labels:
+    ee.pingcap.com/allow-github-actions-sync: "true"
+```
+
+## Naming Conventions
+
+### Kubernetes resources
+
+| Resource | Convention | Example |
+| --- | --- | --- |
+| source `ClusterSecretStore` | `ee-gcp-sm-github-actions` | `ee-gcp-sm-github-actions` |
+| source `ExternalSecret` | `es-src-<logical-secret>` | `es-src-dockerhub-token` |
+| source materialized `Secret` | `src-<logical-secret>` | `src-dockerhub-token` |
+| GitHub App key `ExternalSecret` | `es-github-app-private-key` | `es-github-app-private-key` |
+| GitHub App key `Secret` | `github-app-private-key` | `github-app-private-key` |
+| org `SecretStore` | `gh-org-<org>` on current ESO, `gh-org-<org>-<visibility>` after visibility support is available | `gh-org-pingcap-qe` |
+| repo `SecretStore` | `gh-repo-<org>-<repo>` | `gh-repo-pingcap-qe-ci` |
+| env `SecretStore` | `gh-env-<org>-<repo>-<env>` | `gh-env-pingcap-qe-ci-production` |
+| `PushSecret` | `ps-<logical-secret>-<delivery>` | `ps-dockerhub-token-repo-fanout` |
+
+### GCP Secret Manager
+
+Use a format that is valid for GCP secret IDs and easy to search.
+
+Recommended pattern:
+
+- `gha__shared__<logical-secret>`
+- `gha__repo__<org>__<repo>__<logical-secret>`
+- `gha__env__<org>__<repo>__<environment>__<logical-secret>`
+- `gha__system__github_app_private_key`
+
+Examples:
+
+- `gha__shared__dockerhub_token`
+- `gha__repo__pingcap-qe__ci__codecov_token`
+- `gha__env__pingcap-qe__ci__production__aws_role`
+- `gha__system__github_app_private_key`
+
+## Source Store Pattern
+
+Use a dedicated `ClusterSecretStore` instead of the broad shared one.
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: ee-gcp-sm-github-actions
+spec:
+  conditions:
+    - namespaceSelector:
+        matchLabels:
+          ee.pingcap.com/allow-github-actions-sync: "true"
+  provider:
+    gcpsm:
+      auth:
+        secretRef:
+          secretAccessKeySecretRef:
+            namespace: flux-system
+            name: gcp-sm-sa-secret
+            key: secret-access-credentials
+      projectID: pingcap-testing-account
+```
+
+Notes:
+
+- If the selected active writer cluster is `gcp`, the credential secret can follow the same existing pattern used by `ee-gcp-sm`.
+- `gcp` is also the only cluster in this repo that already uses `PushSecret` today, so it is the least-surprise default for outbound secret sync.
+- Prefer a separate GCP service account for this store with access limited to GitHub-related secrets only.
+
+## GitHub App Private Key Pattern
+
+Store the GitHub App private key in GCP Secret Manager and pull it into the delivery namespace.
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: es-github-app-private-key
+  namespace: github-actions-secrets
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: ee-gcp-sm-github-actions
+    kind: ClusterSecretStore
+  target:
+    name: github-app-private-key
+    creationPolicy: Owner
+  data:
+    - secretKey: privateKey.pem
+      remoteRef:
+        key: projects/pingcap-testing-account/secrets/gha__system__github_app_private_key/versions/latest
+```
+
+## Source Secret Pattern
+
+Each logical credential becomes one source `ExternalSecret` and one materialized Kubernetes `Secret`.
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: es-src-dockerhub-token
+  namespace: github-actions-secrets
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: ee-gcp-sm-github-actions
+    kind: ClusterSecretStore
+  target:
+    name: src-dockerhub-token
+    creationPolicy: Owner
+  data:
+    - secretKey: value
+      remoteRef:
+        key: projects/pingcap-testing-account/secrets/gha__shared__dockerhub_token/versions/latest
+```
+
+## GitHub Target Store Patterns
+
+### Organization secret store
+
+Use this for secrets shared broadly within one org.
+
+Compatibility note:
+
+- with the repo-pinned ESO chart `0.19.0`, the GitHub provider does not expose `orgSecretVisibility`
+- on that version, newly created org secrets default to `all`
+- if the org secret already exists in GitHub, ESO preserves its existing visibility when updating the value
+- if you need declarative `private` vs `all` control in Git, upgrade ESO before implementation
+
+Current repo-compatible org store:
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: gh-org-pingcap-qe
+  namespace: github-actions-secrets
+spec:
+  provider:
+    github:
+      appID: 123456
+      installationID: 10000001
+      organization: pingcap-qe
+      auth:
+        privateKey:
+          name: github-app-private-key
+          key: privateKey.pem
+```
+
+Post-upgrade org store with explicit visibility:
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: gh-org-pingcap-qe-private
+  namespace: github-actions-secrets
+spec:
+  provider:
+    github:
+      appID: 123456
+      installationID: 10000001
+      organization: pingcap-qe
+      orgSecretVisibility: private
+      auth:
+        privateKey:
+          name: github-app-private-key
+          key: privateKey.pem
+```
+
+### Repository secret store
+
+Use this for subset targeting or repo-specific overrides.
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: gh-repo-pingcap-qe-ci
+  namespace: github-actions-secrets
+spec:
+  provider:
+    github:
+      appID: 123456
+      installationID: 10000001
+      organization: pingcap-qe
+      repository: ci
+      auth:
+        privateKey:
+          name: github-app-private-key
+          key: privateKey.pem
+```
+
+### Environment secret store
+
+Use this only for environment-scoped deployment credentials.
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: gh-env-pingcap-qe-ci-production
+  namespace: github-actions-secrets
+spec:
+  provider:
+    github:
+      appID: 123456
+      installationID: 10000001
+      organization: pingcap-qe
+      repository: ci
+      environment: production
+      auth:
+        privateKey:
+          name: github-app-private-key
+          key: privateKey.pem
+```
+
+## PushSecret Patterns
+
+`PushSecret` is still `external-secrets.io/v1alpha1` with the current ESO chart version used in this repo.
+
+### One secret to one org
+
+```yaml
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: ps-dockerhub-token-org
+  namespace: github-actions-secrets
+spec:
+  deletionPolicy: Delete
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: gh-org-pingcap-qe
+      kind: SecretStore
+  selector:
+    secret:
+      name: src-dockerhub-token
+  data:
+    - match:
+        secretKey: value
+        remoteRef:
+          remoteKey: DOCKERHUB_TOKEN
+```
+
+If you stay on the current repo-pinned ESO version, use org-level `PushSecret` only when one of these is true:
+
+- `all` visibility is acceptable for the new org secret
+- the org secret already exists in GitHub with the desired visibility and ESO is only updating the value
+
+### One secret to a selected set of repositories
+
+This is the recommended replacement for org `selected` visibility, because the current ESO GitHub provider does not model selected-repository org secrets.
+
+```yaml
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: ps-codecov-token-repo-fanout
+  namespace: github-actions-secrets
+spec:
+  deletionPolicy: Delete
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: gh-repo-pingcap-qe-ci
+      kind: SecretStore
+    - name: gh-repo-pingcap-qe-artifacts
+      kind: SecretStore
+  selector:
+    secret:
+      name: src-codecov-token
+  data:
+    - match:
+        secretKey: value
+        remoteRef:
+          remoteKey: CODECOV_TOKEN
+```
+
+### One secret to one environment
+
+```yaml
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: ps-aws-role-production
+  namespace: github-actions-secrets
+spec:
+  deletionPolicy: Delete
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: gh-env-pingcap-qe-ci-production
+      kind: SecretStore
+  selector:
+    secret:
+      name: src-aws-role-production
+  data:
+    - match:
+        secretKey: value
+        remoteRef:
+          remoteKey: AWS_ROLE_ARN
+```
+
+## Ownership Metadata
+
+Add labels or annotations so ownership is obvious in Git and in the cluster.
+
+Recommended labels:
+
+```yaml
+metadata:
+  labels:
+    ee.pingcap.com/owner-team: platform
+    ee.pingcap.com/github-org: pingcap-qe
+    ee.pingcap.com/managed-by: fluxcd
+```
+
+Recommended annotations:
+
+```yaml
+metadata:
+  annotations:
+    ee.pingcap.com/source-secret-id: gha__shared__dockerhub_token
+    ee.pingcap.com/github-secret-name: DOCKERHUB_TOKEN
+```
+
+## When To Create A New Target Store
+
+Create a new GitHub `SecretStore` when any of the following changes:
+
+- target organization
+- target repository
+- target environment
+- org secret visibility (`all` vs `private`)
+- GitHub Enterprise base URL
+
+## When To Reuse A Target Store
+
+Reuse a GitHub `SecretStore` when all of the following are the same:
+
+- same GitHub instance
+- same GitHub App and org installation
+- same target organization
+- same target repository, or both are org-scoped
+- same target environment, or both are not env-scoped
+- same org visibility requirement
+
+## Recommended Policy Guardrails
+
+- deny `PushSecret` creation outside `github-actions-secrets`
+- deny GitHub `SecretStore` creation outside `github-actions-secrets`
+- deny use of the restricted `ee-gcp-sm-github-actions` store outside the labeled namespace
+- deny cross-team write access to the delivery namespace
+
+These controls fit well with the Kyverno footprint already present in this repository.

--- a/docs/github-actions-secrets/resource-model.md
+++ b/docs/github-actions-secrets/resource-model.md
@@ -122,7 +122,7 @@ spec:
   data:
     - secretKey: privateKey.pem
       remoteRef:
-        key: projects/pingcap-testing-account/secrets/gha__system__github_app_private_key/versions/latest
+        key: gha__system__github_app_private_key
 ```
 
 ## Source Secret Pattern

--- a/docs/github-actions-secrets/resource-model.md
+++ b/docs/github-actions-secrets/resource-model.md
@@ -16,8 +16,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: github-actions-secrets
-  labels:
-    ee.pingcap.com/allow-github-actions-sync: "true"
 ```
 
 ## Naming Conventions
@@ -26,7 +24,8 @@ metadata:
 
 | Resource | Convention | Example |
 | --- | --- | --- |
-| source `ClusterSecretStore` | `ee-gcp-sm-github-actions` | `ee-gcp-sm-github-actions` |
+| source `ServiceAccount` | `gcp-sm-github-actions` | `gcp-sm-github-actions` |
+| source `SecretStore` | `gcp-sm-github-actions` | `gcp-sm-github-actions` |
 | source `ExternalSecret` | `es-src-<logical-secret>` | `es-src-dockerhub-token` |
 | source materialized `Secret` | `src-<logical-secret>` | `src-dockerhub-token` |
 | GitHub App key `ExternalSecret` | `es-github-app-private-key` | `es-github-app-private-key` |
@@ -56,34 +55,51 @@ Examples:
 
 ## Source Store Pattern
 
-Use a dedicated `ClusterSecretStore` instead of the broad shared one.
+Use a dedicated namespaced `SecretStore` named `gcp-sm-github-actions`.
+
+The source-side authentication model is:
+
+- one Kubernetes service account in `github-actions-secrets`
+- that service account is annotated for GKE Workload Identity
+- the namespaced `SecretStore` references that service account through `auth.workloadIdentity.serviceAccountRef`
+- no static `secret-access-credentials` secret is used
+
+Recommended service account:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gcp-sm-github-actions
+  namespace: github-actions-secrets
+  annotations:
+    iam.gke.io/gcp-service-account: gcp-sm-github-actions@pingcap-testing-account.iam.gserviceaccount.com
+```
+
+Recommended source store:
 
 ```yaml
 apiVersion: external-secrets.io/v1
-kind: ClusterSecretStore
+kind: SecretStore
 metadata:
-  name: ee-gcp-sm-github-actions
+  name: gcp-sm-github-actions
+  namespace: github-actions-secrets
 spec:
-  conditions:
-    - namespaceSelector:
-        matchLabels:
-          ee.pingcap.com/allow-github-actions-sync: "true"
   provider:
     gcpsm:
       auth:
-        secretRef:
-          secretAccessKeySecretRef:
-            namespace: flux-system
-            name: gcp-sm-sa-secret
-            key: secret-access-credentials
+        workloadIdentity:
+          serviceAccountRef:
+            name: gcp-sm-github-actions
       projectID: pingcap-testing-account
 ```
 
 Notes:
 
-- If the selected active writer cluster is `gcp`, the credential secret can follow the same existing pattern used by `ee-gcp-sm`.
+- This uses the same GKE annotation pattern already present elsewhere in the repo, for example `iam.gke.io/gcp-service-account`.
 - `gcp` is also the only cluster in this repo that already uses `PushSecret` today, so it is the least-surprise default for outbound secret sync.
-- Prefer a separate GCP service account for this store with access limited to GitHub-related secrets only.
+- Prefer a dedicated GCP service account for this store with access limited to GitHub-related secrets only.
+- ESO `v0.19.0` supports `gcpsm.auth.workloadIdentity.serviceAccountRef` for GKE Workload Identity.
 
 ## GitHub App Private Key Pattern
 
@@ -98,8 +114,8 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: ee-gcp-sm-github-actions
-    kind: ClusterSecretStore
+    name: gcp-sm-github-actions
+    kind: SecretStore
   target:
     name: github-app-private-key
     creationPolicy: Owner
@@ -122,8 +138,8 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: ee-gcp-sm-github-actions
-    kind: ClusterSecretStore
+    name: gcp-sm-github-actions
+    kind: SecretStore
   target:
     name: src-dockerhub-token
     creationPolicy: Owner
@@ -366,8 +382,9 @@ Reuse a GitHub `SecretStore` when all of the following are the same:
 ## Recommended Policy Guardrails
 
 - deny `PushSecret` creation outside `github-actions-secrets`
+- deny source GCP `SecretStore` creation outside `github-actions-secrets`
 - deny GitHub `SecretStore` creation outside `github-actions-secrets`
-- deny use of the restricted `ee-gcp-sm-github-actions` store outside the labeled namespace
+- deny `ExternalSecret` creation in `github-actions-secrets` unless it references `gcp-sm-github-actions`
 - deny cross-team write access to the delivery namespace
 
 These controls fit well with the Kyverno footprint already present in this repository.

--- a/docs/github-actions-secrets/resource-model.md
+++ b/docs/github-actions-secrets/resource-model.md
@@ -73,7 +73,7 @@ metadata:
   name: gcp-sm-github-actions
   namespace: github-actions-secrets
   annotations:
-    iam.gke.io/gcp-service-account: gcp-sm-github-actions@pingcap-testing-account.iam.gserviceaccount.com
+    iam.gke.io/gcp-service-account: __REPLACE_WITH_GCP_GSA_EMAIL__
 ```
 
 Recommended source store:
@@ -91,7 +91,7 @@ spec:
         workloadIdentity:
           serviceAccountRef:
             name: gcp-sm-github-actions
-      projectID: pingcap-testing-account
+      projectID: __REPLACE_WITH_GCP_PROJECT_ID__
 ```
 
 Notes:

--- a/docs/github-actions-secrets/rollout-and-operations.md
+++ b/docs/github-actions-secrets/rollout-and-operations.md
@@ -18,11 +18,15 @@
 - Grant it access only to the GitHub-related secrets.
 - Store the GitHub App private key in GCP Secret Manager.
 - Store each logical credential in GCP Secret Manager.
+- Bind the Kubernetes service account `github-actions-secrets/gcp-sm-github-actions` to that GCP service account through GKE Workload Identity.
 
 ### Kubernetes and Flux
 
 - Pick one active writer cluster. Recommendation: `gcp`.
 - Create the `github-actions-secrets` namespace.
+- Ensure GKE Workload Identity Federation is enabled on the chosen cluster.
+- Create the Kubernetes service account `gcp-sm-github-actions` in `github-actions-secrets`.
+- Annotate it with `iam.gke.io/gcp-service-account: <gcp-service-account>@<project>.iam.gserviceaccount.com`.
 - Ensure Kubernetes secret encryption at rest is enabled on the chosen cluster.
 - Ensure ESO is healthy in the chosen cluster.
 - If you need declarative org-secret visibility control, upgrade ESO from chart `0.19.0` before implementation.
@@ -34,7 +38,8 @@
 Deliver:
 
 - dedicated namespace
-- restricted GCP `ClusterSecretStore`
+- Workload-Identity-backed Kubernetes service account for GCP Secret Manager access
+- namespaced GCP `SecretStore` `gcp-sm-github-actions`
 - GitHub App private key `ExternalSecret`
 - first GitHub target `SecretStore`
 
@@ -190,6 +195,20 @@ Fix:
 
 - confirm the app installation exists in the target org
 - update the `installationID` in the target `SecretStore`
+
+### Wrong Workload Identity binding
+
+Symptoms:
+
+- source `ExternalSecret` is not ready
+- ESO logs show permission denied or token exchange failures against GCP
+
+Fix:
+
+- confirm GKE Workload Identity Federation is enabled on the cluster
+- confirm the Kubernetes service account annotation matches the intended GCP service account
+- confirm the GCP service account grants `roles/iam.workloadIdentityUser` to the Kubernetes service account
+- confirm the GCP service account has `roles/secretmanager.secretAccessor` on the required secrets or project
 
 ### Secret pushed to the wrong scope
 

--- a/docs/github-actions-secrets/rollout-and-operations.md
+++ b/docs/github-actions-secrets/rollout-and-operations.md
@@ -31,6 +31,208 @@
 - Ensure ESO is healthy in the chosen cluster.
 - If you need declarative org-secret visibility control, upgrade ESO from chart `0.19.0` before implementation.
 
+## Prepare GCP IAM For Workload Identity
+
+The current design uses the Kubernetes-service-account to Google-service-account link pattern for GKE Workload Identity:
+
+- Kubernetes service account: `github-actions-secrets/gcp-sm-github-actions`
+- Google service account: `gcp-sm-github-actions@pingcap-testing-account.iam.gserviceaccount.com`
+- source store: namespaced `SecretStore` `gcp-sm-github-actions`
+
+The currently selected active writer cluster is the repo's `gcp` cluster. In the local environment used to validate this design, that cluster is:
+
+- cluster: `prow`
+- location: `us-central1-c`
+- project: `pingcap-testing-account`
+- workload pool: `pingcap-testing-account.svc.id.goog`
+
+### Recommended Variables
+
+Use these variables when preparing the environment:
+
+```bash
+export PROJECT_ID=pingcap-testing-account
+export CLUSTER_NAME=prow
+export CLUSTER_LOCATION=us-central1-c
+
+export KSA_NAMESPACE=github-actions-secrets
+export KSA_NAME=gcp-sm-github-actions
+
+export GSA_NAME=gcp-sm-github-actions
+export GSA_EMAIL="${GSA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+```
+
+### 1. Confirm Workload Identity Is Enabled On The Cluster
+
+```bash
+gcloud container clusters describe "${CLUSTER_NAME}" \
+  --project="${PROJECT_ID}" \
+  --location="${CLUSTER_LOCATION}" \
+  --format='value(workloadIdentityConfig.workloadPool)'
+```
+
+Expected output:
+
+```text
+pingcap-testing-account.svc.id.goog
+```
+
+If this value is empty, stop here and enable GKE Workload Identity Federation before proceeding.
+
+### 2. Create The Google Service Account
+
+```bash
+gcloud iam service-accounts create "${GSA_NAME}" \
+  --project="${PROJECT_ID}" \
+  --display-name="ESO GitHub Actions Secret Manager access"
+```
+
+Verify:
+
+```bash
+gcloud iam service-accounts describe "${GSA_EMAIL}" \
+  --project="${PROJECT_ID}"
+```
+
+### 3. Grant Secret Manager Access To The Google Service Account
+
+Recommended role:
+
+- `roles/secretmanager.secretAccessor`
+
+Preferred grant model:
+
+- grant access at the individual secret level
+- only use project-level access if secret-level bindings become operationally unmanageable
+
+#### Option A: Secret-level bindings, preferred
+
+Grant the GSA access to each required secret explicitly.
+
+Example for the GitHub App private key:
+
+```bash
+gcloud secrets add-iam-policy-binding gha__system__github_app_private_key \
+  --project="${PROJECT_ID}" \
+  --member="serviceAccount:${GSA_EMAIL}" \
+  --role="roles/secretmanager.secretAccessor"
+```
+
+Example for one shared credential:
+
+```bash
+gcloud secrets add-iam-policy-binding gha__shared__dockerhub_token \
+  --project="${PROJECT_ID}" \
+  --member="serviceAccount:${GSA_EMAIL}" \
+  --role="roles/secretmanager.secretAccessor"
+```
+
+Repeat for every secret that the `gcp-sm-github-actions` `SecretStore` must read.
+
+#### Option B: Project-level binding, broader access
+
+Use this only if secret-level management is too costly for your current rollout stage.
+
+```bash
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+  --member="serviceAccount:${GSA_EMAIL}" \
+  --role="roles/secretmanager.secretAccessor"
+```
+
+Tradeoff:
+
+- simpler to operate
+- significantly broader blast radius
+
+### 4. Create The Kubernetes Namespace And Service Account
+
+```bash
+kubectl create namespace "${KSA_NAMESPACE}"
+
+kubectl create serviceaccount "${KSA_NAME}" \
+  --namespace "${KSA_NAMESPACE}"
+```
+
+If the namespace already exists, only create or reconcile the service account.
+
+### 5. Allow The Kubernetes Service Account To Impersonate The Google Service Account
+
+Grant the Kubernetes service account permission to act as the Google service account:
+
+```bash
+gcloud iam service-accounts add-iam-policy-binding "${GSA_EMAIL}" \
+  --project="${PROJECT_ID}" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="serviceAccount:${PROJECT_ID}.svc.id.goog[${KSA_NAMESPACE}/${KSA_NAME}]"
+```
+
+This binding is required for the linked KSA-to-GSA Workload Identity model used in this design.
+
+### 6. Annotate The Kubernetes Service Account
+
+```bash
+kubectl annotate serviceaccount "${KSA_NAME}" \
+  --namespace "${KSA_NAMESPACE}" \
+  iam.gke.io/gcp-service-account="${GSA_EMAIL}" \
+  --overwrite
+```
+
+Optional:
+
+```bash
+kubectl annotate serviceaccount "${KSA_NAME}" \
+  --namespace "${KSA_NAMESPACE}" \
+  iam.gke.io/return-principal-id-as-email="true" \
+  --overwrite
+```
+
+### 7. Verify The Binding Before Applying ESO Resources
+
+Verify the GSA exists:
+
+```bash
+gcloud iam service-accounts describe "${GSA_EMAIL}" \
+  --project="${PROJECT_ID}" \
+  --format='value(email)'
+```
+
+Verify the KSA annotation:
+
+```bash
+kubectl get serviceaccount "${KSA_NAME}" \
+  --namespace "${KSA_NAMESPACE}" \
+  -o yaml
+```
+
+Verify the Workload Identity IAM binding:
+
+```bash
+gcloud iam service-accounts get-iam-policy "${GSA_EMAIL}" \
+  --project="${PROJECT_ID}" \
+  --format=json
+```
+
+Verify secret-level access for one example secret:
+
+```bash
+gcloud secrets get-iam-policy gha__system__github_app_private_key \
+  --project="${PROJECT_ID}" \
+  --format=json
+```
+
+### 8. Roles That Are Not Required For This Design
+
+You do not need:
+
+- a JSON service account key stored in Kubernetes
+- `roles/iam.serviceAccountTokenCreator` for the ESO source-read path
+- broad owner/editor roles on the project
+
+The minimal intended access pattern is:
+
+- `roles/iam.workloadIdentityUser` on the GSA for `github-actions-secrets/gcp-sm-github-actions`
+- `roles/secretmanager.secretAccessor` on only the secrets, or at most the project, that the design needs to read
+
 ## Rollout Phases
 
 ### Phase 0: Control plane setup

--- a/docs/github-actions-secrets/rollout-and-operations.md
+++ b/docs/github-actions-secrets/rollout-and-operations.md
@@ -1,0 +1,276 @@
+# Rollout And Operations Plan
+
+## Prerequisites
+
+### GitHub
+
+- Create one company GitHub App for Actions secret delivery.
+- Install the app into each target GitHub organization.
+- Record the `appID` and each organization `installationID`.
+- Grant minimum required permissions:
+  - organization `Secrets`: write
+  - repository `Secrets`: write
+  - repository `Environments`: write if environment secrets are needed
+
+### GCP
+
+- Create a dedicated GCP service account for GitHub secret delivery.
+- Grant it access only to the GitHub-related secrets.
+- Store the GitHub App private key in GCP Secret Manager.
+- Store each logical credential in GCP Secret Manager.
+
+### Kubernetes and Flux
+
+- Pick one active writer cluster. Recommendation: `gcp`.
+- Create the `github-actions-secrets` namespace.
+- Ensure Kubernetes secret encryption at rest is enabled on the chosen cluster.
+- Ensure ESO is healthy in the chosen cluster.
+- If you need declarative org-secret visibility control, upgrade ESO from chart `0.19.0` before implementation.
+
+## Rollout Phases
+
+### Phase 0: Control plane setup
+
+Deliver:
+
+- dedicated namespace
+- restricted GCP `ClusterSecretStore`
+- GitHub App private key `ExternalSecret`
+- first GitHub target `SecretStore`
+
+Exit criteria:
+
+- GitHub App private key syncs into the namespace
+- GitHub target `SecretStore` is ready
+- no other cluster is configured to push to GitHub
+
+### Phase 1: Pilot with one org and low-risk secrets
+
+Pilot shape:
+
+- one GitHub organization
+- one or two repositories
+- non-production secrets first
+- prefer repository or environment secrets for the first pilot unless an ESO upgrade for org visibility has already been done
+
+Suggested pilot examples:
+
+- `CODECOV_TOKEN`
+- `NPM_TOKEN`
+- `DOCKERHUB_TOKEN`
+
+Exit criteria:
+
+- secrets appear in GitHub with the expected scope
+- a test workflow can read them successfully
+- updates in GCP Secret Manager are reflected in GitHub after ESO reconciliation
+
+### Phase 2: Migrate broadly shared org secrets
+
+Target secrets that:
+
+- are used by many private repos in the same org
+- do not require selected-repository visibility
+- fit within the org secret count budget
+- are backed by an ESO version that can declare org visibility, or already exist in GitHub with the desired visibility
+
+Exit criteria:
+
+- commonly shared credentials are no longer managed repo by repo
+- organization secret count remains comfortably below the practical per-repo usage limit
+
+### Phase 3: Migrate selected repo and environment secrets
+
+Move:
+
+- repo-specific tokens
+- per-repo overrides
+- deployment environment credentials
+
+Exit criteria:
+
+- manual GitHub secrets are reduced to zero or to an explicitly approved exception list
+- all delivery mappings live in Git
+
+### Phase 4: Add guardrails and scale tooling
+
+Add:
+
+- Kyverno policies for namespace and store restrictions
+- alerts for failing `PushSecret` resources
+- optional catalog generation for large repo inventories
+
+Exit criteria:
+
+- the process is self-service for platform maintainers
+- policy prevents accidental sprawl
+
+## Migration Procedure For One Secret
+
+1. Inventory the current GitHub secret:
+   - scope
+   - secret name
+   - owning team
+   - current repositories and environments
+2. Put the secret value into GCP Secret Manager.
+3. Add the source `ExternalSecret`.
+4. Add the target GitHub `SecretStore` or reuse an existing one.
+5. Add the `PushSecret`.
+6. Let Flux apply the manifests.
+7. Verify the secret exists in GitHub at the expected scope.
+8. Run a workflow that consumes the secret.
+9. Mark the GitHub secret as centrally managed and stop manual edits.
+
+## Rotation Procedure
+
+1. Update the secret value in GCP Secret Manager.
+2. Wait for the source `ExternalSecret` to refresh the Kubernetes `Secret`.
+3. Wait for `PushSecret` to reconcile and update GitHub.
+4. Run a verification workflow if the secret is business-critical.
+
+Operational note:
+
+- org and repo secrets are read when the workflow run is queued
+- environment secrets are read when the job referencing that environment starts
+
+This means already queued runs may still use the old org or repo secret value.
+
+## Break-Glass Procedure
+
+If a production incident requires an emergency secret change:
+
+1. Update the source value in GCP Secret Manager first.
+2. Force reconciliation of the relevant `ExternalSecret` and `PushSecret` if needed.
+3. Avoid editing GitHub directly unless the ESO path is unavailable.
+4. If a direct GitHub edit is unavoidable, backfill GCP Secret Manager and Git immediately after the incident.
+
+## Observability And Validation
+
+### Kubernetes checks
+
+Use ESO status as the primary health signal.
+
+Recommended checks:
+
+```bash
+kubectl -n github-actions-secrets get externalsecret
+kubectl -n github-actions-secrets get pushsecret
+kubectl -n github-actions-secrets describe externalsecret <name>
+kubectl -n github-actions-secrets describe pushsecret <name>
+kubectl -n infra logs deploy/external-secrets -c external-secrets
+```
+
+### GitHub checks
+
+Validate:
+
+- the secret exists at the expected scope
+- the secret name is correct
+- the consuming workflow can access it
+
+### Alerts
+
+Alert on:
+
+- `ExternalSecret` not ready
+- `PushSecret` not ready
+- repeated GitHub API errors
+- repeated GCP Secret Manager access failures
+
+## Common Failure Modes
+
+### Wrong `installationID`
+
+Symptoms:
+
+- GitHub `SecretStore` is not ready
+- GitHub API returns authorization or not found errors
+
+Fix:
+
+- confirm the app installation exists in the target org
+- update the `installationID` in the target `SecretStore`
+
+### Secret pushed to the wrong scope
+
+Cause:
+
+- wrong `SecretStore` reuse
+
+Fix:
+
+- create a separate store for repo or environment scope
+- avoid reusing an org store for repo-specific delivery
+
+### Secret should reach only some repos in an org
+
+Cause:
+
+- attempted use of org-level selected visibility
+
+Fix:
+
+- use repo-scoped `SecretStore` plus `PushSecret` fan-out
+
+### Too many organization secrets available to a repo
+
+Cause:
+
+- org-level sprawl
+
+Fix:
+
+- move narrower secrets to repo or environment scope
+- keep broad shared secrets only at the org layer
+
+### Drift caused by manual GitHub edits
+
+Cause:
+
+- GitHub changed outside the central pipeline
+
+Fix:
+
+- treat GitHub as projection only
+- restore source-of-truth from GCP Secret Manager and Git
+
+## Scale Recommendations
+
+### Up to tens of repos
+
+Plain manifests are fine:
+
+- one source `ExternalSecret` per logical credential
+- one `PushSecret` per delivery set
+- explicit `SecretStore` inventory
+
+### Beyond that
+
+Introduce a generated inventory model:
+
+- one catalog file that describes targets
+- generated `SecretStore` and `PushSecret` manifests from that catalog
+
+Do not start with a generator unless the explicit manifests become hard to review.
+
+## Recommended Initial Scope
+
+Start with:
+
+- one org
+- 3 to 5 shared repository secrets
+- 1 environment secret
+
+Do not start with:
+
+- every org at once
+- production deployment credentials first
+- selected-repository org sharing patterns, because the current provider does not model them
+
+## Success Criteria
+
+- secret values exist only in the external secret manager and in the controlled Kubernetes delivery namespace
+- GitHub secrets are reproducible from Git and the source store
+- there is exactly one active writer cluster for GitHub delivery
+- new orgs and repos can be onboarded without manual secret entry in GitHub
+- platform maintainers can rotate a secret by changing only the source secret manager entry

--- a/docs/github-actions-secrets/rollout-and-operations.md
+++ b/docs/github-actions-secrets/rollout-and-operations.md
@@ -26,7 +26,7 @@
 - Create the `github-actions-secrets` namespace.
 - Ensure GKE Workload Identity Federation is enabled on the chosen cluster.
 - Create the Kubernetes service account `gcp-sm-github-actions` in `github-actions-secrets`.
-- Annotate it with `iam.gke.io/gcp-service-account: <gcp-service-account>@<project>.iam.gserviceaccount.com`.
+- Annotate it with `iam.gke.io/gcp-service-account: __REPLACE_WITH_GCP_GSA_EMAIL__`.
 - Ensure Kubernetes secret encryption at rest is enabled on the chosen cluster.
 - Ensure ESO is healthy in the chosen cluster.
 - If you need declarative org-secret visibility control, upgrade ESO from chart `0.19.0` before implementation.
@@ -36,24 +36,24 @@
 The current design uses the Kubernetes-service-account to Google-service-account link pattern for GKE Workload Identity:
 
 - Kubernetes service account: `github-actions-secrets/gcp-sm-github-actions`
-- Google service account: `gcp-sm-github-actions@pingcap-testing-account.iam.gserviceaccount.com`
+- Google service account: `__REPLACE_WITH_GCP_GSA_EMAIL__`
 - source store: namespaced `SecretStore` `gcp-sm-github-actions`
 
 The currently selected active writer cluster is the repo's `gcp` cluster. In the local environment used to validate this design, that cluster is:
 
-- cluster: `prow`
-- location: `us-central1-c`
-- project: `pingcap-testing-account`
-- workload pool: `pingcap-testing-account.svc.id.goog`
+- cluster: `__REPLACE_WITH_GCP_CLUSTER_NAME__`
+- location: `__REPLACE_WITH_GCP_CLUSTER_LOCATION__`
+- project: `__REPLACE_WITH_GCP_PROJECT_ID__`
+- workload pool: `__REPLACE_WITH_GCP_WORKLOAD_POOL__`
 
 ### Recommended Variables
 
 Use these variables when preparing the environment:
 
 ```bash
-export PROJECT_ID=pingcap-testing-account
-export CLUSTER_NAME=prow
-export CLUSTER_LOCATION=us-central1-c
+export PROJECT_ID=__REPLACE_WITH_GCP_PROJECT_ID__
+export CLUSTER_NAME=__REPLACE_WITH_GCP_CLUSTER_NAME__
+export CLUSTER_LOCATION=__REPLACE_WITH_GCP_CLUSTER_LOCATION__
 
 export KSA_NAMESPACE=github-actions-secrets
 export KSA_NAME=gcp-sm-github-actions
@@ -74,7 +74,7 @@ gcloud container clusters describe "${CLUSTER_NAME}" \
 Expected output:
 
 ```text
-pingcap-testing-account.svc.id.goog
+__REPLACE_WITH_GCP_WORKLOAD_POOL__
 ```
 
 If this value is empty, stop here and enable GKE Workload Identity Federation before proceeding.


### PR DESCRIPTION
## Summary

Add a design package for centrally managing GitHub Actions secrets with External Secrets Operator.

## What Changed

- add `docs/github-actions-secrets/README.md` with the target architecture and design decisions
- add `docs/github-actions-secrets/resource-model.md` with proposed resource layout and manifest patterns
- add `docs/github-actions-secrets/rollout-and-operations.md` with rollout, rotation, and operational guidance
- recommend `gcp` as the active writer cluster because it already hosts ESO and is the only cluster in this repo currently using `PushSecret`
- document the current ESO `0.19.0` limitation: org secret visibility is not declarative at this pinned version, so new org secrets default to `all`

## Validation

- docs only
- no runtime tests executed
