### PR TITLE
feat(apps/prod2/jenkins-beta): upgrade Jenkins to latest LTS 2.555.2

### DIFF
--- a/ee-ops/apps/prod2/jenkins/beta/release/release.yaml
+++ b/ee-ops/apps/prod2/jenkins/beta/release/release.yaml
@@ -1,0 +1,62 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: jenkins
+spec:
+  chart:
+    spec:
+      chart: jenkins
+      version: 5.9.19
+      sourceRef:
+        kind: HelmRepository
+        name: jenkins
+        namespace: flux-system
+  interval: 1h0m0s
+  timeout: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    crds: CreateReplace
+  test:
+    enable: true
+    ignoreFailures: false
+  valuesFrom:
+    - { kind: Secret, name: jenkins-release-values, valuesKey: values1.yaml }
+    - { kind: Secret, name: jenkins-release-values, valuesKey: values2.yaml }
+    - { kind: Secret, name: jenkins-release-values, valuesKey: values3.yaml }
+    - { kind: Secret, name: jenkins-release-values, valuesKey: values4.yaml }
+    - { kind: Secret, name: jenkins-release-values, valuesKey: values5.yaml }
+
+  values:
+    agent:
+      namespace: "${AGENT_NAMESPACE}"
+
+    controller:
+      jenkinsUriPrefix: "${INGRESS_PATH}"
+      jenkinsUrl: "https://${INGRESS_HOST}${INGRESS_PATH}"
+      jenkinsAdminEmail: "${ADMIN_EMAIL}"
+
+    persistence:
+      enabled: true
+
+      # A manually managed Persistent Volume and Claim
+      # Requires persistence.enabled: true
+      # If defined, PVC must be created manually before volume will be bound
+      # existingClaim: jenkins
+
+      # jenkins data Persistent Volume Storage Class
+      # If defined, storageClassName: <storageClass>
+      # If set to "-", storageClassName: "", which disables dynamic provisioning
+      # If undefined (the default) or set to null, no storageClassName spec is
+      #   set, choosing the default provisioner.  (gp2 on AWS, standard on
+      #   GKE, AWS & OpenStack)
+      #
+      storageClass: openebs-3-replicas
+      size: "100Gi"
+
+    serviceAccount:
+      create: true
+      # TODO: setup credentials to pull images from dockerhub to avoid rate limits
+      # imagePullSecretName: jenkins-registry-cred

