### PR TITLE
feat(ci-dashboard): roll out analyze-errors cronjob

### DIFF
--- a/apps/gcp/ci-dashboard/cronjobs.yaml
+++ b/apps/gcp/ci-dashboard/cronjobs.yaml
@@ -27,7 +27,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-builds
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-6-gfd6c789
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-8-g18baab2
               imagePullPolicy: IfNotPresent
               args: ["sync-builds"]
               envFrom:
@@ -75,7 +75,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-pr-events
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-6-gfd6c789
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-8-g18baab2
               imagePullPolicy: IfNotPresent
               args: ["sync-pr-events"]
               envFrom:
@@ -123,7 +123,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: refresh-build-derived
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-6-gfd6c789
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-8-g18baab2
               imagePullPolicy: IfNotPresent
               args: ["refresh-build-derived"]
               envFrom:
@@ -176,7 +176,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-pods
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-6-gfd6c789
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-8-g18baab2
               imagePullPolicy: IfNotPresent
               args: ["sync-pods"]
               envFrom:
@@ -236,7 +236,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-flaky-issues
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-6-gfd6c789
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-8-g18baab2
               imagePullPolicy: IfNotPresent
               args: ["sync-flaky-issues"]
               envFrom:
@@ -292,7 +292,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: archive-error-logs
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-6-gfd6c789
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-8-g18baab2
               imagePullPolicy: IfNotPresent
               args:
                 - archive-error-logs
@@ -350,7 +350,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: analyze-errors
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-6-gfd6c789
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-8-g18baab2
               imagePullPolicy: IfNotPresent
               args:
                 - analyze-errors

--- a/apps/gcp/ci-dashboard/cronjobs.yaml
+++ b/apps/gcp/ci-dashboard/cronjobs.yaml
@@ -27,7 +27,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-builds
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-5-g07bdb70
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-6-gfd6c789
               imagePullPolicy: IfNotPresent
               args: ["sync-builds"]
               envFrom:
@@ -75,7 +75,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-pr-events
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-5-g07bdb70
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-6-gfd6c789
               imagePullPolicy: IfNotPresent
               args: ["sync-pr-events"]
               envFrom:
@@ -123,7 +123,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: refresh-build-derived
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-5-g07bdb70
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-6-gfd6c789
               imagePullPolicy: IfNotPresent
               args: ["refresh-build-derived"]
               envFrom:
@@ -176,7 +176,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-pods
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-5-g07bdb70
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-6-gfd6c789
               imagePullPolicy: IfNotPresent
               args: ["sync-pods"]
               envFrom:
@@ -236,7 +236,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-flaky-issues
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-5-g07bdb70
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-6-gfd6c789
               imagePullPolicy: IfNotPresent
               args: ["sync-flaky-issues"]
               envFrom:
@@ -292,7 +292,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: archive-error-logs
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-5-g07bdb70
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-6-gfd6c789
               imagePullPolicy: IfNotPresent
               args:
                 - archive-error-logs
@@ -312,6 +312,60 @@ spec:
                   value: "262144"
                 - name: CI_DASHBOARD_JENKINS_INTERNAL_BASE_URL
                   value: http://jenkins.jenkins.svc.cluster.local
+              resources:
+                requests:
+                  cpu: "500m"
+                  memory: 1Gi
+                limits:
+                  cpu: "1"
+                  memory: 2Gi
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ci-dashboard-analyze-errors
+  namespace: apps
+  labels:
+    app.kubernetes.io/name: ci-dashboard-analyze-errors
+    app.kubernetes.io/part-of: ci-dashboard
+spec:
+  schedule: "45 * * * *"
+  timeZone: Asia/Shanghai
+  suspend: true
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 1800
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 3600
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: ci-dashboard-analyze-errors
+            app.kubernetes.io/part-of: ci-dashboard
+        spec:
+          serviceAccountName: ci-dashboard
+          restartPolicy: Never
+          containers:
+            - name: analyze-errors
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-6-gfd6c789
+              imagePullPolicy: IfNotPresent
+              args:
+                - analyze-errors
+                - --limit
+                - "100"
+              envFrom:
+                - secretRef:
+                    name: ci-dashboard-eq-prd-insight-db
+                - secretRef:
+                    name: ci-dashboard-llm
+              env:
+                - name: PYTHONUNBUFFERED
+                  value: "1"
+                - name: CI_DASHBOARD_LOG_LEVEL
+                  value: INFO
               resources:
                 requests:
                   cpu: "500m"

--- a/apps/gcp/ci-dashboard/cronjobs.yaml
+++ b/apps/gcp/ci-dashboard/cronjobs.yaml
@@ -271,7 +271,7 @@ metadata:
     app.kubernetes.io/name: ci-dashboard-archive-error-logs
     app.kubernetes.io/part-of: ci-dashboard
 spec:
-  schedule: "35 * * * *"
+  schedule: "5,25,45 * * * *"
   timeZone: Asia/Shanghai
   suspend: false
   concurrencyPolicy: Forbid
@@ -329,7 +329,7 @@ metadata:
     app.kubernetes.io/name: ci-dashboard-analyze-errors
     app.kubernetes.io/part-of: ci-dashboard
 spec:
-  schedule: "45 * * * *"
+  schedule: "15,35,55 * * * *"
   timeZone: Asia/Shanghai
   suspend: true
   concurrencyPolicy: Forbid

--- a/apps/gcp/ci-dashboard/jenkins-worker.yaml
+++ b/apps/gcp/ci-dashboard/jenkins-worker.yaml
@@ -25,7 +25,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: jenkins-worker
-          image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-5-g07bdb70
+          image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-6-gfd6c789
           imagePullPolicy: IfNotPresent
           args:
             - consume-jenkins-events

--- a/apps/gcp/ci-dashboard/jenkins-worker.yaml
+++ b/apps/gcp/ci-dashboard/jenkins-worker.yaml
@@ -25,7 +25,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: jenkins-worker
-          image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-6-gfd6c789
+          image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-8-g18baab2
           imagePullPolicy: IfNotPresent
           args:
             - consume-jenkins-events


### PR DESCRIPTION
## Summary
- bump ci-dashboard jobs image to v2026.4.26-6-gfd6c789
- add ci-dashboard-analyze-errors cronjob wired to the ci-dashboard-llm secret
- keep analyze-errors suspended for the first rollout so we can run a manual smoke first

## Validation
- python yaml parse for cronjobs.yaml and jenkins-worker.yaml
- kubectl kustomize apps/gcp/ci-dashboard
- verified ghcr image tags exist for ci-dashboard-jobs and ci-dashboard
