### PR TITLE
fix: use numeric github app IDs for lake-jdbc release SecretStore

### DIFF
--- a/docs/github-actions-secrets/resource-model.md
+++ b/docs/github-actions-secrets/resource-model.md
@@ -161,6 +161,7 @@ Compatibility note:
 - on that version, newly created org secrets default to `all`
 - if the org secret already exists in GitHub, ESO preserves its existing visibility when updating the value
 - if you need declarative `private` vs `all` control in Git, upgrade ESO before implementation
+- `appID` and `installationID` must be numeric values, not quoted strings, to pass schema validation
 
 Current repo-compatible org store:
 
@@ -173,8 +174,8 @@ metadata:
 spec:
   provider:
     github:
-      appID: "123456"
-      installationID: "10000001"
+      appID: 123456
+      installationID: 10000001
       organization: pingcap-qe
       auth:
         privateKey:
@@ -193,8 +194,8 @@ metadata:
 spec:
   provider:
     github:
-      appID: "123456"
-      installationID: "10000001"
+      appID: 123456
+      installationID: 10000001
       organization: pingcap-qe
       orgSecretVisibility: private
       auth:
@@ -216,8 +217,8 @@ metadata:
 spec:
   provider:
     github:
-      appID: "123456"
-      installationID: "10000001"
+      appID: 123456
+      installationID: 10000001
       organization: pingcap-qe
       repository: ci
       auth:
@@ -239,8 +240,8 @@ metadata:
 spec:
   provider:
     github:
-      appID: "123456"
-      installationID: "10000001"
+      appID: 123456
+      installationID: 10000001
       organization: pingcap-qe
       repository: ci
       environment: production

--- a/docs/github-actions-secrets/resource-model.md
+++ b/docs/github-actions-secrets/resource-model.md
@@ -161,7 +161,7 @@ Compatibility note:
 - on that version, newly created org secrets default to `all`
 - if the org secret already exists in GitHub, ESO preserves its existing visibility when updating the value
 - if you need declarative `private` vs `all` control in Git, upgrade ESO before implementation
-- `appID` and `installationID` must be numeric values, not quoted strings, to pass schema validation
+- appID and installationID must be integers, not quoted strings, in all GitHub SecretStore types to pass schema validation
 
 Current repo-compatible org store:
 

--- a/infrastructure/gcp/github-actions-secrets/target-stores/gh-env-tidbcloud-lake-jdbc-maven-central-com-tidbcloud-release.yaml
+++ b/infrastructure/gcp/github-actions-secrets/target-stores/gh-env-tidbcloud-lake-jdbc-maven-central-com-tidbcloud-release.yaml
@@ -9,8 +9,8 @@ metadata:
 spec:
   provider:
     github:
-      appID: "214286"
-      installationID: "65036159"
+      appID: 214286
+      installationID: 65036159
       organization: tidbcloud
       repository: lake-jdbc # current implementation assumes Maven release target repo is tidbcloud/lake-jdbc
       environment: maven-central-com-tidbcloud-release


### PR DESCRIPTION
## Summary
- fix Flux dry-run schema error by setting appID and installationID as numeric values in the gh-env-tidbcloud-lake-jdbc-maven-central-com-tidbcloud-release SecretStore
- update docs/github-actions-secrets/resource-model.md to document numeric type requirements
- align all GitHub SecretStore examples in the doc to use unquoted numeric IDs

## Validation
- verified no quoted appID/installationID remain in the touched manifest and resource model doc

Related issue: FLA-105