### PR TITLE
feat(ci-dashboard): roll out Jenkins V3 worker

### DIFF
--- a/apps/gcp/ci-dashboard/cronjobs.yaml
+++ b/apps/gcp/ci-dashboard/cronjobs.yaml
@@ -308,8 +308,6 @@ spec:
                   value: INFO
                 - name: CI_DASHBOARD_GCS_BUCKET
                   value: pingcap-ci-console-logs-us-central1
-                - name: CI_DASHBOARD_GCS_PREFIX
-                  value: ci-dashboard/v3/jenkins-logs
                 - name: CI_DASHBOARD_ARCHIVE_LOG_TAIL_BYTES
                   value: "262144"
                 - name: CI_DASHBOARD_JENKINS_INTERNAL_BASE_URL

--- a/apps/gcp/ci-dashboard/cronjobs.yaml
+++ b/apps/gcp/ci-dashboard/cronjobs.yaml
@@ -27,7 +27,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-builds
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-1-g97da47a
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-4-gecebd61
               imagePullPolicy: IfNotPresent
               args: ["sync-builds"]
               envFrom:
@@ -75,7 +75,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-pr-events
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-1-g97da47a
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-4-gecebd61
               imagePullPolicy: IfNotPresent
               args: ["sync-pr-events"]
               envFrom:
@@ -123,7 +123,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: refresh-build-derived
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-1-g97da47a
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-4-gecebd61
               imagePullPolicy: IfNotPresent
               args: ["refresh-build-derived"]
               envFrom:
@@ -176,7 +176,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-pods
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-1-g97da47a
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-4-gecebd61
               imagePullPolicy: IfNotPresent
               args: ["sync-pods"]
               envFrom:
@@ -236,7 +236,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-flaky-issues
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-1-g97da47a
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-4-gecebd61
               imagePullPolicy: IfNotPresent
               args: ["sync-flaky-issues"]
               envFrom:
@@ -254,6 +254,66 @@ spec:
                     secretKeyRef:
                       name: prow-github
                       key: token
+              resources:
+                requests:
+                  cpu: "500m"
+                  memory: 1Gi
+                limits:
+                  cpu: "1"
+                  memory: 2Gi
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ci-dashboard-archive-error-logs
+  namespace: apps
+  labels:
+    app.kubernetes.io/name: ci-dashboard-archive-error-logs
+    app.kubernetes.io/part-of: ci-dashboard
+spec:
+  schedule: "35 * * * *"
+  timeZone: Asia/Shanghai
+  suspend: false
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 1800
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 1800
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: ci-dashboard-archive-error-logs
+            app.kubernetes.io/part-of: ci-dashboard
+        spec:
+          serviceAccountName: ci-dashboard
+          restartPolicy: Never
+          containers:
+            - name: archive-error-logs
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-4-gecebd61
+              imagePullPolicy: IfNotPresent
+              args:
+                - archive-error-logs
+                - --limit
+                - "100"
+              envFrom:
+                - secretRef:
+                    name: ci-dashboard-eq-prd-insight-db
+              env:
+                - name: PYTHONUNBUFFERED
+                  value: "1"
+                - name: CI_DASHBOARD_LOG_LEVEL
+                  value: INFO
+                - name: CI_DASHBOARD_GCS_BUCKET
+                  value: pingcap-ci-console-logs-us-central1
+                - name: CI_DASHBOARD_GCS_PREFIX
+                  value: ci-dashboard/v3/jenkins-logs
+                - name: CI_DASHBOARD_ARCHIVE_LOG_TAIL_BYTES
+                  value: "262144"
+                - name: CI_DASHBOARD_JENKINS_INTERNAL_BASE_URL
+                  value: http://jenkins.jenkins.svc.cluster.local
               resources:
                 requests:
                   cpu: "500m"

--- a/apps/gcp/ci-dashboard/cronjobs.yaml
+++ b/apps/gcp/ci-dashboard/cronjobs.yaml
@@ -27,7 +27,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-builds
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-4-gecebd61
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-5-g07bdb70
               imagePullPolicy: IfNotPresent
               args: ["sync-builds"]
               envFrom:
@@ -75,7 +75,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-pr-events
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-4-gecebd61
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-5-g07bdb70
               imagePullPolicy: IfNotPresent
               args: ["sync-pr-events"]
               envFrom:
