### PR TITLE
refactor(apps): rename shared library to `tisys` for Jenkins instances

### DIFF
--- a/apps/gcp/jenkins/beta/release/values-JCasC.yaml
+++ b/apps/gcp/jenkins/beta/release/values-JCasC.yaml
@@ -318,20 +318,22 @@ controller:
         unclassified:
           globalLibraries:
             libraries:
-              - name: "tipipeline"
+              - name: "tisys"
                 retriever:
                   modernSCM:
                     scm:
                       gitSource:
                         remote: "https://github.com/pingcap-qe/ci.git"
-                    libraryPath: "libraries/tipipeline"
+                    libraryPath: "libraries/tisys"
                 defaultVersion: "main"
-                implicit: false
+                implicit: true
                 allowVersionOverride: true
                 includeInChangesets: false
                 cachingConfiguration:
                   refreshTimeMinutes: 60
+                  includedVersionsStr: "main"
                   excludedVersionsStr: "feature/ fix/ bugfix/"
+
       # for global env variables
       env-vars: |
         jenkins:

--- a/apps/gcp/jenkins/beta/release/values-JCasC.yaml
+++ b/apps/gcp/jenkins/beta/release/values-JCasC.yaml
@@ -333,10 +333,3 @@ controller:
                   refreshTimeMinutes: 60
                   includedVersionsStr: "main"
                   excludedVersionsStr: "feature/ fix/ bugfix/"
-
-      # for global env variables
-      env-vars: |
-        jenkins:
-          globalNodeProperties:
-            - envVars:
-                env: []

--- a/apps/prod/jenkins/release/values-JCasC.yaml
+++ b/apps/prod/jenkins/release/values-JCasC.yaml
@@ -274,6 +274,28 @@ controller:
             username: ${jenkins-cache-access-key}
             password: ${jenkins-cache-access-secret}
             threshold: 400000 # limit to 400GiB
+
+      # for global shared libraries
+      global-library: |
+        unclassified:
+          globalLibraries:
+            libraries:
+              - name: "tisys"
+                retriever:
+                  modernSCM:
+                    scm:
+                      gitSource:
+                        remote: "https://github.com/pingcap-qe/ci.git"
+                    libraryPath: "libraries/tisys"
+                defaultVersion: "main"
+                implicit: true
+                allowVersionOverride: true
+                includeInChangesets: false
+                cachingConfiguration:
+                  refreshTimeMinutes: 60
+                  includedVersionsStr: "main"
+                  excludedVersionsStr: "feature/ fix/ bugfix/"
+
       # for global env variables
       env-vars: |
         jenkins:

--- a/apps/prod2/jenkins/beta/release/values-JCasC.yaml
+++ b/apps/prod2/jenkins/beta/release/values-JCasC.yaml
@@ -321,10 +321,3 @@ controller:
                   refreshTimeMinutes: 60
                   includedVersionsStr: "main"
                   excludedVersionsStr: "feature/ fix/ bugfix/"
-
-      # for global env variables
-      env-vars: |
-        jenkins:
-          globalNodeProperties:
-            - envVars:
-                env: []

--- a/apps/prod2/jenkins/beta/release/values-JCasC.yaml
+++ b/apps/prod2/jenkins/beta/release/values-JCasC.yaml
@@ -299,26 +299,27 @@ controller:
       cdevents: |
         unclassified:
           cDEventsGlobalConfig:
-            httpSinkUrl: "http://cloudevents-server.cs.svc"
+            httpSinkUrl: "http://cloudevents-server.cs.svc/events"
             sinkType: "http"
       # for global shared libraries
       global-library: |
         unclassified:
           globalLibraries:
             libraries:
-              - name: "tipipeline"
+              - name: "tisys"
                 retriever:
                   modernSCM:
                     scm:
                       gitSource:
                         remote: "https://github.com/pingcap-qe/ci.git"
-                    libraryPath: "libraries/tipipeline"
+                    libraryPath: "libraries/tisys"
                 defaultVersion: "main"
-                implicit: false
+                implicit: true
                 allowVersionOverride: true
                 includeInChangesets: false
                 cachingConfiguration:
                   refreshTimeMinutes: 60
+                  includedVersionsStr: "main"
                   excludedVersionsStr: "feature/ fix/ bugfix/"
 
       # for global env variables


### PR DESCRIPTION


Rename library from tipipeline to tisys across all Jenkins instances. Set tisys as implicit library and add includedVersionsStr caching config.
Add tisys global library configuration to prod Jenkins.