### PR TITLE
release(ci-dashboard): release 0.1.1 version. bump app and jobs images to v2026.4.19-3-gca3e999

### DIFF
--- a/apps/gcp/ci-dashboard/cronjobs.yaml
+++ b/apps/gcp/ci-dashboard/cronjobs.yaml
@@ -27,7 +27,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-builds
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-1-g8cc80f4
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-3-gca3e999
               imagePullPolicy: IfNotPresent
               args: ["sync-builds"]
               envFrom:
@@ -75,7 +75,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-pr-events
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-1-g8cc80f4
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-3-gca3e999
               imagePullPolicy: IfNotPresent
               args: ["sync-pr-events"]
               envFrom:
@@ -123,7 +123,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: refresh-build-derived
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-1-g8cc80f4
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-3-gca3e999
               imagePullPolicy: IfNotPresent
               args: ["refresh-build-derived"]
               envFrom:
@@ -173,7 +173,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-flaky-issues
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-1-g8cc80f4
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-3-gca3e999
               imagePullPolicy: IfNotPresent
               args: ["sync-flaky-issues"]
               envFrom:

--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -34,7 +34,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/ci-dashboard
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/ci-dashboard versioning=semver
-      tag: v2026.4.19-1-g8cc80f4
+      tag: v2026.4.19-3-gca3e999
     resources:
       requests:
         cpu: "2"


### PR DESCRIPTION
## Summary
- bump `ci-dashboard` app image to `v2026.4.19-3-gca3e999`
- bump `ci-dashboard-jobs` image to `v2026.4.19-3-gca3e999`
- keep chart version unchanged because the merged ee-apps PR did not modify `charts/ci-dashboard`

## Source
- ee-apps PR: https://github.com/PingCAP-QE/ee-apps/pull/413
- merge commit: `ca3e99996c0dfb480cf01dc97b08bc4607931367`
- release workflow: `Skaffold - release` run `24700481444` succeeded on `main`

## Validation
- confirmed new images were published by the successful ee-apps release workflow
- ran `kubectl kustomize apps/gcp/ci-dashboard` successfully in this branch
