### PR TITLE
feat(gcp): manage Maven Central GitHub Actions secrets via ESO

### DIFF
--- a/docs/github-actions-secrets/resource-model.md
+++ b/docs/github-actions-secrets/resource-model.md
@@ -173,8 +173,8 @@ metadata:
 spec:
   provider:
     github:
-      appID: 123456
-      installationID: 10000001
+      appID: "123456"
+      installationID: "10000001"
       organization: pingcap-qe
       auth:
         privateKey:
@@ -193,8 +193,8 @@ metadata:
 spec:
   provider:
     github:
-      appID: 123456
-      installationID: 10000001
+      appID: "123456"
+      installationID: "10000001"
       organization: pingcap-qe
       orgSecretVisibility: private
       auth:
@@ -216,8 +216,8 @@ metadata:
 spec:
   provider:
     github:
-      appID: 123456
-      installationID: 10000001
+      appID: "123456"
+      installationID: "10000001"
       organization: pingcap-qe
       repository: ci
       auth:
@@ -239,8 +239,8 @@ metadata:
 spec:
   provider:
     github:
-      appID: 123456
-      installationID: 10000001
+      appID: "123456"
+      installationID: "10000001"
       organization: pingcap-qe
       repository: ci
       environment: production

--- a/infrastructure/gcp/github-actions-secrets/deliveries/kustomization.yaml
+++ b/infrastructure/gcp/github-actions-secrets/deliveries/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: github-actions-secrets
+resources:
+  - ps-maven-central-token-username-lake-jdbc-release.yaml
+  - ps-maven-central-token-password-lake-jdbc-release.yaml
+  - ps-maven-gpg-private-key-lake-jdbc-release.yaml
+  - ps-maven-gpg-passphrase-lake-jdbc-release.yaml

--- a/infrastructure/gcp/github-actions-secrets/deliveries/ps-maven-central-token-password-lake-jdbc-release.yaml
+++ b/infrastructure/gcp/github-actions-secrets/deliveries/ps-maven-central-token-password-lake-jdbc-release.yaml
@@ -2,7 +2,6 @@ apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: ps-maven-central-token-password-lake-jdbc-release
-  namespace: github-actions-secrets
   labels:
     ee.pingcap.com/owner-team: platform
     ee.pingcap.com/managed-by: fluxcd

--- a/infrastructure/gcp/github-actions-secrets/deliveries/ps-maven-central-token-password-lake-jdbc-release.yaml
+++ b/infrastructure/gcp/github-actions-secrets/deliveries/ps-maven-central-token-password-lake-jdbc-release.yaml
@@ -1,0 +1,25 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: ps-maven-central-token-password-lake-jdbc-release
+  namespace: github-actions-secrets
+  labels:
+    ee.pingcap.com/owner-team: platform
+    ee.pingcap.com/managed-by: fluxcd
+    ee.pingcap.com/github-org: tidbcloud
+  annotations:
+    ee.pingcap.com/github-secret-name: MAVEN_CENTRAL_TOKEN_PASSWORD
+spec:
+  deletionPolicy: Delete
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: gh-env-tidbcloud-lake-jdbc-maven-central-com-tidbcloud-release
+      kind: SecretStore
+  selector:
+    secret:
+      name: src-maven-central-token-password
+  data:
+    - match:
+        secretKey: value
+        remoteRef:
+          remoteKey: MAVEN_CENTRAL_TOKEN_PASSWORD

--- a/infrastructure/gcp/github-actions-secrets/deliveries/ps-maven-central-token-username-lake-jdbc-release.yaml
+++ b/infrastructure/gcp/github-actions-secrets/deliveries/ps-maven-central-token-username-lake-jdbc-release.yaml
@@ -1,0 +1,25 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: ps-maven-central-token-username-lake-jdbc-release
+  namespace: github-actions-secrets
+  labels:
+    ee.pingcap.com/owner-team: platform
+    ee.pingcap.com/managed-by: fluxcd
+    ee.pingcap.com/github-org: tidbcloud
+  annotations:
+    ee.pingcap.com/github-secret-name: MAVEN_CENTRAL_TOKEN_USERNAME
+spec:
+  deletionPolicy: Delete
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: gh-env-tidbcloud-lake-jdbc-maven-central-com-tidbcloud-release
+      kind: SecretStore
+  selector:
+    secret:
+      name: src-maven-central-token-username
+  data:
+    - match:
+        secretKey: value
+        remoteRef:
+          remoteKey: MAVEN_CENTRAL_TOKEN_USERNAME

