### PR TITLE
feat(ci-dashboard): release dashboard v3 for PR #436

### DIFF
--- a/apps/gcp/ci-dashboard/cronjobs.yaml
+++ b/apps/gcp/ci-dashboard/cronjobs.yaml
@@ -27,7 +27,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-builds
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-9-gf1ae215
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-10-gd9b14ff
               imagePullPolicy: IfNotPresent
               args: ["sync-builds"]
               envFrom:
@@ -75,7 +75,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-pr-events
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-9-gf1ae215
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-10-gd9b14ff
               imagePullPolicy: IfNotPresent
               args: ["sync-pr-events"]
               envFrom:
@@ -123,7 +123,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: refresh-build-derived
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-9-gf1ae215
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-10-gd9b14ff
               imagePullPolicy: IfNotPresent
               args: ["refresh-build-derived"]
               envFrom:
@@ -176,7 +176,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-pods
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-9-gf1ae215
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-10-gd9b14ff
               imagePullPolicy: IfNotPresent
               args: ["sync-pods"]
               envFrom:
@@ -236,7 +236,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-flaky-issues
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-9-gf1ae215
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-10-gd9b14ff
               imagePullPolicy: IfNotPresent
               args: ["sync-flaky-issues"]
               envFrom:
@@ -292,7 +292,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: archive-error-logs
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-9-gf1ae215
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-10-gd9b14ff
               imagePullPolicy: IfNotPresent
               args:
                 - archive-error-logs
@@ -350,7 +350,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: analyze-errors
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-9-gf1ae215
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-10-gd9b14ff
               imagePullPolicy: IfNotPresent
               args:
                 - analyze-errors

--- a/apps/gcp/ci-dashboard/jenkins-worker.yaml
+++ b/apps/gcp/ci-dashboard/jenkins-worker.yaml
@@ -25,7 +25,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: jenkins-worker
-          image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-9-gf1ae215
+          image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-10-gd9b14ff
           imagePullPolicy: IfNotPresent
           args:
             - consume-jenkins-events

--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/ci-dashboard
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/ci-dashboard versioning=semver
-      tag: v2026.4.26-9-gf1ae215
+      tag: v2026.4.26-10-gd9b14ff
     resources:
       requests:
         cpu: "2"


### PR DESCRIPTION
## Summary
- bump `ghcr.io/pingcap-qe/ee-apps/ci-dashboard` to `v2026.4.26-10-gd9b14ff`
- bump `ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs` to `v2026.4.26-10-gd9b14ff`
- roll out the dashboard changes merged in PingCAP-QE/ee-apps#436

## Source
- app PR: https://github.com/PingCAP-QE/ee-apps/pull/436
- release workflow: https://github.com/PingCAP-QE/ee-apps/actions/runs/25094647501

## Validation
- verified the release workflow for commit `d9b14ff33a346a5a8c321dbe402335375287fae5` completed successfully
- verified both `ci-dashboard` and `ci-dashboard-jobs` images were published with tag `v2026.4.26-10-gd9b14ff`
