### PR TITLE
chore(jenkins): route GCP CD events to /jenkins-event

### DIFF
--- a/apps/gcp/jenkins/beta/release/values-JCasC.yaml
+++ b/apps/gcp/jenkins/beta/release/values-JCasC.yaml
@@ -312,7 +312,7 @@ controller:
       cdevents: |
         unclassified:
           cDEventsGlobalConfig:
-            httpSinkUrl: "http://cloudevents-server.cs.svc"
+            httpSinkUrl: "http://cloudevents-server.cs.svc/jenkins-event"
             sinkType: "http"
       # for global env variables
       env-vars: |


### PR DESCRIPTION
## Summary
- update the GCP Jenkins CD Events Plugin sink URL to `http://cloudevents-server.cs.svc/jenkins-event`

## Testing
- configuration-only change
- intended validation path:
  1. first merge the Kafka topic PR
  2. merge the `cloudevents-server` code PR
  3. roll out the new `cloudevents-server` image in GCP
  4. manually update the sink in Jenkins Web UI and verify events land in Kafka topic `jenkins-event`
  5. merge this JCasC PR during a low-traffic window after manual validation succeeds

## Rollout Notes
- this change can restart or reload Jenkins controller configuration
- keep this PR separate from the Kafka topic and `cloudevents-server` rollout
- do not merge this PR before the new `cloudevents-server` image is actually running in GCP