--- a/infrastructure/gcp/github-actions-secrets/deliveries/ps-maven-central-token-username-lake-jdbc-release.yaml
+++ b/infrastructure/gcp/github-actions-secrets/deliveries/ps-maven-central-token-username-lake-jdbc-release.yaml
@@ -2,7 +2,6 @@ apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: ps-maven-central-token-username-lake-jdbc-release
-  namespace: github-actions-secrets
   labels:
     ee.pingcap.com/owner-team: platform
     ee.pingcap.com/managed-by: fluxcd

--- a/infrastructure/gcp/github-actions-secrets/deliveries/ps-maven-gpg-passphrase-lake-jdbc-release.yaml
+++ b/infrastructure/gcp/github-actions-secrets/deliveries/ps-maven-gpg-passphrase-lake-jdbc-release.yaml
@@ -2,7 +2,6 @@ apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: ps-maven-gpg-passphrase-lake-jdbc-release
-  namespace: github-actions-secrets
   labels:
     ee.pingcap.com/owner-team: platform
     ee.pingcap.com/managed-by: fluxcd

--- a/infrastructure/gcp/github-actions-secrets/deliveries/ps-maven-gpg-passphrase-lake-jdbc-release.yaml
+++ b/infrastructure/gcp/github-actions-secrets/deliveries/ps-maven-gpg-passphrase-lake-jdbc-release.yaml
@@ -1,0 +1,25 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: ps-maven-gpg-passphrase-lake-jdbc-release
+  namespace: github-actions-secrets
+  labels:
+    ee.pingcap.com/owner-team: platform
+    ee.pingcap.com/managed-by: fluxcd
+    ee.pingcap.com/github-org: tidbcloud
+  annotations:
+    ee.pingcap.com/github-secret-name: MAVEN_GPG_PASSPHRASE
+spec:
+  deletionPolicy: Delete
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: gh-env-tidbcloud-lake-jdbc-maven-central-com-tidbcloud-release
+      kind: SecretStore
+  selector:
+    secret:
+      name: src-maven-gpg-passphrase
+  data:
+    - match:
+        secretKey: value
+        remoteRef:
+          remoteKey: MAVEN_GPG_PASSPHRASE

--- a/infrastructure/gcp/github-actions-secrets/deliveries/ps-maven-gpg-private-key-lake-jdbc-release.yaml
+++ b/infrastructure/gcp/github-actions-secrets/deliveries/ps-maven-gpg-private-key-lake-jdbc-release.yaml
@@ -2,7 +2,6 @@ apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: ps-maven-gpg-private-key-lake-jdbc-release
-  namespace: github-actions-secrets
   labels:
     ee.pingcap.com/owner-team: platform
     ee.pingcap.com/managed-by: fluxcd

--- a/infrastructure/gcp/github-actions-secrets/deliveries/ps-maven-gpg-private-key-lake-jdbc-release.yaml
+++ b/infrastructure/gcp/github-actions-secrets/deliveries/ps-maven-gpg-private-key-lake-jdbc-release.yaml
@@ -1,0 +1,25 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: ps-maven-gpg-private-key-lake-jdbc-release
+  namespace: github-actions-secrets
+  labels:
+    ee.pingcap.com/owner-team: platform
+    ee.pingcap.com/managed-by: fluxcd
+    ee.pingcap.com/github-org: tidbcloud
+  annotations:
+    ee.pingcap.com/github-secret-name: MAVEN_GPG_PRIVATE_KEY
+spec:
+  deletionPolicy: Delete
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: gh-env-tidbcloud-lake-jdbc-maven-central-com-tidbcloud-release
+      kind: SecretStore
+  selector:
+    secret:
+      name: src-maven-gpg-private-key
+  data:
+    - match:
+        secretKey: value
+        remoteRef:
+          remoteKey: MAVEN_GPG_PRIVATE_KEY

