### PR TITLE
fix(ci-dashboard): unblock sync-pods rbac reconcile

### DIFF
--- a/apps/gcp/ci-dashboard/sync-pods-rbac.yaml
+++ b/apps/gcp/ci-dashboard/sync-pods-rbac.yaml
@@ -1,7 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: ci-dashboard-sync-pods-reader
+  namespace: prow-test-pods
 rules:
   - apiGroups: [""]
     resources: ["pods"]
@@ -18,8 +19,18 @@ subjects:
     namespace: apps
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: ci-dashboard-sync-pods-reader
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ci-dashboard-sync-pods-reader
+  namespace: jenkins-tidb
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -32,8 +43,18 @@ subjects:
     namespace: apps
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: ci-dashboard-sync-pods-reader
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ci-dashboard-sync-pods-reader
+  namespace: jenkins-tiflow
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -46,5 +67,5 @@ subjects:
     namespace: apps
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: ci-dashboard-sync-pods-reader


### PR DESCRIPTION
## Summary
- switch `ci-dashboard-sync-pods-reader` back to namespace-scoped `Role + RoleBinding`
- add the missing `prow-test-pods` namespaced RBAC objects
- align the manifest with the manual canary objects already present in `jenkins-tidb` and `jenkins-tiflow`

## Why
The rollout in #1903 is currently blocked in Flux reconciliation because Kubernetes does not allow mutating an existing `RoleBinding.roleRef` from `Role` to `ClusterRole`.

Existing canary-created objects in `jenkins-tidb` and `jenkins-tiflow` already use:
- `Role/ci-dashboard-sync-pods-reader`
- `RoleBinding/ci-dashboard-sync-pods-reader`

This PR keeps the same namespaced model so Flux can reconcile cleanly and continue the `ci-dashboard` rollout.

## Validation
- `kubectl kustomize apps/gcp/ci-dashboard`
- confirmed rendered output contains three namespace-scoped `Role`s and three matching `RoleBinding`s for:
  - `prow-test-pods`
  - `jenkins-tidb`
  - `jenkins-tiflow`
