### PR TITLE
chore(apps/prod2/tibuild): bump tibuild-v2 image to v2026.4.19-10-gab82bf8

### DIFF
--- a/apps/prod2/tibuild/v2/release.yaml
+++ b/apps/prod2/tibuild/v2/release.yaml
@@ -37,7 +37,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/exp-tibuild-v2
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/exp-tibuild-v2 versioning=semver
-      tag: v2026.4.19-6-g44bc5e2
+      tag: v2026.4.19-10-gab82bf8
     server:
       debug: false
       config:


### PR DESCRIPTION
Bump tibuild/v2 deployment image to match ee-apps#422 merge commit (ab82bf8e) build.

- Image: ghcr.io/pingcap-qe/ee-apps/exp-tibuild-v2:v2026.4.19-10-gab82bf8
- Source: PingCAP-QE/ee-apps#422 (merged 2026-04-23)
