### PR TITLE
feat(ci-dashboard): release images and enable error analysis

### DIFF
--- a/apps/gcp/ci-dashboard/cronjobs.yaml
+++ b/apps/gcp/ci-dashboard/cronjobs.yaml
@@ -27,7 +27,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-builds
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-8-g18baab2
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-9-gf1ae215
               imagePullPolicy: IfNotPresent
               args: ["sync-builds"]
               envFrom:
@@ -75,7 +75,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-pr-events
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-8-g18baab2
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-9-gf1ae215
               imagePullPolicy: IfNotPresent
               args: ["sync-pr-events"]
               envFrom:
@@ -123,7 +123,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: refresh-build-derived
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-8-g18baab2
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-9-gf1ae215
               imagePullPolicy: IfNotPresent
               args: ["refresh-build-derived"]
               envFrom:
@@ -176,7 +176,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-pods
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-8-g18baab2
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-9-gf1ae215
               imagePullPolicy: IfNotPresent
               args: ["sync-pods"]
               envFrom:
@@ -236,7 +236,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-flaky-issues
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-8-g18baab2
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-9-gf1ae215
               imagePullPolicy: IfNotPresent
               args: ["sync-flaky-issues"]
               envFrom:
@@ -292,7 +292,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: archive-error-logs
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-8-g18baab2
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-9-gf1ae215
               imagePullPolicy: IfNotPresent
               args:
                 - archive-error-logs
@@ -331,7 +331,7 @@ metadata:
 spec:
   schedule: "15,35,55 * * * *"
   timeZone: Asia/Shanghai
-  suspend: true
+  suspend: false
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 1800
   successfulJobsHistoryLimit: 3
@@ -350,7 +350,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: analyze-errors
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-8-g18baab2
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-9-gf1ae215
               imagePullPolicy: IfNotPresent
               args:
                 - analyze-errors

--- a/apps/gcp/ci-dashboard/jenkins-worker.yaml
+++ b/apps/gcp/ci-dashboard/jenkins-worker.yaml
@@ -25,7 +25,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: jenkins-worker
-          image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-8-g18baab2
+          image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-9-gf1ae215
           imagePullPolicy: IfNotPresent
           args:
             - consume-jenkins-events

--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/ci-dashboard
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/ci-dashboard versioning=semver
-      tag: v2026.4.26-1-g97da47a
+      tag: v2026.4.26-9-gf1ae215
     resources:
       requests:
         cpu: "2"


### PR DESCRIPTION
## Summary
- bump ci-dashboard app image to v2026.4.26-9-gf1ae215
- bump ci-dashboard jobs and jenkins worker image to v2026.4.26-9-gf1ae215
- enable the analyze-errors cronjob for prod rollout

## Verification
- confirmed ghcr image exists for ci-dashboard and ci-dashboard-jobs
- verified analyze-errors suspend is set to false
- kept rollout scope to release.yaml, cronjobs.yaml, and jenkins-worker.yaml only