### PR TITLE
feat(infrastructure/gcp): add tofu-controller GitOps

### DIFF
--- a/clusters/gcp/README.md
+++ b/clusters/gcp/README.md
@@ -18,6 +18,22 @@
 
 This cluster uses [tofu-controller](https://flux-iac.github.io/tofu-controller/) to manage GCP resources via GitOps.
 
+### Prerequisites
+
+- FluxCD installed and bootstrapped on the cluster
+- `kubectl` configured with cluster access
+- `gcloud` CLI installed and authenticated
+- GCP project with required APIs enabled (IAM, GKE, DNS, Storage, etc.)
+
+### Namespace Convention
+
+| Namespace    | Purpose                                                             |
+| ------------ | ------------------------------------------------------------------- |
+| `infra`      | tofu-controller deployment (controller pod)                         |
+| `terraform`  | Terraform CRs and runner pods (runner SA with Workload Identity)    |
+
+The controller runs in `infra`, while the runner SA and Terraform CRs live in `terraform`.
+
 ### Setup
 
 1. **Create GCP Service Account** (if not already exists):
@@ -40,21 +56,27 @@ gcloud projects add-iam-policy-binding pingcap-testing-account \
 2. **Configure Workload Identity** (optional, recommended for GKE):
 
 ```bash
-# Get the GKE cluster name
-gcloud container clusters list --project=pingcap-testing-account
-
-# Create IAM policy binding between KSA and GCP SA
+# Create IAM policy binding between KSA (in terraform namespace) and GCP SA
 gcloud iam service-accounts add-iam-policy-binding \
     tf-controller@pingcap-testing-account.iam.gserviceaccount.com \
     --role roles/iam.workloadIdentityUser \
     --member "serviceAccount:pingcap-testing-account.svc.id.goog[terraform/tofu-controller-runner]"
 ```
 
-3. **Deploy**: After the above prerequisites are met, tofu-controller will be deployed automatically via FluxCD.
+> **Note**: The runner ServiceAccount `tofu-controller-runner` is created in the `terraform` namespace
+> with the Workload Identity annotation by the FluxCD post-install kustomization. Update the
+> GCP SA email in `infrastructure/gcp/tofu-controller/post/runner-workload-identity.yaml` before deployment.
+
+3. **Deploy**: After the above prerequisites are met, push changes to main. FluxCD will
+   automatically reconcile and deploy tofu-controller. Key resources:
+   - `HelmRepository` → defines the tofu-controller Helm chart source
+   - `HelmRelease` → deploys tofu-controller to `infra` namespace
+   - `Namespace` (`terraform`) → created for Terraform CRs and runner pods
+   - `ServiceAccount` → runner SA with Workload Identity annotation in `terraform` namespace
 
 ### Usage
 
-Terraform resources are defined as Kubernetes CRDs in `infrastructure/gcp/terraform/`:
+Terraform resources are defined as Kubernetes CRDs in `infrastructure/gcp/terraform/` and deployed to the `terraform` namespace:
 
 ```
 infrastructure/gcp/terraform/
@@ -70,7 +92,7 @@ infrastructure/gcp/terraform/
 To add new GCP resources managed by Terraform:
 1. Create a new directory under `infrastructure/gcp/terraform/`
 2. Add Terraform HCL files (e.g., `main.tf`, `variables.tf`, `outputs.tf`)
-3. Create a `terraform.yaml` with the `Terraform` CRD
+3. Create a `terraform.yaml` with the `Terraform` CRD (set `metadata.namespace: terraform`)
 4. Add the resource to `kustomization.yaml`
 
 ### Workflow
@@ -81,14 +103,30 @@ To add new GCP resources managed by Terraform:
 4. After merge, tofu-controller will reconcile the Terraform resources
 5. Check status: `kubectl get terraform -n terraform`
 6. View logs: `kubectl logs -n infra deployment/tofu-controller`
+7. Check runner logs if Terraform apply fails: `kubectl logs -n terraform -l app=tofu-controller-runner`
 
 ### Manual Approval
 
 For production resources, set `spec.approvePlan` explicitly instead of `auto`:
+
 ```yaml
-# First, let the controller generate a plan
-# Then find the plan name:
-kubectl get terraform gcp-dns-example -n terraform -o jsonpath='{.status.plan}'
-# Finally, set the plan name to apply:
-# approvePlan: plan-main-<generated-id>
+# First, let the controller generate a plan:
+kubectl get terraform <resource-name> -n terraform -o jsonpath='{.status.plan}'
+# Then set the plan name to apply (under spec.approvePlan):
+#   approvePlan: plan-main-<generated-id>
 ```
+
+This ensures a human reviews the plan before Terraform applies changes.
+
+### Troubleshooting
+
+| Symptom                              | Likely Cause                                   | Check                                                           |
+| ------------------------------------ | ---------------------------------------------- | --------------------------------------------------------------- |
+| Controller pod not starting          | Missing HelmRepository or chart version        | `kubectl get helmrelease -n infra tofu-controller`              |
+| Terraform CR not reconciling         | Namespace mismatch or RBAC issue               | `kubectl describe terraform -n terraform <name>`                |
+| Runner pod fails with auth error     | Workload Identity not configured correctly     | `kubectl describe sa -n terraform tofu-controller-runner`       |
+| Terraform plan stuck in "pending"    | Concurrency limit reached or plan in progress  | Check `tofu-controller` logs and runner status                  |
+
+For further investigation, check:
+- `kubectl get kustomizations -n flux-system` to verify FluxCD reconciliation
+- `flux logs --all-namespaces` for FluxCD reconciliation logs

--- a/clusters/gcp/README.md
+++ b/clusters/gcp/README.md
@@ -12,3 +12,83 @@
 | flux-system | gcs-credentials            | `service-account.json`                             | GCS credentials for prow                                                                                                                                                                        |             |
 | apps        | prow-jenkins-operator-auth | `user`, `token`                                    | auth to external jenkins controller                                                                                                                                                             |             |
 | apps        | prow-tls                   |                                                    | prow site ingress cert secret                                                                                                                                                                   |             |
+| infra       | tf-controller-gcp-sa       | `kubectl -n infra create secret generic ...`       | GCP service account JSON key (alternative to Workload Identity)                                                                                                                                 |             |
+
+## Terraform GitOps (tofu-controller)
+
+This cluster uses [tofu-controller](https://flux-iac.github.io/tofu-controller/) to manage GCP resources via GitOps.
+
+### Setup
+
+1. **Create GCP Service Account** (if not already exists):
+
+```bash
+gcloud iam service-accounts create tf-controller \
+    --project=pingcap-testing-account \
+    --display-name="Terraform Controller Runner"
+
+# Grant necessary roles (adjust as needed):
+gcloud projects add-iam-policy-binding pingcap-testing-account \
+    --member="serviceAccount:tf-controller@pingcap-testing-account.iam.gserviceaccount.com" \
+    --role="roles/dns.admin"
+
+gcloud projects add-iam-policy-binding pingcap-testing-account \
+    --member="serviceAccount:tf-controller@pingcap-testing-account.iam.gserviceaccount.com" \
+    --role="roles/storage.admin"
+```
+
+2. **Configure Workload Identity** (optional, recommended for GKE):
+
+```bash
+# Get the GKE cluster name
+gcloud container clusters list --project=pingcap-testing-account
+
+# Create IAM policy binding between KSA and GCP SA
+gcloud iam service-accounts add-iam-policy-binding \
+    tf-controller@pingcap-testing-account.iam.gserviceaccount.com \
+    --role roles/iam.workloadIdentityUser \
+    --member "serviceAccount:pingcap-testing-account.svc.id.goog[terraform/tofu-controller-runner]"
+```
+
+3. **Deploy**: After the above prerequisites are met, tofu-controller will be deployed automatically via FluxCD.
+
+### Usage
+
+Terraform resources are defined as Kubernetes CRDs in `infrastructure/gcp/terraform/`:
+
+```
+infrastructure/gcp/terraform/
+├── kustomization.yaml
+├── gcp-dns/                  # Example: DNS zone management
+│   ├── main.tf
+│   └── terraform.yaml
+└── gcp-storage-bucket/        # Example: GCS bucket management
+    ├── main.tf
+    └── terraform.yaml
+```
+
+To add new GCP resources managed by Terraform:
+1. Create a new directory under `infrastructure/gcp/terraform/`
+2. Add Terraform HCL files (e.g., `main.tf`, `variables.tf`, `outputs.tf`)
+3. Create a `terraform.yaml` with the `Terraform` CRD
+4. Add the resource to `kustomization.yaml`
+
+### Workflow
+
+1. Make changes to Terraform modules or CRs in `infrastructure/gcp/terraform/`
+2. Commit and push to feature branch
+3. Create PR to main
+4. After merge, tofu-controller will reconcile the Terraform resources
+5. Check status: `kubectl get terraform -n terraform`
+6. View logs: `kubectl logs -n infra deployment/tofu-controller`
+
+### Manual Approval
+
+For production resources, set `spec.approvePlan` explicitly instead of `auto`:
+```yaml
+# First, let the controller generate a plan
+# Then find the plan name:
+kubectl get terraform gcp-dns-example -n terraform -o jsonpath='{.status.plan}'
+# Finally, set the plan name to apply:
+# approvePlan: plan-main-<generated-id>
+```

--- a/infrastructure/_base/sources/helm-repo-tofu-controller.yaml
+++ b/infrastructure/_base/sources/helm-repo-tofu-controller.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
 metadata:

--- a/infrastructure/_base/sources/kustomization.yaml
+++ b/infrastructure/_base/sources/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - helm-repo-others.yaml
   - helm-repo-kyverno.yaml
   - helm-repo-external-secrets.yaml
+  - helm-repo-tofu-controller.yaml

--- a/infrastructure/gcp/kustomization.yaml
+++ b/infrastructure/gcp/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - gateways
   - kyverno
   - external-secrets
+  - tofu-controller
   - github-actions-secrets
   - operators
   - cleaners

--- a/infrastructure/gcp/tofu-controller/kustomization.yaml
+++ b/infrastructure/gcp/tofu-controller/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - release
+  - post

--- a/infrastructure/gcp/tofu-controller/post.yaml
+++ b/infrastructure/gcp/tofu-controller/post.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: tofu-controller-post
+spec:
+  targetNamespace: infra
+  dependsOn:
+    - name: tofu-controller-release
+  interval: 30m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./infrastructure/gcp/tofu-controller/post
+  prune: true

--- a/infrastructure/gcp/tofu-controller/post.yaml
+++ b/infrastructure/gcp/tofu-controller/post.yaml
@@ -7,7 +7,7 @@ spec:
   targetNamespace: infra
   dependsOn:
     - name: tofu-controller-release
-  interval: 30m0s
+  interval: 10m
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/infrastructure/gcp/tofu-controller/post/kustomization.yaml
+++ b/infrastructure/gcp/tofu-controller/post/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - terraform-namespace.yaml
+  - runner-workload-identity.yaml

--- a/infrastructure/gcp/tofu-controller/post/runner-workload-identity.yaml
+++ b/infrastructure/gcp/tofu-controller/post/runner-workload-identity.yaml
@@ -1,15 +1,22 @@
 ---
+# ServiceAccount for tofu-controller runner pods.
+# Runner pods execute Terraform in the `terraform` namespace.
+# Workload Identity links this KSA to a GCP SA for GCP resource management.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: tofu-controller-runner
   namespace: terraform
   annotations:
-    # GCP Workload Identity: link this KSA to a GCP SA
-    # The GCP SA must be created manually and granted appropriate roles
-    # Replace with your actual GCP SA email when ready:
+    # GCP Workload Identity: link this KSA to a GCP SA.
+    # The GCP SA must be created manually and granted appropriate roles.
+    # Replace with your actual GCP SA email before deployment:
     iam.gke.io/gcp-service-account: tf-controller@pingcap-testing-account.iam.gserviceaccount.com
 ---
+# ClusterRoleBinding for the runner SA.
+# NOTE: cluster-admin grants broad permissions. If the runner only manages GCP
+# resources (via Workload Identity), consider scoping down to a narrower
+# ClusterRole or namespace-scoped Role for better security (least privilege).
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/infrastructure/gcp/tofu-controller/post/runner-workload-identity.yaml
+++ b/infrastructure/gcp/tofu-controller/post/runner-workload-identity.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tofu-controller-runner
+  namespace: terraform
+  annotations:
+    # GCP Workload Identity: link this KSA to a GCP SA
+    # The GCP SA must be created manually and granted appropriate roles
+    # Replace with your actual GCP SA email when ready:
+    iam.gke.io/gcp-service-account: tf-controller@pingcap-testing-account.iam.gserviceaccount.com
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tofu-controller-runner-terraform
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: tofu-controller-runner
+    namespace: terraform

--- a/infrastructure/gcp/tofu-controller/post/runner-workload-identity.yaml
+++ b/infrastructure/gcp/tofu-controller/post/runner-workload-identity.yaml
@@ -12,6 +12,9 @@ metadata:
     # The GCP SA must be created manually and granted appropriate roles.
     # Replace with your actual GCP SA email before deployment:
     iam.gke.io/gcp-service-account: tf-controller@pingcap-testing-account.iam.gserviceaccount.com
+# Disable automounting the Kubernetes API token since the runner uses
+# GCP Workload Identity for resource management, not the K8s API.
+automountServiceAccountToken: false
 ---
 # Namespace-scoped Role for the runner SA.
 # The runner executes Terraform in the `terraform` namespace and needs access

--- a/infrastructure/gcp/tofu-controller/post/runner-workload-identity.yaml
+++ b/infrastructure/gcp/tofu-controller/post/runner-workload-identity.yaml
@@ -13,18 +13,38 @@ metadata:
     # Replace with your actual GCP SA email before deployment:
     iam.gke.io/gcp-service-account: tf-controller@pingcap-testing-account.iam.gserviceaccount.com
 ---
-# ClusterRoleBinding for the runner SA.
-# NOTE: cluster-admin grants broad permissions. If the runner only manages GCP
-# resources (via Workload Identity), consider scoping down to a narrower
-# ClusterRole or namespace-scoped Role for better security (least privilege).
+# Namespace-scoped Role for the runner SA.
+# The runner executes Terraform in the `terraform` namespace and needs access
+# to read Terraform inputs (secrets/configmaps) and monitor its own pods.
+# GCP resource permissions are handled via Workload Identity, not Kubernetes RBAC.
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: Role
 metadata:
-  name: tofu-controller-runner-terraform
+  name: tofu-controller-runner
+  namespace: terraform
+rules:
+  # Read Terraform variable files and backend configs
+  - apiGroups: [""]
+    resources: ["secrets", "configmaps"]
+    verbs: ["get", "list", "watch"]
+  # Monitor runner pod status
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
+  # Write events for observability
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tofu-controller-runner
+  namespace: terraform
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
+  kind: Role
+  name: tofu-controller-runner
 subjects:
   - kind: ServiceAccount
     name: tofu-controller-runner

--- a/infrastructure/gcp/tofu-controller/post/terraform-namespace.yaml
+++ b/infrastructure/gcp/tofu-controller/post/terraform-namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: terraform

--- a/infrastructure/gcp/tofu-controller/release.yaml
+++ b/infrastructure/gcp/tofu-controller/release.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: tofu-controller-release
+spec:
+  targetNamespace: infra
+  interval: 1h
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./infrastructure/gcp/tofu-controller/release
+  prune: true

--- a/infrastructure/gcp/tofu-controller/release.yaml
+++ b/infrastructure/gcp/tofu-controller/release.yaml
@@ -5,7 +5,7 @@ metadata:
   name: tofu-controller-release
 spec:
   targetNamespace: infra
-  interval: 1h
+  interval: 15m
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/infrastructure/gcp/tofu-controller/release/kustomization.yaml
+++ b/infrastructure/gcp/tofu-controller/release/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - release.yaml

--- a/infrastructure/gcp/tofu-controller/release/release.yaml
+++ b/infrastructure/gcp/tofu-controller/release/release.yaml
@@ -1,0 +1,63 @@
+#yaml-language-server: $schema=https://github.com/fluxcd-community/flux2-schemas/raw/refs/heads/main/helmrelease-helm-v2beta1.json
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: tofu-controller
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: tofu-controller
+      version: 0.16.2
+      sourceRef:
+        kind: HelmRepository
+        name: tofu-controller
+        namespace: flux-system
+  values:
+    # Watch all namespaces for Terraform resources
+    watchAllNamespaces: true
+    allowCrossNamespaceRefs: true
+
+    # Controller settings
+    replicaCount: 1
+    concurrency: 24
+
+    # Runner configuration
+    runner:
+      serviceAccount:
+        create: true
+        # Runner SA annotations for GCP Workload Identity
+        # Uncomment and configure when GCP SA is created:
+        # annotations:
+        #   iam.gke.io/gcp-service-account: tf-controller@pingcap-testing-account.iam.gserviceaccount.com
+        allowedNamespaces:
+          - flux-system
+          - infra
+          - terraform
+
+    # Resource limits
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+      requests:
+        cpu: 200m
+        memory: 64Mi
+
+    # Enable metrics (optional)
+    metrics:
+      enabled: false
+      serviceMonitor:
+        enabled: false
+
+    # Branch planner (disabled by default)
+    branchPlanner:
+      enabled: false
+
+    # AWS package (not needed for GCP, disabled)
+    awsPackage:
+      install: false
+
+    # Logging
+    logLevel: info
+    logEncoding: json

--- a/infrastructure/gcp/tofu-controller/release/release.yaml
+++ b/infrastructure/gcp/tofu-controller/release/release.yaml
@@ -20,7 +20,7 @@ spec:
 
     # Controller settings
     replicaCount: 1
-    concurrency: 24
+    concurrency: 8
 
     # Runner configuration
     runner:

--- a/infrastructure/gcp/tofu-controller/release/release.yaml
+++ b/infrastructure/gcp/tofu-controller/release/release.yaml
@@ -42,7 +42,7 @@ spec:
         memory: 1Gi
       requests:
         cpu: 200m
-        memory: 64Mi
+        memory: 256Mi
 
     # Enable metrics (optional)
     metrics:

--- a/infrastructure/gcp/tofu-controller/release/release.yaml
+++ b/infrastructure/gcp/tofu-controller/release/release.yaml
@@ -23,13 +23,15 @@ spec:
     concurrency: 8
 
     # Runner configuration
+    # Note: The runner ServiceAccount is managed via the post-install manifest
+    # (post/runner-workload-identity.yaml) in the `terraform` namespace, where
+    # runner pods execute. HelmRelease SA creation is disabled to avoid
+    # duplicate SA creation (Helm would create it in 'infra', but runner pods
+    # need it in 'terraform' namespace).
     runner:
       serviceAccount:
-        create: true
-        # Runner SA annotations for GCP Workload Identity
-        # Uncomment and configure when GCP SA is created:
-        # annotations:
-        #   iam.gke.io/gcp-service-account: tf-controller@pingcap-testing-account.iam.gserviceaccount.com
+        create: false
+        name: tofu-controller-runner
         allowedNamespaces:
           - flux-system
           - infra


### PR DESCRIPTION
Provide HelmRepository and HelmRelease, kustomizations, and post-install manifests (terraform namespace, runner ServiceAccount with workload-identity annotation placeholder, and ClusterRoleBinding). Update clusters/gcp/README.md with setup and usage instructions for Terraform GitOps.

/approve
/hold