--- a/infrastructure/gcp/github-actions-secrets/kustomization.yaml
+++ b/infrastructure/gcp/github-actions-secrets/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - serviceaccounts
+  - source-store
+  - source-secrets
+  - target-stores
+  - deliveries

--- a/infrastructure/gcp/github-actions-secrets/namespace.yaml
+++ b/infrastructure/gcp/github-actions-secrets/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: github-actions-secrets
+  labels:
+    ee.pingcap.com/owner-team: platform
+    ee.pingcap.com/managed-by: fluxcd

--- a/infrastructure/gcp/github-actions-secrets/serviceaccounts/kustomization.yaml
+++ b/infrastructure/gcp/github-actions-secrets/serviceaccounts/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: github-actions-secrets
+resources:
+  - sa-gcp-sm-github-actions.yaml

--- a/infrastructure/gcp/github-actions-secrets/serviceaccounts/sa-gcp-sm-github-actions.yaml
+++ b/infrastructure/gcp/github-actions-secrets/serviceaccounts/sa-gcp-sm-github-actions.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gcp-sm-github-actions
+  namespace: github-actions-secrets
+  labels:
+    ee.pingcap.com/owner-team: platform
+    ee.pingcap.com/managed-by: fluxcd
+  annotations:
+    iam.gke.io/gcp-service-account: gcp-sm-github-actions@pingcap-testing-account.iam.gserviceaccount.com

--- a/infrastructure/gcp/github-actions-secrets/serviceaccounts/sa-gcp-sm-github-actions.yaml
+++ b/infrastructure/gcp/github-actions-secrets/serviceaccounts/sa-gcp-sm-github-actions.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: gcp-sm-github-actions
-  namespace: github-actions-secrets
   labels:
     ee.pingcap.com/owner-team: platform
     ee.pingcap.com/managed-by: fluxcd

--- a/infrastructure/gcp/github-actions-secrets/source-secrets/es-github-app-private-key.yaml
+++ b/infrastructure/gcp/github-actions-secrets/source-secrets/es-github-app-private-key.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: es-github-app-private-key
+  namespace: github-actions-secrets
+  labels:
+    ee.pingcap.com/owner-team: platform
+    ee.pingcap.com/managed-by: fluxcd
+  annotations:
+    ee.pingcap.com/source-secret-id: gha__system__github_app_private_key
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcp-sm-github-actions
+    kind: SecretStore
+  target:
+    name: github-app-private-key
+    creationPolicy: Owner
+  data:
+    - secretKey: privateKey.pem
+      remoteRef:
+        key: gha__system__github_app_private_key

--- a/infrastructure/gcp/github-actions-secrets/source-secrets/es-github-app-private-key.yaml
+++ b/infrastructure/gcp/github-actions-secrets/source-secrets/es-github-app-private-key.yaml
@@ -2,7 +2,6 @@ apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: es-github-app-private-key
-  namespace: github-actions-secrets
   labels:
     ee.pingcap.com/owner-team: platform
     ee.pingcap.com/managed-by: fluxcd

--- a/infrastructure/gcp/github-actions-secrets/source-secrets/es-src-maven-central-token-password.yaml
+++ b/infrastructure/gcp/github-actions-secrets/source-secrets/es-src-maven-central-token-password.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: es-src-maven-central-token-password
+  namespace: github-actions-secrets
+  labels:
+    ee.pingcap.com/owner-team: platform
+    ee.pingcap.com/managed-by: fluxcd
+    ee.pingcap.com/github-org: tidbcloud
+  annotations:
+    ee.pingcap.com/source-secret-id: gha__env__tidbcloud__lake-jdbc__maven-central-com-tidbcloud-release__maven_central_token_password
+    ee.pingcap.com/github-secret-name: MAVEN_CENTRAL_TOKEN_PASSWORD
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcp-sm-github-actions
+    kind: SecretStore
+  target:
+    name: src-maven-central-token-password
+    creationPolicy: Owner
+  data:
+    - secretKey: value
+      remoteRef:
+        key: gha__env__tidbcloud__lake-jdbc__maven-central-com-tidbcloud-release__maven_central_token_password

