### PR TITLE
feat(apps/gcp/roster): add roster sync cronjob

### DIFF
--- a/apps/gcp/kustomization.yaml
+++ b/apps/gcp/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - kafka
   - cloudevents-server
   - ci-dashboard
+  - roster
   # workloads
   - acr-runners
   - jenkins/beta

--- a/apps/gcp/roster/cronjob.yaml
+++ b/apps/gcp/roster/cronjob.yaml
@@ -1,0 +1,50 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: roster-sync
+  namespace: apps
+  labels:
+    app.kubernetes.io/name: roster-sync
+    app.kubernetes.io/part-of: roster
+spec:
+  schedule: "0 3 * * *"
+  timeZone: Asia/Shanghai
+  suspend: false
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 1800
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 3600
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: roster-sync
+            app.kubernetes.io/part-of: roster
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: sync-roster
+              image: ghcr.io/pingcap-qe/ee-apps/roster-jobs:v2026.5.10-3-gbe1d9e1
+              imagePullPolicy: IfNotPresent
+              args:
+                - sync-roster
+              envFrom:
+                - secretRef:
+                    name: ci-dashboard-eq-prd-insight-db
+                - secretRef:
+                    name: roster-lark
+              env:
+                - name: PYTHONUNBUFFERED
+                  value: "1"
+                - name: ROSTER_LOG_LEVEL
+                  value: "INFO"
+              resources:
+                requests:
+                  cpu: "250m"
+                  memory: "512Mi"
+                limits:
+                  cpu: "1"
+                  memory: "1Gi"

--- a/apps/gcp/roster/kustomization.yaml
+++ b/apps/gcp/roster/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cronjob.yaml


### PR DESCRIPTION
## Summary
- add a new apps/gcp/roster kustomization
- deploy the roster-sync CronJob in namespace apps
- run ghcr.io/pingcap-qe/ee-apps/roster-jobs:v2026.5.10-3-gbe1d9e1 daily at 03:00 Asia/Shanghai
- reuse ci-dashboard-eq-prd-insight-db and roster-lark secrets

## Validation
- kubectl kustomize apps/gcp/roster
- kubectl kustomize apps/gcp
- kubectl apply --dry-run=client --validate=false -f apps/gcp/roster/cronjob.yaml