--- a/ee-ops/apps/prod2/jenkins/beta/release/values-JCasC.yaml
+++ b/ee-ops/apps/prod2/jenkins/beta/release/values-JCasC.yaml
@@ -1,0 +1,338 @@
+controller:
+  # 'name' is a name of an existing secret in same namespace as jenkins,
+  # 'keyName' is the name of one of the keys inside current secret.
+  # the 'name' and 'keyName' are concatenated with a '-' in between, so for example:
+  # an existing secret "secret-credentials" and a key inside it named "github-password" should be used in Jcasc as ${secret-credentials-github-password}
+  # 'name' and 'keyName' must be lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-',
+  # and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc')
+  additionalExistingSecrets:
+    # for login with google
+    - { name: google-oauth, keyName: client-id }
+    - { name: google-oauth, keyName: client-secret }
+
+    # for git clone for private repo.
+    - { name: github, keyName: git-private-key }
+    - { name: github, keyName: git-username }
+    - { name: github, keyName: bot-token }
+    - { name: github, keyName: pr-diff-token }
+
+    # for codecov.io uploading
+    - { name: codecov-token, keyName: tidb }
+    - { name: codecov-token, keyName: tikv-migration }
+    - { name: codecov-token, keyName: tiflow }
+    - { name: codecov-token, keyName: tiproxy }
+
+    # for harbor
+    - { name: harbor, keyName: tiflow-engine-username }
+    - { name: harbor, keyName: tiflow-engine-password }
+
+    # for ci cache, no need create manually.
+    - { name: jenkins-cache, keyName: region }
+    - { name: jenkins-cache, keyName: bucket }
+    - { name: jenkins-cache, keyName: endpoint }
+    - { name: jenkins-cache, keyName: access-key }
+    - { name: jenkins-cache, keyName: access-secret }
+
+    # for s3 upload
+    - { name: docs-cn, keyName: aws-ak }
+    - { name: docs-cn, keyName: aws-sk }
+    - { name: docs-cn, keyName: aws-region }
+    - { name: docs-cn, keyName: aws-bn }
+    - { name: docs-cn, keyName: qiniu-ak }
+    - { name: docs-cn, keyName: qiniu-sk }
+    - { name: docs-cn, keyName: qiniu-bn }
+
+    # for ks3util
+    - { name: ks3util, keyName: config }
+
+  additionalSecrets: []
+  #  - name: nameOfSecret
+  #    value: secretText
+
+  JCasC:
+    defaultConfig: true
+    # Ignored if authorizationStrategy is defined in controller.JCasC.configScripts
+    authorizationStrategy: |-
+      # loggedInUsersCanDoAnything:
+      #   allowAnonymousRead: true # allow users to read builds logs without logging in.
+      #
+      roleBased:
+        permissionTemplates:
+          - name: "read-build-template"
+            permissions:
+              - "Job/Cancel"
+              - "Job/Build"
+              - "Job/Read"
+          - name: "configure-template"
+            permissions:
+              - "Job/Cancel"
+              - "Job/Build"
+              - "Job/Read"
+              - "Job/Configure"
+        roles:
+          global:
+            # Full administrator
+            - name: "admin"
+              pattern: ".*"
+              permissions:
+                - "Overall/Read"
+                - "Overall/Administer"
+              entries:
+                - user: "wuhui.zuo@pingcap.com"
+
+            # Reader
+            - name: "builder"
+              pattern: ".*"
+              permissions:
+                - "Overall/Read"
+                - "Job/Read"
+                - "Job/Build"
+                - "Job/Cancel"
+                - "Run/Read"
+                - "Run/Replay"
+                - "View/Read"
+                - "Metrics/Read"
+              entries:
+                - user: "yebin.li@pingcap.com"
+                - user: "wei.zheng@pingcap.com"
+
+            # Readonly
+            - name: "readonly"
+              pattern: ".*"
+              permissions:
+                - "Overall/Read"
+                - "Job/Read"
+                - "Run/Read"
+                - "View/Read"
+              entries:
+                - user: anonymous
+                - group: authenticated
+
+    # for security.
+    security:
+      globalJobDslSecurityConfiguration:
+        useScriptSecurity: false
+      gitHostKeyVerificationConfiguration:
+        sshHostKeyVerificationStrategy: "noHostKeyVerificationStrategy"
+
+    securityRealm: |-
+      # local:
+      #   allowsSignup: false
+      #   enableCaptcha: false
+      #   users:
+      #   - id: "${chart-admin-username}"
+      #     name: "Jenkins Admin"
+      #     password: "${chart-admin-password}"
+      googleOAuth2:
+        clientId: "${google-oauth-client-id}"
+        clientSecret: "${google-oauth-client-secret}"
+        domain: "pingcap.com"
+
+    # REF Doc: https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/README.md
+    #
+    # Notable: if you want delete some key, first please delete the conetnt but keep the key.
+    #   after deployed, then create other commit and push to delete the key.
+    configScripts:
+      #  welcome-message: |
+      #    jenkins:
+      #      systemMessage: Welcome to our CI\CD server.  This Jenkins is configured and managed 'as code'.
+      # Ignored if securityRealm is defined in controller.JCasC.configScripts and
+      # ignored if controller.enableXmlConfig=true as controller.securityRealm takes precedence
+      # securityRealm: |
+      #   jenkins:
+      #     securityRealm:
+      #       googleOAuth2:
+      #         # will read from key `client-id` from secret `google-oauth2`
+      #         clientId: "${google-oauth2-client-id}"
+      #         # will read from key `client-secret` from secret `google-oauth2`
+      #         clientSecret: "${google-oauth2-client-secret}"
+
+      # for credentials, REF Doc: https://github.com/jenkinsci/configuration-as-code-plugin/tree/master/demos/credentials
+      credentials: |
+        credentials:
+          system:
+            domainCredentials:
+              - credentials:
+                  - file:
+                      scope: GLOBAL
+                      id: "ks3util-config"
+                      fileName: "ks3util.conf"
+                      secretBytes: "${base64:${ks3util-config}}"
+              - domain:
+                  name: github.com
+                  description: github ssh and open api
+                credentials:
+                  - basicSSHUserPrivateKey:
+                      id: github-sre-bot-ssh # TODO: change the id.
+                      privateKeySource:
+                        directEntry:
+                          privateKey: ${github-git-private-key}
+                      scope: GLOBAL
+                      username: ${github-git-username}
+                      usernameSecret: true
+                  - string:
+                      id: github-bot-token
+                      description: github private token to call api.
+                      scope: GLOBAL
+                      secret: ${github-bot-token}
+                  - string:
+                      id: github-pr-diff-token
+                      description: github token to list pr diff files.
+                      scope: GLOBAL
+                      secret: ${github-pr-diff-token}
+              - domain:
+                  name: codecov.io
+                credentials:
+                  - string:
+                      id: codecov-token-tidb
+                      description: codecov token for tidb
+                      scope: GLOBAL
+                      secret: ${codecov-token-tidb}
+                  - string:
+                      id: codecov-token-tikv-migration
+                      description: codecov token for tikv/migration
+                      scope: GLOBAL
+                      secret: ${codecov-token-tikv-migration}
+                  - string:
+                      id: codecov-token-tiflow
+                      description: codecov token for tiflow
+                      scope: GLOBAL
+                      secret: ${codecov-token-tiflow}
+                  - string:
+                      id: codecov-token-tiproxy
+                      description: codecov token for tiproxy
+                      scope: GLOBAL
+                      secret: ${codecov-token-tiproxy}
+              - domain:
+                  name: ci.service
+                credentials:
+                  - string:
+                      id: docs-cn-aws-ak
+                      description: aws token for docs-cn
+                      scope: GLOBAL
+                      secret: ${docs-cn-aws-ak}
+                  - string:
+                      id: docs-cn-aws-sk
+                      description: aws token for docs-cn
+                      scope: GLOBAL
+                      secret: ${docs-cn-aws-sk}
+                  - string:
+                      id: docs-cn-aws-region
+                      description: aws token for docs-cn
+                      scope: GLOBAL
+                      secret: ${docs-cn-aws-region}
+                  - string:
+                      id: docs-cn-aws-bn
+                      description: aws token for docs-cn
+                      scope: GLOBAL
+                      secret: ${docs-cn-aws-bn}
+                  - string:
+                      id: docs-cn-qiniu-ak
+                      description: qiniu token for docs-cn
+                      scope: GLOBAL
+                      secret: ${docs-cn-qiniu-ak}
+                  - string:
+                      id: docs-cn-qiniu-sk
+                      description: qiniu token for docs-cn
+                      scope: GLOBAL
+                      secret: ${docs-cn-qiniu-sk}
+                  - string:
+                      id: docs-cn-qiniu-bn
+                      description: qiniu token for docs-cn
+                      scope: GLOBAL
+                      secret: ${docs-cn-qiniu-bn}
+              - domain:
+                  name: hub.pingcap.net
+                credentials:
+                  - usernamePassword:
+                      scope: GLOBAL
+                      id: harbor-tiflow-engine
+                      description: user/password for tiflow engine test in harbor
+                      username: ${harbor-tiflow-engine-username}
+                      password: ${harbor-tiflow-engine-password}
+
+      # for jobs.
+      jobs-dsl: |
+        jobs:
+          - script: |
+              job('seed') {
+                description('''
+                    Jenkins jobs As Code
+                    No need to configure job on Jenkins Web UI anymore.
+                ''')
+                scm {
+                  git {
+                    remote {
+                      github('PingCAP-QE/ci', 'https')
+                    }
+                    branch('main')
+                  }
+                }
+                triggers {
+                  githubPush()
+                }
+                steps {
+                  jobDsl {
+                    targets('jobs/**/*.groovy')
+                    failOnMissingPlugin(false)
+                    ignoreMissingFiles(true)
+                    ignoreExisting(false)
+                    removedJobAction('DELETE')
+                    removedConfigFilesAction('DELETE')
+                    removedViewAction('DELETE')
+                    lookupStrategy('SEED_JOB')
+                    sandbox(false)
+                  }
+                }
+              }
+
+              queue('seed')
+      github-plugin-config: |
+        unclassified:
+          gitHubConfiguration:
+            apiRateLimitChecker: ThrottleOnOver
+          gitHubPluginConfig:
+            hookUrl: "https://${INGRESS_HOST}${INGRESS_PATH}/github-webhook/"
+      pipeline-cache: |
+        unclassified:
+          pipeline-cache:
+            region: ${jenkins-cache-region}
+            bucket: ${jenkins-cache-bucket}
+            endpoint: ${jenkins-cache-endpoint}
+            username: ${jenkins-cache-access-key}
+            password: ${jenkins-cache-access-secret}
+            threshold: 400000 # limit to 400GiB
+      cdevents: |
+        unclassified:
+          cDEventsGlobalConfig:
+            httpSinkUrl: "http://cloudevents-server.cs.svc"
+            sinkType: "http"
+      # for global shared libraries
+      global-library: |
+        unclassified:
+          globalLibraries:
+            libraries:
+              - name: "tipipeline"
+                retriever:
+                  modernSCM:
+                    scm:
+                      github:
+                        configuredByUrl: true
+                        repoOwner: "PingCAP-QE"
+                        repository: "ci"
+                        repositoryUrl: "https://github.com/PingCAP-QE/ci"
+                    libraryPath: "libraries/tipipeline"
+                defaultVersion: "main"
+                implicit: false
+                allowVersionOverride: true
+                includeInChangesets: true
+                cachingConfiguration:
+                  refreshTimeMinutes: 60
+                  excludedVersionsStr: "feature/ fix/ bugfix/"
+
+      # for global env variables
+      env-vars: |
+        jenkins:
+          globalNodeProperties:
+            - envVars:
+                env: []

