### PR TITLE
chore(prow): enable label CI control plane pods

### DIFF
--- a/apps/gcp/jenkins/beta/release/values-controller.yaml
+++ b/apps/gcp/jenkins/beta/release/values-controller.yaml
@@ -1,5 +1,10 @@
 # please see: https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/VALUES.md
 controller:
+  podLabels:
+    env: cicd
+    team: eq
+    author: wuhuizuo
+
   image:
     registry: "docker.io"
     repository: "jenkins/jenkins"

--- a/apps/gcp/prow/post/cronjobs-community.yaml
+++ b/apps/gcp/prow/post/cronjobs-community.yaml
@@ -21,3 +21,89 @@ spec:
       TEST_PODS_NAMESPACE: prow-test-pods
       BUCKET_NAME: prow-tidb-logs
       DOMAIN_NAME: prow.tidb.net
+  patches:
+    - target:
+        kind: CronJob
+        name: prow-branch-protector-others
+      patch: |-
+        apiVersion: batch/v1
+        kind: CronJob
+        metadata:
+          name: prow-branch-protector-others
+        spec:
+          jobTemplate:
+            spec:
+              template:
+                metadata:
+                  labels:
+                    env: cicd
+                    team: eq
+                    author: wuhuizuo
+    - target:
+        kind: CronJob
+        name: prow-branch-protector-pingcap
+      patch: |-
+        apiVersion: batch/v1
+        kind: CronJob
+        metadata:
+          name: prow-branch-protector-pingcap
+        spec:
+          jobTemplate:
+            spec:
+              template:
+                metadata:
+                  labels:
+                    env: cicd
+                    team: eq
+                    author: wuhuizuo
+    - target:
+        kind: CronJob
+        name: prow-branch-protector-tikv
+      patch: |-
+        apiVersion: batch/v1
+        kind: CronJob
+        metadata:
+          name: prow-branch-protector-tikv
+        spec:
+          jobTemplate:
+            spec:
+              template:
+                metadata:
+                  labels:
+                    env: cicd
+                    team: eq
+                    author: wuhuizuo
+    - target:
+        kind: CronJob
+        name: prow-label-sync-pingcap
+      patch: |-
+        apiVersion: batch/v1
+        kind: CronJob
+        metadata:
+          name: prow-label-sync-pingcap
+        spec:
+          jobTemplate:
+            spec:
+              template:
+                metadata:
+                  labels:
+                    env: cicd
+                    team: eq
+                    author: wuhuizuo
+    - target:
+        kind: CronJob
+        name: prow-label-sync-tikv
+      patch: |-
+        apiVersion: batch/v1
+        kind: CronJob
+        metadata:
+          name: prow-label-sync-tikv
+        spec:
+          jobTemplate:
+            spec:
+              template:
+                metadata:
+                  labels:
+                    env: cicd
+                    team: eq
+                    author: wuhuizuo

--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: prow
-      version: 0.10.2
+      version: 0.10.3
       sourceRef:
         kind: HelmRepository
         name: ee-ops
@@ -32,6 +32,11 @@ spec:
     enable: true
     ignoreFailures: false
   values:
+    podLabels:
+      env: cicd
+      team: eq
+      author: wuhuizuo
+
     prow:
       podsNamespace: ${TEST_PODS_NAMESPACE} # should delete old prow-pcm pods when changed.
       domainName: ${DOMAIN_NAME}


### PR DESCRIPTION
## Summary
- add fixed cost labels to the GCP Jenkins controller pod
- configure GCP Prow to use `prow@0.10.3` and pass fixed pod labels
- patch Prow community CronJobs so generated job pods receive the same cost labels

Labels applied:
- `env: cicd`
- `team: eq`
- `author: wuhuizuo`

## Rollout order
Depends on #1963. Merge this PR after `prow@0.10.3` has been published by the chart release workflow.

## Validation
- YAML parse for changed files
- `kubectl kustomize apps/gcp/prow/post`
- `kubectl kustomize apps/gcp/prow/release`
- `kubectl kustomize apps/gcp/jenkins/beta/release`
- `git diff --cached --check`