### PR TITLE
chore(ci-dashboard): enable sync-pods cronjob

### DIFF
--- a/apps/gcp/ci-dashboard/cronjobs.yaml
+++ b/apps/gcp/ci-dashboard/cronjobs.yaml
@@ -157,8 +157,7 @@ metadata:
 spec:
   schedule: "15 * * * *"
   timeZone: Asia/Shanghai
-  # Keep the recurring job suspended until Cloud Logging runtime permission is wired for the ci-dashboard service account.
-  suspend: true
+  suspend: false
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 1800
   successfulJobsHistoryLimit: 3


### PR DESCRIPTION
## Summary
- unsuspend the `ci-dashboard-sync-pods` CronJob in GKE
- keep the existing schedule `15 * * * *` and current jobs image unchanged

## Why
The dashboard rollout and RBAC fix are already live, and the pod collection job is still paused only because the manifest keeps `suspend: true`.

This change opens the recurring pod ingestion path without changing any source tables or the application deployment.

## Validation
- `kubectl kustomize apps/gcp/ci-dashboard`
- confirmed rendered `ci-dashboard-sync-pods` now has `suspend: false`
- all other `ci-dashboard` cronjobs remain unchanged