--- a/ee-ops/apps/prod2/jenkins/beta/release/values-controller-plugins.yaml
+++ b/ee-ops/apps/prod2/jenkins/beta/release/values-controller-plugins.yaml
@@ -1,0 +1,60 @@
+# please see: https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/VALUES_SUMMARY.md
+controller:
+  overwritePlugins: true
+  installLatestPlugins: true
+  # List of plugins to install in addition to those listed in controller.installPlugins
+  additionalPlugins:
+    # Ref: https://github.com/jenkinsci/plugin-installation-manager-tool#plugin-input-format
+    # but without outer `plugin` key.
+    - blueocean:1.27.25
+    - build-failure-analyzer::https://github.com/PingCAP-QE/build-failure-analyzer-plugin/releases/download/v2.4.2-jobname/build-failure-analyzer.hpi
+    - cdevents::https://github.com/dillon-zheng/cdevents-plugin/releases/download/cdevents-1-40-pingcap-1/cdevents-1-40-pingcap-1.hpi
+    - generic-webhook-trigger:2.4.1
+    - google-login:109.v022b_cf87b_e5b_
+    - http_request:1.22
+    - jenkins-pipeline-cache:0.2.0:https://github.com/j3t/jenkins-pipeline-cache-plugin/releases/download/0.2.0/jenkins-pipeline-cache-0.2.0.hpi
+    - job-dsl:1.93
+    - role-strategy:840.v206ff7f7312e
+    - pipeline-utility-steps:2.20.0
+    - prometheus:795.v995762102f28
+    - ssh-agent:386.v36cc0c7582f0
+    - kubernetes-credentials-provider:1.299.v610fa_e76761a_
+    - lockable-resources:1469.v52dff5a_80e32
+    - pipeline-graph-view:836.v68ef091500dd
+
+  initializeOnce: false
+
+  # for plugin build-failure-analyzer
+  #   Exporting to prometheus
+  #   Ref: https://github.com/jenkinsci/build-failure-analyzer-plugin/blob/master/docs/metrics.md
+  prometheus:
+    metricRelabelings:
+      # add label: category
+      - sourceLabels: [__name__]
+        regex: jenkins_bfa_category_(.*)
+        targetLabel: category
+      - sourceLabels: [__name__]
+        regex: jenkins_bfa_job_category:_:.*:_:(.*)
+        targetLabel: category
+
+      # add label: cause
+      - sourceLabels: [__name__]
+        regex: jenkins_bfa_cause_(.*)
+        targetLabel: cause
+      - sourceLabels: [__name__]
+        regex: jenkins_bfa_job_cause:_:.*:_:(.*)
+        targetLabel: cause
+
+      # add label: jobname
+      - sourceLabels: [__name__]
+        regex: jenkins_bfa_job_category:_:(.*):_:.*
+        targetLabel: jobname
+      - sourceLabels: [__name__]
+        regex: jenkins_bfa_job_cause:_:(.*):_:.*
+        targetLabel: jobname
+
+      # aggerate to uniq metric: jenkins_bfa
+      - sourceLabels: [__name__]
+        regex: jenkins_bfa_(.*)_(.*)
+        replacement: jenkins_bfa
+        targetLabel: __name__

