### PR TITLE
release(ci-dashboard): deploy 0.1.2 rollout

### DIFF
--- a/apps/gcp/ci-dashboard/cronjobs.yaml
+++ b/apps/gcp/ci-dashboard/cronjobs.yaml
@@ -27,7 +27,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-builds
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-8-g25222cc
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-9-ga121b4c
               imagePullPolicy: IfNotPresent
               args: ["sync-builds"]
               envFrom:
@@ -75,7 +75,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-pr-events
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-8-g25222cc
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-9-ga121b4c
               imagePullPolicy: IfNotPresent
               args: ["sync-pr-events"]
               envFrom:
@@ -123,7 +123,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: refresh-build-derived
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-8-g25222cc
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-9-ga121b4c
               imagePullPolicy: IfNotPresent
               args: ["refresh-build-derived"]
               envFrom:
@@ -176,7 +176,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-pods
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-8-g25222cc
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-9-ga121b4c
               imagePullPolicy: IfNotPresent
               args: ["sync-pods"]
               envFrom:
@@ -236,7 +236,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-flaky-issues
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-8-g25222cc
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-9-ga121b4c
               imagePullPolicy: IfNotPresent
               args: ["sync-flaky-issues"]
               envFrom:

--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: ci-dashboard
-      version: 0.1.0
+      version: 0.1.2
       sourceRef:
         kind: HelmRepository
         name: ee-apps
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/ci-dashboard
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/ci-dashboard versioning=semver
-      tag: v2026.4.19-8-g25222cc
+      tag: v2026.4.19-9-ga121b4c
     resources:
       requests:
         cpu: "2"


### PR DESCRIPTION
## Summary
- bump the ci-dashboard HelmRelease chart version from `0.1.0` to `0.1.2`
- roll the ci-dashboard app image to `ghcr.io/pingcap-qe/ee-apps/ci-dashboard:v2026.4.19-9-ga121b4c`
- roll all ci-dashboard job CronJobs to `ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-9-ga121b4c`

## Release inputs
- ee-apps PR: https://github.com/PingCAP-QE/ee-apps/pull/421
- ee-apps release workflow: https://github.com/PingCAP-QE/ee-apps/actions/runs/24821177463
- ee-apps charts release workflow: https://github.com/PingCAP-QE/ee-apps/actions/runs/24821177458

## Validation
- confirmed `Skaffold - release` succeeded for merge commit `a121b4c5700030a575750087661b6e3664115c2c`
- confirmed chart push log contains `ghcr.io/pingcap-qe/ee-apps/charts/ci-dashboard:0.1.2`
- confirmed image push log contains `v2026.4.19-9-ga121b4c` for both `ci-dashboard` and `ci-dashboard-jobs`