@@ -123,7 +123,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: refresh-build-derived
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-4-gecebd61
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-5-g07bdb70
               imagePullPolicy: IfNotPresent
               args: ["refresh-build-derived"]
               envFrom:
@@ -176,7 +176,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-pods
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-4-gecebd61
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-5-g07bdb70
               imagePullPolicy: IfNotPresent
               args: ["sync-pods"]
               envFrom:
@@ -236,7 +236,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-flaky-issues
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-4-gecebd61
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-5-g07bdb70
               imagePullPolicy: IfNotPresent
               args: ["sync-flaky-issues"]
               envFrom:
@@ -292,7 +292,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: archive-error-logs
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-4-gecebd61
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-5-g07bdb70
               imagePullPolicy: IfNotPresent
               args:
                 - archive-error-logs

--- a/apps/gcp/ci-dashboard/jenkins-worker.yaml
+++ b/apps/gcp/ci-dashboard/jenkins-worker.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ci-dashboard-jenkins-worker
+  namespace: apps
+  labels:
+    app.kubernetes.io/name: ci-dashboard-jenkins-worker
+    app.kubernetes.io/part-of: ci-dashboard
+    ci-dashboard.pingcap.com/instance: jenkins-worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ci-dashboard-jenkins-worker
+      app.kubernetes.io/part-of: ci-dashboard
+      ci-dashboard.pingcap.com/instance: jenkins-worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ci-dashboard-jenkins-worker
+        app.kubernetes.io/part-of: ci-dashboard
+        ci-dashboard.pingcap.com/instance: jenkins-worker
+    spec:
+      serviceAccountName: ci-dashboard
+      restartPolicy: Always
+      containers:
+        - name: jenkins-worker
+          image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-4-gecebd61
+          imagePullPolicy: IfNotPresent
+          args:
+            - consume-jenkins-events
+          envFrom:
+            - secretRef:
+                name: ci-dashboard-eq-prd-insight-db
+          env:
+            - name: PYTHONUNBUFFERED
+              value: "1"
+            - name: CI_DASHBOARD_LOG_LEVEL
+              value: INFO
+            - name: CI_DASHBOARD_KAFKA_BOOTSTRAP_SERVERS
+              value: cluster-cd-kafka-bootstrap.kafka.svc:9092
+            - name: CI_DASHBOARD_KAFKA_JENKINS_EVENTS_TOPIC
+              value: jenkins-event
+            - name: CI_DASHBOARD_KAFKA_JENKINS_GROUP_ID
+              value: ci-dashboard-v3-jenkins-worker
+            - name: CI_DASHBOARD_KAFKA_POLL_TIMEOUT_MS
+              value: "1000"
+            - name: CI_DASHBOARD_JENKINS_FINISHED_EVENT_TYPE
+              value: dev.cdevents.pipelinerun.finished.0.1.0
+          resources:
+            requests:
+              cpu: "500m"
+              memory: 1Gi
+            limits:
+              cpu: "1"
+              memory: 2Gi

--- a/apps/gcp/ci-dashboard/jenkins-worker.yaml
+++ b/apps/gcp/ci-dashboard/jenkins-worker.yaml
@@ -25,7 +25,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: jenkins-worker
-          image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-4-gecebd61
+          image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-5-g07bdb70
           imagePullPolicy: IfNotPresent
           args:
             - consume-jenkins-events

--- a/apps/gcp/ci-dashboard/kustomization.yaml
+++ b/apps/gcp/ci-dashboard/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 resources:
   - release.yaml
   - cronjobs.yaml
+  - jenkins-worker.yaml
   - sync-pods-rbac.yaml


### PR DESCRIPTION
## Summary
- add the GCP ci-dashboard Jenkins event worker deployment
- add the archive-error-logs cronjob for Jenkins failure logs
- bump ci-dashboard jobs image to `v2026.4.26-4-gecebd61` for existing cronjobs

## Validation
- verified merged image `ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-4-gecebd61` on canary
- confirmed `normalize_build_url()` preserves host and no longer merges IDC/GCP Jenkins URLs
- ran `archive-error-logs --build-id 1682039` in-cluster with Jenkins progressiveText and GCS upload success
- confirmed `ci_l1_builds.log_gcs_uri` was written for build `1682039`
- ran `kubectl kustomize apps/gcp/ci-dashboard` successfully

## Notes
- worker deployment uses a unique selector label to avoid overlapping the temporary canary deployment
- archive cronjob is enabled with hourly cadence and uses service account `ci-dashboard` for GCS access