--- a/infrastructure/gcp/github-actions-secrets/source-secrets/es-src-maven-central-token-password.yaml
+++ b/infrastructure/gcp/github-actions-secrets/source-secrets/es-src-maven-central-token-password.yaml
@@ -2,7 +2,6 @@ apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: es-src-maven-central-token-password
-  namespace: github-actions-secrets
   labels:
     ee.pingcap.com/owner-team: platform
     ee.pingcap.com/managed-by: fluxcd

--- a/infrastructure/gcp/github-actions-secrets/source-secrets/es-src-maven-central-token-username.yaml
+++ b/infrastructure/gcp/github-actions-secrets/source-secrets/es-src-maven-central-token-username.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: es-src-maven-central-token-username
+  namespace: github-actions-secrets
+  labels:
+    ee.pingcap.com/owner-team: platform
+    ee.pingcap.com/managed-by: fluxcd
+    ee.pingcap.com/github-org: tidbcloud
+  annotations:
+    ee.pingcap.com/source-secret-id: gha__env__tidbcloud__lake-jdbc__maven-central-com-tidbcloud-release__maven_central_token_username
+    ee.pingcap.com/github-secret-name: MAVEN_CENTRAL_TOKEN_USERNAME
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcp-sm-github-actions
+    kind: SecretStore
+  target:
+    name: src-maven-central-token-username
+    creationPolicy: Owner
+  data:
+    - secretKey: value
+      remoteRef:
+        key: gha__env__tidbcloud__lake-jdbc__maven-central-com-tidbcloud-release__maven_central_token_username

--- a/infrastructure/gcp/github-actions-secrets/source-secrets/es-src-maven-central-token-username.yaml
+++ b/infrastructure/gcp/github-actions-secrets/source-secrets/es-src-maven-central-token-username.yaml
@@ -2,7 +2,6 @@ apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: es-src-maven-central-token-username
-  namespace: github-actions-secrets
   labels:
     ee.pingcap.com/owner-team: platform
     ee.pingcap.com/managed-by: fluxcd

--- a/infrastructure/gcp/github-actions-secrets/source-secrets/es-src-maven-gpg-passphrase.yaml
+++ b/infrastructure/gcp/github-actions-secrets/source-secrets/es-src-maven-gpg-passphrase.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: es-src-maven-gpg-passphrase
+  namespace: github-actions-secrets
+  labels:
+    ee.pingcap.com/owner-team: platform
+    ee.pingcap.com/managed-by: fluxcd
+    ee.pingcap.com/github-org: tidbcloud
+  annotations:
+    ee.pingcap.com/source-secret-id: gha__env__tidbcloud__lake-jdbc__maven-central-com-tidbcloud-release__maven_gpg_passphrase
+    ee.pingcap.com/github-secret-name: MAVEN_GPG_PASSPHRASE
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcp-sm-github-actions
+    kind: SecretStore
+  target:
+    name: src-maven-gpg-passphrase
+    creationPolicy: Owner
+  data:
+    - secretKey: value
+      remoteRef:
+        key: gha__env__tidbcloud__lake-jdbc__maven-central-com-tidbcloud-release__maven_gpg_passphrase

--- a/infrastructure/gcp/github-actions-secrets/source-secrets/es-src-maven-gpg-passphrase.yaml
+++ b/infrastructure/gcp/github-actions-secrets/source-secrets/es-src-maven-gpg-passphrase.yaml
@@ -2,7 +2,6 @@ apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: es-src-maven-gpg-passphrase
-  namespace: github-actions-secrets
   labels:
     ee.pingcap.com/owner-team: platform
     ee.pingcap.com/managed-by: fluxcd

