### PR TITLE
fix(apps/prod2/zot): enable scale-out clustering for hub-zot

### DIFF
--- a/apps/prod2/zot/config/config.json
+++ b/apps/prod2/zot/config/config.json
@@ -83,6 +83,13 @@
       ]
     }
   },
+  "cluster": {
+    "members": [
+      "zot-0.zot-headless.zot.svc:5000",
+      "zot-1.zot-headless.zot.svc:5000"
+    ],
+    "hashKey": "prod2zotcluster0"
+  },
   "extensions": {
     "ui": {
       "enable": true

--- a/apps/prod2/zot/release.yaml
+++ b/apps/prod2/zot/release.yaml
@@ -42,6 +42,10 @@ spec:
       create: true
       storage: 8Gi
       storageClassName: openebs-3-replicas
+    # Enable the governing headless service so cluster members get stable
+    # pod DNS names such as zot-0.zot-headless.zot.svc:5000.
+    serviceHeadless:
+      enabled: true
     replicaCount: 2
     service:
       type: ClusterIP

--- a/apps/prod2/zot/release.yaml
+++ b/apps/prod2/zot/release.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       chart: zot
       # renovate: datasource=helm depName=zot registryUrl=https://zotregistry.dev/helm-charts
-      version: 0.1.104
+      version: 0.1.106
       reconcileStrategy: ChartVersion
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
## Summary
- enable the governing headless service for `apps/prod2/zot`
- configure zot scale-out clustering with stable member DNS and a cluster `hashKey`
- bump the `project-zot/zot` chart from `0.1.104` to `0.1.106` (`zot v2.1.16`)

## Context
`hub-zot.pingcap.net` currently serves two zot replicas behind one `Service`/`HTTPRoute` while using on-demand mirroring.
Without zot's own scale-out cluster config, hot repositories can be handled independently by either pod instead of being proxied to a single responsible member.
That makes pulls of hot images such as `hub-zot.pingcap.net/mirrors/hub/tikv/tikv/image:v8.5.6` more likely to hit blob read failures like `unexpected EOF`.

This change keeps dual replicas but switches them to zot's official scale-out mode so repo requests are consistently sharded and proxied by zot itself.

## Validation
- `kustomize build apps/prod2/zot`
- `kustomize build apps/prod2/zot | kubectl apply --dry-run=server -f -`
- verified the upgraded chart metadata from the official `project-zot` helm repository
