### PR TITLE
fix(apps/prod2/zot): remediate immutable StatefulSet upgrades

### DIFF
--- a/apps/prod2/zot/release.yaml
+++ b/apps/prod2/zot/release.yaml
@@ -15,6 +15,11 @@ spec:
   dependsOn:
     - name: redis
   interval: 1h
+  upgrade:
+    remediation:
+      strategy: uninstall
+      retries: 1
+      remediateLastFailure: true
   values:
     mountSecret: true
     secretFiles: false # We are in charge of managing it(the secret `zot-secret`)


### PR DESCRIPTION
## Summary
- configure Flux Helm upgrade remediation for `apps/prod2/zot`
- automatically `uninstall` and retry once when the upgrade hits immutable `StatefulSet` fields
- keep the release GitOps-driven instead of requiring a manual StatefulSet rebuild

## Context
`apps/prod2/zot` now enables `serviceHeadless`, which changes the rendered `StatefulSet.spec.serviceName` to `zot-headless`.
That field is immutable for an existing StatefulSet, so a normal Helm upgrade fails.

This change lets Flux remediate that upgrade path by uninstalling and reinstalling the Helm release automatically.

## Validation
- `kustomize build apps/prod2/zot`
- `git diff --cached --check`