--- a/infrastructure/gcp/github-actions-secrets/source-secrets/es-src-maven-gpg-private-key.yaml
+++ b/infrastructure/gcp/github-actions-secrets/source-secrets/es-src-maven-gpg-private-key.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: es-src-maven-gpg-private-key
+  namespace: github-actions-secrets
+  labels:
+    ee.pingcap.com/owner-team: platform
+    ee.pingcap.com/managed-by: fluxcd
+    ee.pingcap.com/github-org: tidbcloud
+  annotations:
+    ee.pingcap.com/source-secret-id: gha__env__tidbcloud__lake-jdbc__maven-central-com-tidbcloud-release__maven_gpg_private_key
+    ee.pingcap.com/github-secret-name: MAVEN_GPG_PRIVATE_KEY
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcp-sm-github-actions
+    kind: SecretStore
+  target:
+    name: src-maven-gpg-private-key
+    creationPolicy: Owner
+  data:
+    - secretKey: value
+      remoteRef:
+        key: gha__env__tidbcloud__lake-jdbc__maven-central-com-tidbcloud-release__maven_gpg_private_key

--- a/infrastructure/gcp/github-actions-secrets/source-secrets/es-src-maven-gpg-private-key.yaml
+++ b/infrastructure/gcp/github-actions-secrets/source-secrets/es-src-maven-gpg-private-key.yaml
@@ -2,7 +2,6 @@ apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: es-src-maven-gpg-private-key
-  namespace: github-actions-secrets
   labels:
     ee.pingcap.com/owner-team: platform
     ee.pingcap.com/managed-by: fluxcd

--- a/infrastructure/gcp/github-actions-secrets/source-secrets/kustomization.yaml
+++ b/infrastructure/gcp/github-actions-secrets/source-secrets/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: github-actions-secrets
+resources:
+  - es-github-app-private-key.yaml
+  - es-src-maven-central-token-username.yaml
+  - es-src-maven-central-token-password.yaml
+  - es-src-maven-gpg-private-key.yaml
+  - es-src-maven-gpg-passphrase.yaml

--- a/infrastructure/gcp/github-actions-secrets/source-store/kustomization.yaml
+++ b/infrastructure/gcp/github-actions-secrets/source-store/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: github-actions-secrets
+resources:
+  - ss-gcp-sm-github-actions.yaml

--- a/infrastructure/gcp/github-actions-secrets/source-store/ss-gcp-sm-github-actions.yaml
+++ b/infrastructure/gcp/github-actions-secrets/source-store/ss-gcp-sm-github-actions.yaml
@@ -2,7 +2,6 @@ apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: gcp-sm-github-actions
-  namespace: github-actions-secrets
   labels:
     ee.pingcap.com/owner-team: platform
     ee.pingcap.com/managed-by: fluxcd

--- a/infrastructure/gcp/github-actions-secrets/source-store/ss-gcp-sm-github-actions.yaml
+++ b/infrastructure/gcp/github-actions-secrets/source-store/ss-gcp-sm-github-actions.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: gcp-sm-github-actions
+  namespace: github-actions-secrets
+  labels:
+    ee.pingcap.com/owner-team: platform
+    ee.pingcap.com/managed-by: fluxcd
+spec:
+  provider:
+    gcpsm:
+      auth:
+        workloadIdentity:
+          serviceAccountRef:
+            name: gcp-sm-github-actions
+      projectID: pingcap-testing-account

--- a/infrastructure/gcp/github-actions-secrets/target-stores/gh-env-tidbcloud-lake-jdbc-maven-central-com-tidbcloud-release.yaml
+++ b/infrastructure/gcp/github-actions-secrets/target-stores/gh-env-tidbcloud-lake-jdbc-maven-central-com-tidbcloud-release.yaml
@@ -2,7 +2,6 @@ apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: gh-env-tidbcloud-lake-jdbc-maven-central-com-tidbcloud-release
-  namespace: github-actions-secrets
   labels:
     ee.pingcap.com/owner-team: platform
     ee.pingcap.com/managed-by: fluxcd

