### PR TITLE
chore(ci-dashboard): prepare V2.5 cutover rollout

### DIFF
--- a/apps/gcp/ci-dashboard/cronjobs.yaml
+++ b/apps/gcp/ci-dashboard/cronjobs.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   schedule: "5 * * * *"
   timeZone: Asia/Shanghai
-  suspend: false
+  suspend: true
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 1800
   successfulJobsHistoryLimit: 5
@@ -27,7 +27,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-builds
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-9-ga121b4c
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-11-gad85ad3
               imagePullPolicy: IfNotPresent
               args: ["sync-builds"]
               envFrom:
@@ -57,7 +57,7 @@ metadata:
 spec:
   schedule: "15 * * * *"
   timeZone: Asia/Shanghai
-  suspend: false
+  suspend: true
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 1800
   successfulJobsHistoryLimit: 5
@@ -75,7 +75,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-pr-events
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-9-ga121b4c
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-11-gad85ad3
               imagePullPolicy: IfNotPresent
               args: ["sync-pr-events"]
               envFrom:
@@ -105,7 +105,7 @@ metadata:
 spec:
   schedule: "20,50 * * * *"
   timeZone: Asia/Shanghai
-  suspend: false
+  suspend: true
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 1800
   successfulJobsHistoryLimit: 5
@@ -123,7 +123,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: refresh-build-derived
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-9-ga121b4c
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-11-gad85ad3
               imagePullPolicy: IfNotPresent
               args: ["refresh-build-derived"]
               envFrom:
@@ -157,7 +157,7 @@ metadata:
 spec:
   schedule: "*/15 * * * *"
   timeZone: Asia/Shanghai
-  suspend: false
+  suspend: true
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 1800
   successfulJobsHistoryLimit: 3
@@ -176,7 +176,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-pods
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-9-ga121b4c
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-11-gad85ad3
               imagePullPolicy: IfNotPresent
               args: ["sync-pods"]
               envFrom:
@@ -218,7 +218,7 @@ metadata:
 spec:
   schedule: "0 */4 * * *"
   timeZone: Asia/Shanghai
-  suspend: false
+  suspend: true
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 1800
   successfulJobsHistoryLimit: 5
@@ -236,7 +236,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-flaky-issues
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-9-ga121b4c
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.19-11-gad85ad3
               imagePullPolicy: IfNotPresent
               args: ["sync-flaky-issues"]
               envFrom:

--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/ci-dashboard
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/ci-dashboard versioning=semver
-      tag: v2026.4.19-9-ga121b4c
+      tag: v2026.4.19-11-gad85ad3
     resources:
       requests:
         cpu: "2"


### PR DESCRIPTION
## Summary
- bump `ci-dashboard` app image to `v2026.4.19-11-gad85ad3`
- bump all `ci-dashboard` jobs images to `v2026.4.19-11-gad85ad3`
- keep all five recurring CronJobs suspended during the V2.5 maintenance window

## Why
- `ee-apps` V2.5 merged in PingCAP-QE/ee-apps#424 and the release workflow has already published the new app/jobs images
- production DB cutover SQL `013_cutover_canonical_build_urls.sql` has already been applied
- old `sync-pods` jobs are not schema-compatible after the cutover, so we need Flux to stop reconciling the old images
- we intentionally keep the CronJobs suspended in GitOps so we can deploy the new images, run the one-off backfill/reconcile jobs, and smoke test before resuming the recurring schedule

## Follow-up after merge
- wait for Flux to apply the new app/jobs images
- run one-off `backfill-range`
- run one-off `reconcile-pod-linkage-range`
- run a `sync-pods` smoke job from the suspended CronJob
- send a small follow-up PR to set the five CronJobs back to `suspend: false`
