### PR TITLE
chore(apps/prod2/tibuild/v2): bump exp-tibuild-v2 image

### DIFF
--- a/apps/prod2/tibuild/v2/release.yaml
+++ b/apps/prod2/tibuild/v2/release.yaml
@@ -37,7 +37,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/exp-tibuild-v2
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/exp-tibuild-v2 versioning=semver
-      tag: v2026.4.19-6-g44bc5e2
+      tag: v2026.4.19-10-gab82bf8
     server:
       debug: false
       config:


### PR DESCRIPTION
Bump `ghcr.io/pingcap-qe/ee-apps/exp-tibuild-v2` image tag to `v2026.4.19-10-gab82bf8`.

Source: PingCAP-QE/ee-apps#422 (merge commit `ab82bf8e1389e5502fc63517ec430f06e29170b7`).

Post-merge CI/build: https://github.com/PingCAP-QE/ee-apps/actions/runs/24838033820