--- a/infrastructure/gcp/github-actions-secrets/target-stores/gh-env-tidbcloud-lake-jdbc-maven-central-com-tidbcloud-release.yaml
+++ b/infrastructure/gcp/github-actions-secrets/target-stores/gh-env-tidbcloud-lake-jdbc-maven-central-com-tidbcloud-release.yaml
@@ -10,8 +10,8 @@ metadata:
 spec:
   provider:
     github:
-      appID: 0 # replace with the GitHub App ID prepared for Actions secret delivery
-      installationID: 0 # replace with the tidbcloud org installation ID of that GitHub App
+      appID: 214286
+      installationID: 65036159
       organization: tidbcloud
       repository: lake-jdbc # current implementation assumes Maven release target repo is tidbcloud/lake-jdbc
       environment: maven-central-com-tidbcloud-release

--- a/infrastructure/gcp/github-actions-secrets/target-stores/gh-env-tidbcloud-lake-jdbc-maven-central-com-tidbcloud-release.yaml
+++ b/infrastructure/gcp/github-actions-secrets/target-stores/gh-env-tidbcloud-lake-jdbc-maven-central-com-tidbcloud-release.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: gh-env-tidbcloud-lake-jdbc-maven-central-com-tidbcloud-release
+  namespace: github-actions-secrets
+  labels:
+    ee.pingcap.com/owner-team: platform
+    ee.pingcap.com/managed-by: fluxcd
+    ee.pingcap.com/github-org: tidbcloud
+spec:
+  provider:
+    github:
+      appID: 0 # replace with the GitHub App ID prepared for Actions secret delivery
+      installationID: 0 # replace with the tidbcloud org installation ID of that GitHub App
+      organization: tidbcloud
+      repository: lake-jdbc # current implementation assumes Maven release target repo is tidbcloud/lake-jdbc
+      environment: maven-central-com-tidbcloud-release
+      auth:
+        privateKey:
+          name: github-app-private-key
+          key: privateKey.pem

--- a/infrastructure/gcp/github-actions-secrets/target-stores/gh-env-tidbcloud-lake-jdbc-maven-central-com-tidbcloud-release.yaml
+++ b/infrastructure/gcp/github-actions-secrets/target-stores/gh-env-tidbcloud-lake-jdbc-maven-central-com-tidbcloud-release.yaml
@@ -10,8 +10,8 @@ metadata:
 spec:
   provider:
     github:
-      appID: 214286
-      installationID: 65036159
+      appID: "214286"
+      installationID: "65036159"
       organization: tidbcloud
       repository: lake-jdbc # current implementation assumes Maven release target repo is tidbcloud/lake-jdbc
       environment: maven-central-com-tidbcloud-release

--- a/infrastructure/gcp/github-actions-secrets/target-stores/kustomization.yaml
+++ b/infrastructure/gcp/github-actions-secrets/target-stores/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: github-actions-secrets
+resources:
+  - gh-env-tidbcloud-lake-jdbc-maven-central-com-tidbcloud-release.yaml

--- a/infrastructure/gcp/kustomization.yaml
+++ b/infrastructure/gcp/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
   - gateways
   - kyverno
   - external-secrets
+  - github-actions-secrets
   - operators
   - cleaners


### PR DESCRIPTION
## Summary
- add a dedicated `infrastructure/gcp/github-actions-secrets` stack for GitHub Actions secret delivery via ESO
- materialize the Maven Central and GPG source secrets from GCP Secret Manager into the `github-actions-secrets` namespace
- push those values to the `tidbcloud/lake-jdbc` GitHub environment `maven-central-com-tidbcloud-release`

## Notes
- this PR currently assumes the Maven release target repo is `tidbcloud/lake-jdbc`
- GitHub App IDs and installation IDs are left as explicit placeholders and need to be filled after the app setup is prepared

## Validation
- `git diff --check`
- `python3` YAML parse for `infrastructure/gcp/github-actions-secrets/**/*.yaml`
- local `kustomize build` was not runnable in this environment because neither `kustomize` nor `kubectl` is installed