--- a/ee-ops/apps/prod2/jenkins/beta/release/values-controller.yaml
+++ b/ee-ops/apps/prod2/jenkins/beta/release/values-controller.yaml
@@ -1,0 +1,58 @@
+# please see: https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/VALUES.md
+controller:
+  image:
+    registry: "docker.io"
+    repository: "jenkins/jenkins"
+    tag: "2.555.2-jdk21"
+  resources:
+    requests:
+      cpu: "4"
+      memory: 16Gi
+    limits:
+      cpu: "8"
+      memory: 32Gi
+
+  # https://docs.cloudbees.com/docs/admin-resources/latest/jvm-troubleshooting/
+  # current jenkins using java-11.
+  # Set min/max heap here if needed with:
+  javaOpts: >-
+    -XX:+UseContainerSupport -XX:InitialRAMPercentage=20.0 -XX:MaxRAMPercentage=60.0 -XX:+UseG1GC -XX:+AlwaysPreTouch
+    -XX:+UseStringDeduplication -XX:+ParallelRefProcEnabled
+    -XX:+DisableExplicitGC -XX:+UnlockExperimentalVMOptions
+    -XX:+UnlockDiagnosticVMOptions
+    -XX:+HeapDumpOnOutOfMemoryError
+    -Xlog:gc*=info,gc+heap=debug,gc+ref*=debug,gc+ergo*=trace,gc+age*=trace:file=/var/jenkins_home/logs/gc-%t.log:utctime,pid,level,tags:filecount=2,filesize=100M
+
+  # Optionally specify additional init-containers
+  customInitContainers:
+    - name: init-create-logs-dir
+      image: "alpine:3.20.3"
+      imagePullPolicy: Always
+      command: ["mkdir", "-p", "/var/jenkins_home/logs"]
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        runAsGroup: 1000
+        runAsUser: 1000
+      volumeMounts:
+        - mountPath: /var/jenkins_home
+          name: jenkins-home
+
+  # jenkinsOpts: ""
+  # If you are using the ingress definitions provided by this chart via the `controller.ingress` block the configured hostname will be the ingress hostname starting with `https://` or `http://` depending on the `tls` configuration.
+  # The Protocol can be overwritten by specifying `controller.jenkinsUrlProtocol`.
+  # jenkinsUrlProtocol: "https"
+  # If you are not using the provided ingress you can specify `controller.jenkinsUrl` to change the url definition.
+  # jenkinsUrl: ""
+  # If you set this prefix and use ingress controller then you might want to set the ingress path below
+
+  ingress:
+    enabled: false
+
+  # Expose Prometheus metrics
+  prometheus:
+    # If enabled, add the prometheus plugin to the list of plugins to install
+    # https://plugins.jenkins.io/prometheus
+    enabled: true
+    # Additional labels to add to the ServiceMonitor object
+    serviceMonitorAdditionalLabels: { release: kps }


