### PR TITLE
fix(ci-dashboard): bind workload identity to gsa

### DIFF
--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -43,6 +43,9 @@ spec:
       limits:
         cpu: "4"
         memory: 8Gi
+    serviceAccount:
+      annotations:
+        iam.gke.io/gcp-service-account: ci-dashboard@pingcap-testing-account.iam.gserviceaccount.com
     httpRoute:
       enabled: true
       parentRefs:


### PR DESCRIPTION
## Summary
- bind the `apps/ci-dashboard` Kubernetes ServiceAccount to a dedicated GSA
- set `iam.gke.io/gcp-service-account: ci-dashboard@pingcap-testing-account.iam.gserviceaccount.com`
- keep the app and jobs image tags unchanged

## Why
`ci-dashboard-sync-pods` is now scheduled, but recurring runs fail with Cloud Logging `403 PERMISSION_DENIED`.

The current `apps/ci-dashboard` ServiceAccount has no explicit GSA binding, so the workload identity path is incomplete for the dedicated runtime we want.

This PR prepares the Kubernetes side of the dedicated Workload Identity setup. GCP IAM grants for the GSA will be applied separately.

## Validation
- `kubectl kustomize apps/gcp/ci-dashboard`
- confirmed the rendered `ci-dashboard` ServiceAccount includes the `iam.gke.io/gcp-service-account` annotation
