### PR TITLE
feat(prow): enable label on prow job and support custom pod labels

### DIFF
--- a/.github/workflows/charts_test-prow.yaml
+++ b/.github/workflows/charts_test-prow.yaml
@@ -39,6 +39,10 @@ jobs:
       - name: Add test optional files for charts/prow
         env:
           ORG_NAME: ${{ github.event.repository.owner.login }}
+          PROW_APP_ID: ${{ secrets.PROW_APP_ID }}
+          PROW_APP_CERT: ${{ secrets.PROW_APP_CERT }}
+          PROW_HMAC_TOKEN: ${{ secrets.PROW_HMAC_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           ns=prow && kubectl create ns $ns
 
@@ -71,12 +75,23 @@ jobs:
               final_redirect_url: https://prow.test.io/pr
 
           EOF
-          yq -i e '.stringData["app-id"] = "${{ secrets.PROW_APP_ID }}"' prow-github.yaml
-          yq -i e '.stringData["app-private-key"] = "${{ secrets.PROW_APP_CERT }}"' prow-github.yaml
-          yq -i e '.stringData["token"] = "${{ secrets.GITHUB_TOKEN }}"' prow-github.yaml
+          prow_test_app_id="${PROW_APP_ID}"
+          prow_test_app_cert="${PROW_APP_CERT}"
+          if [ -z "$prow_test_app_id" ] || [ -z "$prow_test_app_cert" ]; then
+            prow_test_app_id="1"
+            prow_test_app_cert="$(openssl genrsa -traditional 2048 2>/dev/null || openssl genrsa 2048)"
+          fi
+          export prow_test_app_id prow_test_app_cert GITHUB_TOKEN
+          yq -i e '.stringData["app-id"] = strenv(prow_test_app_id)' prow-github.yaml
+          yq -i e '.stringData["app-private-key"] = strenv(prow_test_app_cert)' prow-github.yaml
+          yq -i e '.stringData["token"] = strenv(GITHUB_TOKEN)' prow-github.yaml
           kubectl -n $ns apply -f prow-github.yaml && rm prow-github.yaml
           # prow-webhook secret
-          kubectl -n $ns create secret generic prow-webhook --from-literal hmac="${{ secrets.PROW_HMAC_TOKEN }}"
+          prow_test_hmac="${PROW_HMAC_TOKEN}"
+          if [ -z "$prow_test_hmac" ]; then
+            prow_test_hmac="$(openssl rand -hex 32)"
+          fi
+          kubectl -n $ns create secret generic prow-webhook --from-literal hmac="$prow_test_hmac"
 
           # prow-oauth-cookie secret
           kubectl -n $ns create secret generic prow-oauth-cookie --from-literal secret="$(openssl rand -base64 32)"

--- a/.github/workflows/test-data/prow/ct-values.yaml
+++ b/.github/workflows/test-data/prow/ct-values.yaml
@@ -13,7 +13,7 @@ jenkinsOperator:
         targetCPUUtilizationPercentage: 80
       resources: {}
       kubeconfigSecret: ""
-      dryRun: true
+      dryRun: false
       skipReport: false
       jenkinsUrl: http://jenkins-proxy
       csrfProtect: false

--- a/.github/workflows/test-data/prow/ct-values.yaml
+++ b/.github/workflows/test-data/prow/ct-values.yaml
@@ -2,9 +2,33 @@ prow:
   domainName: prow.test.io
 jenkinsOperator:
   enabled: true
-  dryRun: false
-  auth:
-    secretName: prow-jenkins
+  instances:
+    - name: default
+      additionalArgs: []
+      replicaCount: 1
+      autoscaling:
+        enabled: false
+        minReplicas: 1
+        maxReplicas: 100
+        targetCPUUtilizationPercentage: 80
+      resources: {}
+      kubeconfigSecret: ""
+      dryRun: true
+      skipReport: false
+      jenkinsUrl: http://jenkins-proxy
+      csrfProtect: false
+      auth:
+        secretName: prow-jenkins
+        secretKeyJenkinsUser: jenkins-admin-user
+        secretKeyJenkinsToken: jenkins-admin-password
+        secretKeyJenkinsBearerToken: ""
+        secretKeyCert: ""
+        secretKeyKey: ""
+        secretKeyCaCert: ""
+      config:
+        maxConcurrency: 100
+        maxGoroutines: 10
+      labelSelector: ""
 hook:
   additionalEnv:
     - name: FOO

--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -125,7 +125,7 @@ spec:
     pcm:
       image:
         repository: ghcr.io/ti-community-infra/prow/prow-controller-manager
-        tag: v20250905-a0cfed255
+        tag: v20260520-5d43b45c8
       kubeconfigSecret: prow-kubeconfig
       additionalArgs:
         - --kubeconfig=/etc/kubeconfig/config

--- a/charts/prow/Chart.yaml
+++ b/charts/prow/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates,
 # including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.10.2"
+version: "0.10.3"
 
 # This is the version number of the application being deployed.
 # This version number should be incremented each time you make changes to the

--- a/charts/prow/templates/_helpers.tpl
+++ b/charts/prow/templates/_helpers.tpl
@@ -301,6 +301,17 @@ app.kubernetes.io/app: tide
 {{- end }}
 
 {{/*
+Merge user-provided Pod labels with labels required by selectors.
+Selector labels take precedence so Deployment selectors continue to match Pod templates.
+*/}}
+{{- define "prow.podLabels" -}}
+{{- $root := .root -}}
+{{- $selectorLabels := include .selector $root | fromYaml -}}
+{{- $extraLabels := .extra | default dict -}}
+{{- toYaml (mergeOverwrite (deepCopy ($root.Values.podLabels | default dict)) $selectorLabels $extraLabels) -}}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "prow.serviceAccountName.crier" -}}