### PR DESCRIPTION
## Summary

Upgrade the Jenkins-beta instance in the `prod2` cluster to the latest LTS version and add the global trusted shared library.

### Changes

1. **Chart version**: Updated from `5.9.9` to `5.9.19` (latest chart release)
   - The new chart corresponds to Jenkins appVersion `2.555.2`
   - Includes updated `k8s-sidecar:2.6.0` and `inbound-agent:3355.v388858a_47b_33-19`

2. **Jenkins controller version**: Updated from `2.541.3-jdk21` to `2.555.2-jdk21`
   - This is the latest Jenkins LTS release (as of 2026-05-14)

3. **Global trusted shared library**: Added `tipipeline` library via JCasC
   - Sourced from `https://github.com/PingCAP-QE/ci` with library path `libraries/tipipeline`
   - Default version: `main`
   - `allowVersionOverride: true` — scripts can use `@someversion` in `@Library` annotation
   - `implicit: false` — scripts must explicitly request via `@Library('tipipeline')`
   - `includeInChangesets: true` — library changes trigger pipeline rebuilds
   - Caching with 60-minute refresh, excluding `feature/ fix/ bugfix/` branches
   - Mirrors the existing configuration in `ci/jobs/ti-community-infra/aa_folder.groovy`

4. **Plugins**: The existing configuration already includes:
   - `controller.overwritePlugins: true` — overwrites plugins on each restart
   - `controller.installLatestPlugins: true` — installs the latest plugin versions compatible with the current Jenkins controller

   With `installLatestPlugins: true`, the plugin manager will automatically install the latest compatible versions of all plugins when Jenkins upgrades to `2.555.2`. No manual version bumps are needed for the official plugins.

### Files changed

- `ee-ops/apps/prod2/jenkins/beta/release/release.yaml` — chart version 5.9.19
- `ee-ops/apps/prod2/jenkins/beta/release/values-controller.yaml` — controller tag 2.555.2-jdk21
- `ee-ops/apps/prod2/jenkins/beta/release/values-JCasC.yaml` — global shared library tipipeline

### Verification

After merge, FluxCD will reconcile the HelmRelease and upgrade Jenkins automatically. Monitor with:
```bash
flux get helmrelease jenkins -n jenkins-beta
flux logs --all-namespaces
```