### PR TITLE
chore(ci-dashboard): modify dashboard  refresh job internal

### DIFF
--- a/apps/gcp/ci-dashboard/cronjobs.yaml
+++ b/apps/gcp/ci-dashboard/cronjobs.yaml
@@ -155,7 +155,7 @@ metadata:
     app.kubernetes.io/name: ci-dashboard-sync-pods
     app.kubernetes.io/part-of: ci-dashboard
 spec:
-  schedule: "15 * * * *"
+  schedule: "*/15 * * * *"
   timeZone: Asia/Shanghai
   suspend: false
   concurrencyPolicy: Forbid

--- a/apps/gcp/ci-dashboard/cronjobs.yaml
+++ b/apps/gcp/ci-dashboard/cronjobs.yaml
@@ -103,7 +103,7 @@ metadata:
     app.kubernetes.io/name: ci-dashboard-refresh-build-derived
     app.kubernetes.io/part-of: ci-dashboard
 spec:
-  schedule: "35 * * * *"
+  schedule: "20,50 * * * *"
   timeZone: Asia/Shanghai
   suspend: false
   concurrencyPolicy: Forbid


### PR DESCRIPTION
ci-dashboard-sync-pods , every 15m
ci-dashboard-refresh-build-derived ,   every 30m