### PR TITLE
chore(roster): bump roster sync image

### DIFF
--- a/apps/gcp/roster/cronjob.yaml
+++ b/apps/gcp/roster/cronjob.yaml
@@ -27,7 +27,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-roster
-              image: ghcr.io/pingcap-qe/ee-apps/roster-jobs:v2026.5.10-3-gbe1d9e1
+              image: ghcr.io/pingcap-qe/ee-apps/roster-jobs:v2026.5.17-1-g006d4fc
               imagePullPolicy: IfNotPresent
               args:
                 - sync-roster


### PR DESCRIPTION
## Summary
- bump the GCP roster sync CronJob image to `ghcr.io/pingcap-qe/ee-apps/roster-jobs:v2026.5.17-1-g006d4fc`
- deploys PingCAP-QE/ee-apps#450, which syncs Lark `en_name` and adds historical roster validation

## Verification
- `kubectl kustomize apps/gcp`
- `git diff --check`

## Notes
- The `roster_employees.en_name` column has already been added manually before rollout.