### PR TITLE
release(ci-dashboard): deploy dashboard v2 sync-pods rollout

### DIFF
--- a/apps/gcp/ci-dashboard/cronjobs.yaml
+++ b/apps/gcp/ci-dashboard/cronjobs.yaml
@@ -27,7 +27,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-builds
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-4-gda86f3b
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-8-g25222cc
               imagePullPolicy: IfNotPresent
               args: ["sync-builds"]
               envFrom:
@@ -75,7 +75,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-pr-events
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-4-gda86f3b
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-8-g25222cc
               imagePullPolicy: IfNotPresent
               args: ["sync-pr-events"]
               envFrom:
@@ -123,7 +123,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: refresh-build-derived
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-4-gda86f3b
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-8-g25222cc
               imagePullPolicy: IfNotPresent
               args: ["refresh-build-derived"]
               envFrom:
@@ -177,7 +177,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-pods
-              image: us-docker.pkg.dev/pingcap-testing-account/internal/test/ci-dashboard-jobs:sync-pods-canary-20260421-214249
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-8-g25222cc
               imagePullPolicy: IfNotPresent
               args: ["sync-pods"]
               envFrom:
@@ -237,7 +237,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-flaky-issues
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-4-gda86f3b
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-8-g25222cc
               imagePullPolicy: IfNotPresent
               args: ["sync-flaky-issues"]
               envFrom:

--- a/apps/gcp/ci-dashboard/cronjobs.yaml
+++ b/apps/gcp/ci-dashboard/cronjobs.yaml
@@ -149,6 +149,68 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
+  name: ci-dashboard-sync-pods
+  namespace: apps
+  labels:
+    app.kubernetes.io/name: ci-dashboard-sync-pods
+    app.kubernetes.io/part-of: ci-dashboard
+spec:
+  schedule: "15 * * * *"
+  timeZone: Asia/Shanghai
+  # Keep the recurring job suspended until Cloud Logging runtime permission is wired for the ci-dashboard service account.
+  suspend: true
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 1800
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 2700
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: ci-dashboard-sync-pods
+            app.kubernetes.io/part-of: ci-dashboard
+        spec:
+          serviceAccountName: ci-dashboard
+          restartPolicy: Never
+          containers:
+            - name: sync-pods
+              image: us-docker.pkg.dev/pingcap-testing-account/internal/test/ci-dashboard-jobs:sync-pods-canary-20260421-214249
+              imagePullPolicy: IfNotPresent
+              args: ["sync-pods"]
+              envFrom:
+                - secretRef:
+                    name: ci-dashboard-eq-prd-insight-db
+              env:
+                - name: PYTHONUNBUFFERED
+                  value: "1"
+                - name: CI_DASHBOARD_LOG_LEVEL
+                  value: INFO
+                - name: CI_DASHBOARD_GCP_PROJECT
+                  value: pingcap-testing-account
+                - name: CI_DASHBOARD_BATCH_SIZE
+                  value: "200"
+                - name: CI_DASHBOARD_POD_EVENT_NAMESPACES
+                  value: prow-test-pods,jenkins-tidb,jenkins-tiflow
+                - name: CI_DASHBOARD_POD_SYNC_OVERLAP_MINUTES
+                  value: "15"
+                - name: CI_DASHBOARD_POD_SYNC_LOOKBACK_MINUTES
+                  value: "180"
+                - name: CI_DASHBOARD_POD_SYNC_MAX_PAGES
+                  value: "200"
+              resources:
+                requests:
+                  cpu: "500m"
+                  memory: 1Gi
+                limits:
+                  cpu: "2"
+                  memory: 4Gi
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
   name: ci-dashboard-sync-flaky-issues
   namespace: apps
   labels:

--- a/apps/gcp/ci-dashboard/kustomization.yaml
+++ b/apps/gcp/ci-dashboard/kustomization.yaml
@@ -4,3 +4,4 @@ namespace: apps
 resources:
   - release.yaml
   - cronjobs.yaml
+  - sync-pods-rbac.yaml

--- a/apps/gcp/ci-dashboard/kustomization.yaml
+++ b/apps/gcp/ci-dashboard/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: apps
 resources:
   - release.yaml
   - cronjobs.yaml

--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -34,7 +34,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/ci-dashboard
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/ci-dashboard versioning=semver
-      tag: v2026.4.19-4-gda86f3b
+      tag: v2026.4.19-8-g25222cc
     resources:
       requests:
         cpu: "2"

--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -2,6 +2,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: ci-dashboard
+  namespace: apps
 spec:
   releaseName: ci-dashboard
   chart:

--- a/apps/gcp/ci-dashboard/sync-pods-rbac.yaml
+++ b/apps/gcp/ci-dashboard/sync-pods-rbac.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ci-dashboard-sync-pods-reader
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ci-dashboard-sync-pods-reader
+subjects:
+  - kind: ServiceAccount
+    name: ci-dashboard
+    namespace: apps
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ci-dashboard-sync-pods-reader

--- a/apps/gcp/ci-dashboard/sync-pods-rbac.yaml
+++ b/apps/gcp/ci-dashboard/sync-pods-rbac.yaml
@@ -8,9 +8,38 @@ rules:
     verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: ci-dashboard-sync-pods-reader
+  namespace: prow-test-pods
+subjects:
+  - kind: ServiceAccount
+    name: ci-dashboard
+    namespace: apps
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ci-dashboard-sync-pods-reader
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ci-dashboard-sync-pods-reader
+  namespace: jenkins-tidb
+subjects:
+  - kind: ServiceAccount
+    name: ci-dashboard
+    namespace: apps
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ci-dashboard-sync-pods-reader
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ci-dashboard-sync-pods-reader
+  namespace: jenkins-tiflow
 subjects:
   - kind: ServiceAccount
     name: ci-dashboard


### PR DESCRIPTION
## Summary
- deploy `ci-dashboard` app and jobs at `v2026.4.19-8-g25222cc`
- include both merged `ee-apps` changes from:
  - `#418` pod sync foundation
  - `#420` refresh-build-derived polish
- add the `ci-dashboard-sync-pods` CronJob and read-only pod RBAC
- switch `sync-pods` from the temporary canary image to the official GHCR jobs image

## What is safe about this rollout
- existing source tables remain untouched
- the new pod ingestion path only writes to the three new pod tables
- current sync jobs keep their existing schedules and semantics, only the jobs image tag is bumped
- `ci-dashboard-sync-pods` remains `suspend: true`, so merging this PR still does not start recurring pod collection

## Validation
- `kubectl kustomize apps/gcp/ci-dashboard`
- canary smoke already validated the sync-pods logic against live data before the app PR merged
- this PR now points at the official release tag derived from `ee-apps` main head `25222cc`

## Before merge / deploy
- confirm the `ee-apps` main release workflow has finished publishing:
  - `ghcr.io/pingcap-qe/ee-apps/ci-dashboard:v2026.4.19-8-g25222cc`
  - `ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-8-g25222cc`

## Follow-up
- wire durable Cloud Logging runtime auth for `apps/ci-dashboard`
- then unsuspend `ci-dashboard-sync-pods`

## Related
- app PRs:
  - https://github.com/PingCAP-QE/ee-apps/pull/418
  - https://github.com/PingCAP-QE/ee-apps/pull/420
