### PR TITLE
chore(apps/prod2/tibuild/v2): bump image tag

### DIFF
--- a/apps/prod2/tibuild/v2/release.yaml
+++ b/apps/prod2/tibuild/v2/release.yaml
@@ -37,7 +37,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/exp-tibuild-v2
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/exp-tibuild-v2 versioning=semver
-      tag: v2026.4.19-2-g4a1843b
+      tag: v2026.4.19-6-g44bc5e2
     server:
       debug: false
       config:


### PR DESCRIPTION
## Summary
- bump prod2 tibuild-v2 image tag to v2026.4.19-6-g44bc5e2
- align ee-ops deployment image with latest ee-apps exp-tibuild-v2 build

## Why
- ee-apps includes newer tibuild-v2 changes packaged in v2026.4.19-6-g44bc5e2; prod2 should consume the same build