--- a/charts/prow/templates/components/crier/deployment.yaml
+++ b/charts/prow/templates/components/crier/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       {{- end }}
       labels:
         {{- include "prow.selectorLabels.crier" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prow/templates/components/crier/deployment.yaml
+++ b/charts/prow/templates/components/crier/deployment.yaml
@@ -18,10 +18,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "prow.selectorLabels.crier" . | nindent 8 }}
-        {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "prow.podLabels" (dict "root" . "selector" "prow.selectorLabels.crier") | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prow/templates/components/deck/deployment.yaml
+++ b/charts/prow/templates/components/deck/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       {{- end }}
       labels:
         {{- include "prow.selectorLabels.deck" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prow/templates/components/deck/deployment.yaml
+++ b/charts/prow/templates/components/deck/deployment.yaml
@@ -18,10 +18,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "prow.selectorLabels.deck" . | nindent 8 }}
-        {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "prow.podLabels" (dict "root" . "selector" "prow.selectorLabels.deck") | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prow/templates/components/ghproxy/deployment.yaml
+++ b/charts/prow/templates/components/ghproxy/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       {{- end }}
       labels:
         {{- include "prow.selectorLabels.ghproxy" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prow/templates/components/ghproxy/deployment.yaml
+++ b/charts/prow/templates/components/ghproxy/deployment.yaml
@@ -18,10 +18,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "prow.selectorLabels.ghproxy" . | nindent 8 }}
-        {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "prow.podLabels" (dict "root" . "selector" "prow.selectorLabels.ghproxy") | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prow/templates/components/hook/deployment.yaml
+++ b/charts/prow/templates/components/hook/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       {{- end }}
       labels:
         {{- include "prow.selectorLabels.hook" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prow/templates/components/hook/deployment.yaml
+++ b/charts/prow/templates/components/hook/deployment.yaml
@@ -18,10 +18,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "prow.selectorLabels.hook" . | nindent 8 }}
-        {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "prow.podLabels" (dict "root" . "selector" "prow.selectorLabels.hook") | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prow/templates/components/horologium/deployment.yaml
+++ b/charts/prow/templates/components/horologium/deployment.yaml
@@ -21,6 +21,9 @@ spec:
       {{- end }}
       labels:
         {{- include "prow.selectorLabels.horologium" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prow/templates/components/horologium/deployment.yaml
+++ b/charts/prow/templates/components/horologium/deployment.yaml
@@ -20,10 +20,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "prow.selectorLabels.horologium" . | nindent 8 }}
-        {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "prow.podLabels" (dict "root" . "selector" "prow.selectorLabels.horologium") | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prow/templates/components/jenkins-operator/deployment.yaml
+++ b/charts/prow/templates/components/jenkins-operator/deployment.yaml
@@ -26,6 +26,9 @@ spec:
       labels:
         {{ include "prow.selectorLabels" $ | nindent 8 }}
         app.kubernetes.io/app: jenkins-operator-{{ $index }}
+        {{- with $.Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with $.Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prow/templates/components/jenkins-operator/deployment.yaml
+++ b/charts/prow/templates/components/jenkins-operator/deployment.yaml
@@ -24,11 +24,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{ include "prow.selectorLabels" $ | nindent 8 }}
-        app.kubernetes.io/app: jenkins-operator-{{ $index }}
-        {{- with $.Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{ include "prow.podLabels" (dict "root" $ "selector" "prow.selectorLabels" "extra" (dict "app.kubernetes.io/app" (printf "jenkins-operator-%d" $index))) | nindent 8 }}
     spec:
       {{- with $.Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prow/templates/components/pipeline/deployment.yaml
+++ b/charts/prow/templates/components/pipeline/deployment.yaml
@@ -21,6 +21,9 @@ spec:
       {{- end }}
       labels:
         {{- include "prow.selectorLabels.pipeline" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prow/templates/components/pipeline/deployment.yaml
+++ b/charts/prow/templates/components/pipeline/deployment.yaml
@@ -20,10 +20,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "prow.selectorLabels.pipeline" . | nindent 8 }}
-        {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "prow.podLabels" (dict "root" . "selector" "prow.selectorLabels.pipeline") | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prow/templates/components/prow-controller-manager/deployment.yaml
+++ b/charts/prow/templates/components/prow-controller-manager/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       {{- end }}
       labels:
         {{- include "prow.selectorLabels.pcm" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prow/templates/components/prow-controller-manager/deployment.yaml
+++ b/charts/prow/templates/components/prow-controller-manager/deployment.yaml
@@ -18,10 +18,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "prow.selectorLabels.pcm" . | nindent 8 }}
-        {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "prow.podLabels" (dict "root" . "selector" "prow.selectorLabels.pcm") | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prow/templates/components/sinker/deployment.yaml
+++ b/charts/prow/templates/components/sinker/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       {{- end }}
       labels:
         {{- include "prow.selectorLabels.sinker" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prow/templates/components/sinker/deployment.yaml
+++ b/charts/prow/templates/components/sinker/deployment.yaml
@@ -18,10 +18,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "prow.selectorLabels.sinker" . | nindent 8 }}
-        {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "prow.podLabels" (dict "root" . "selector" "prow.selectorLabels.sinker") | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prow/templates/components/status-reconciler/deployment.yaml
+++ b/charts/prow/templates/components/status-reconciler/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       {{- end }}
       labels:
         {{- include "prow.selectorLabels.statusReconciler" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prow/templates/components/status-reconciler/deployment.yaml
+++ b/charts/prow/templates/components/status-reconciler/deployment.yaml
@@ -18,10 +18,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "prow.selectorLabels.statusReconciler" . | nindent 8 }}
-        {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "prow.podLabels" (dict "root" . "selector" "prow.selectorLabels.statusReconciler") | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prow/templates/components/tide/deployment.yaml
+++ b/charts/prow/templates/components/tide/deployment.yaml
@@ -21,6 +21,9 @@ spec:
       {{- end }}
       labels:
         {{- include "prow.selectorLabels.tide" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prow/templates/components/tide/deployment.yaml
+++ b/charts/prow/templates/components/tide/deployment.yaml
@@ -20,10 +20,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "prow.selectorLabels.tide" . | nindent 8 }}
-        {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "prow.podLabels" (dict "root" . "selector" "prow.selectorLabels.tide") | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prow/templates/third-plugins/deployment.yaml
+++ b/charts/prow/templates/third-plugins/deployment.yaml
@@ -30,6 +30,9 @@ spec:
       labels:
         {{- include "prow.selectorLabels" $root | nindent 8 }}
         app.kubernetes.io/app: {{ $name }}
+        {{- with $root.Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with $root.Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prow/templates/third-plugins/deployment.yaml
+++ b/charts/prow/templates/third-plugins/deployment.yaml
@@ -28,11 +28,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "prow.selectorLabels" $root | nindent 8 }}
-        app.kubernetes.io/app: {{ $name }}
-        {{- with $root.Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "prow.podLabels" (dict "root" $root "selector" "prow.selectorLabels" "extra" (dict "app.kubernetes.io/app" $name)) | nindent 8 }}
     spec:
       {{- with $root.Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prow/values.yaml
+++ b/charts/prow/values.yaml
@@ -12,6 +12,7 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 podAnnotations: {}
+podLabels: {}
 podSecurityContext: {}
 securityContext: {}
 


### PR DESCRIPTION
## Summary
- add a global `podLabels` value to the Prow chart
- render the labels into core component and third-plugin pod templates
- bump the chart version to `0.10.3`

## Validation
- `helm lint charts/prow`
- `helm lint charts/prow -f /tmp/prow-release-values.yaml`
- `git diff --check HEAD~1..HEAD`

This PR should merge first so the `prow@0.10.3` chart is published before the GCP HelmRelease switches to it.