### PR TITLE
fix(ci-dashboard): deploy runtime insights gated image

### DIFF
--- a/apps/gcp/ci-dashboard/cronjobs.yaml
+++ b/apps/gcp/ci-dashboard/cronjobs.yaml
@@ -27,7 +27,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-builds
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-12-g215a3ab
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:replaced-by-kustomize
               imagePullPolicy: IfNotPresent
               args: ["sync-builds"]
               envFrom:
@@ -75,7 +75,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-pr-events
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-12-g215a3ab
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:replaced-by-kustomize
               imagePullPolicy: IfNotPresent
               args: ["sync-pr-events"]
               envFrom:
@@ -123,7 +123,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: refresh-build-derived
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-12-g215a3ab
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:replaced-by-kustomize
               imagePullPolicy: IfNotPresent
               args: ["refresh-build-derived"]
               envFrom:
@@ -176,7 +176,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-pods
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-12-g215a3ab
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:replaced-by-kustomize
               imagePullPolicy: IfNotPresent
               args: ["sync-pods"]
               envFrom:
@@ -236,7 +236,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-flaky-issues
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-12-g215a3ab
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:replaced-by-kustomize
               imagePullPolicy: IfNotPresent
               args: ["sync-flaky-issues"]
               envFrom:
@@ -292,7 +292,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: archive-error-logs
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-12-g215a3ab
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:replaced-by-kustomize
               imagePullPolicy: IfNotPresent
               args:
                 - archive-error-logs
@@ -350,7 +350,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: analyze-errors
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-12-g215a3ab
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:replaced-by-kustomize
               imagePullPolicy: IfNotPresent
               args:
                 - analyze-errors

--- a/apps/gcp/ci-dashboard/cronjobs.yaml
+++ b/apps/gcp/ci-dashboard/cronjobs.yaml
@@ -27,7 +27,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-builds
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-10-gd9b14ff
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-12-g215a3ab
               imagePullPolicy: IfNotPresent
               args: ["sync-builds"]
               envFrom:
@@ -75,7 +75,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-pr-events
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-10-gd9b14ff
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-12-g215a3ab
               imagePullPolicy: IfNotPresent
               args: ["sync-pr-events"]
               envFrom:
@@ -123,7 +123,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: refresh-build-derived
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-10-gd9b14ff
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-12-g215a3ab
               imagePullPolicy: IfNotPresent
               args: ["refresh-build-derived"]
               envFrom:
@@ -176,7 +176,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-pods
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-10-gd9b14ff
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-12-g215a3ab
               imagePullPolicy: IfNotPresent
               args: ["sync-pods"]
               envFrom:
@@ -236,7 +236,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-flaky-issues
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-10-gd9b14ff
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-12-g215a3ab
               imagePullPolicy: IfNotPresent
               args: ["sync-flaky-issues"]
               envFrom:
@@ -292,7 +292,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: archive-error-logs
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-10-gd9b14ff
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-12-g215a3ab
               imagePullPolicy: IfNotPresent
               args:
                 - archive-error-logs
@@ -350,7 +350,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: analyze-errors
-              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-10-gd9b14ff
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-12-g215a3ab
               imagePullPolicy: IfNotPresent
               args:
                 - analyze-errors

--- a/apps/gcp/ci-dashboard/jenkins-worker.yaml
+++ b/apps/gcp/ci-dashboard/jenkins-worker.yaml
@@ -25,7 +25,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: jenkins-worker
-          image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-10-gd9b14ff
+          image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-12-g215a3ab
           imagePullPolicy: IfNotPresent
           args:
             - consume-jenkins-events

--- a/apps/gcp/ci-dashboard/jenkins-worker.yaml
+++ b/apps/gcp/ci-dashboard/jenkins-worker.yaml
@@ -25,7 +25,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: jenkins-worker
-          image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.4.26-12-g215a3ab
+          image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:replaced-by-kustomize
           imagePullPolicy: IfNotPresent
           args:
             - consume-jenkins-events

--- a/apps/gcp/ci-dashboard/kustomization.yaml
+++ b/apps/gcp/ci-dashboard/kustomization.yaml
@@ -5,3 +5,24 @@ resources:
   - cronjobs.yaml
   - jenkins-worker.yaml
   - sync-pods-rbac.yaml
+replacements:
+  - source:
+      kind: HelmRelease
+      name: ci-dashboard
+      fieldPath: spec.values.image.tag
+    targets:
+      - select:
+          kind: CronJob
+        fieldPaths:
+          - spec.jobTemplate.spec.template.spec.containers.0.image
+        options:
+          delimiter: ":"
+          index: 1
+      - select:
+          kind: Deployment
+          name: ci-dashboard-jenkins-worker
+        fieldPaths:
+          - spec.template.spec.containers.0.image
+        options:
+          delimiter: ":"
+          index: 1

--- a/apps/gcp/ci-dashboard/kustomization.yaml
+++ b/apps/gcp/ci-dashboard/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - cronjobs.yaml
   - jenkins-worker.yaml
   - sync-pods-rbac.yaml
+# Keep ci-dashboard app and worker/job images on the same release tag.
 replacements:
   - source:
       kind: HelmRelease

--- a/apps/gcp/ci-dashboard/kustomization.yaml
+++ b/apps/gcp/ci-dashboard/kustomization.yaml
@@ -5,7 +5,9 @@ resources:
   - cronjobs.yaml
   - jenkins-worker.yaml
   - sync-pods-rbac.yaml
-# Keep ci-dashboard app and worker/job images on the same release tag.
+# Keep ci-dashboard app and worker/job images on the HelmRelease tag.
+# CronJobs and the Jenkins worker use a placeholder tag in source and are
+# rewritten during kustomize rendering, so releases only update release.yaml.
 replacements:
   - source:
       kind: HelmRelease

--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/ci-dashboard
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/ci-dashboard versioning=semver
-      tag: v2026.4.26-10-gd9b14ff
+      tag: v2026.4.26-12-g215a3ab
     resources:
       requests:
         cpu: "2"


### PR DESCRIPTION
## Summary
- deploy ci-dashboard image tag v2026.4.26-12-g215a3ab from PingCAP-QE/ee-apps#438
- use HelmRelease spec.values.image.tag as the single source of truth for ci-dashboard app, CronJobs, and Jenkins worker image tags
- keep Runtime Insights hidden in production by leaving CI_DASHBOARD_ENABLE_RUNTIME_INSIGHTS unset

## Validation
- ee-apps Skaffold release succeeded: https://github.com/PingCAP-QE/ee-apps/actions/runs/25172723273
- kubectl kustomize apps/gcp/ci-dashboard renders ci-dashboard-jobs:v2026.4.26-12-g215a3ab for all CronJobs and the Jenkins worker
- rendered manifests do not contain replaced-by-kustomize, old tag v2026.4.26-10-gd9b14ff, or CI_DASHBOARD_ENABLE_RUNTIME_INSIGHTS