### PR TITLE
chore: disable Renovate flux updates for prod/prod2

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,5 +32,16 @@
       "datasourceTemplate": "docker",
       "versioningTemplate": "docker"
     }
+  ],
+  "packageRules": [
+    {
+      "description": "Disable Flux system updates for prod and prod2 only",
+      "matchManagers": ["flux"],
+      "matchFileNames": [
+        "clusters/prod/flux-system/gotk-components.yaml",
+        "clusters/prod2/flux-system/gotk-components.yaml"
+      ],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- disable Renovate flux manager updates for clusters/prod/flux-system/gotk-components.yaml
- disable Renovate flux manager updates for clusters/prod2/flux-system/gotk-components.yaml
- keep other Renovate managers and clusters such as clusters/gcp unaffected

## Validation
- jq empty .github/renovate.json
- npx --yes --package renovate renovate-config-validator .github/renovate.json