### PR TITLE
feat(dashboard): enable cost insight cronjobs

### DIFF
--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/name: cost-insight-sync-gcp-billing-export
     app.kubernetes.io/part-of: cost-insight
 spec:
+  # Interpreted with timeZone below: 21:10 Asia/Shanghai, intentionally outside BJ work time.
   schedule: "10 21 * * *"
   timeZone: Asia/Shanghai
   suspend: false
@@ -71,6 +72,7 @@ metadata:
     app.kubernetes.io/name: cost-insight-refresh-attribution-daily
     app.kubernetes.io/part-of: cost-insight
 spec:
+  # Interpreted with timeZone below: 23:10 Asia/Shanghai, after the raw sync window.
   schedule: "10 23 * * *"
   timeZone: Asia/Shanghai
   suspend: false
@@ -88,6 +90,8 @@ spec:
             app.kubernetes.io/name: cost-insight-refresh-attribution-daily
             app.kubernetes.io/part-of: cost-insight
         spec:
+          # This job only uses DB credentials from envFrom; keep it off Workload Identity.
+          serviceAccountName: default
           automountServiceAccountToken: false
           restartPolicy: Never
           containers:

--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -16,7 +16,7 @@ spec:
   failedJobsHistoryLimit: 5
   jobTemplate:
     spec:
-      backoffLimit: 2
+      backoffLimit: 4
       activeDeadlineSeconds: 7200
       template:
         metadata:
@@ -32,6 +32,8 @@ spec:
             - name: sync-gcp-billing-export
               image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.5.17-4-ge7e0ea6
               imagePullPolicy: IfNotPresent
+              command:
+                - cost-insight
               args:
                 - sync-gcp-billing-export
               envFrom:
@@ -78,7 +80,7 @@ spec:
   failedJobsHistoryLimit: 5
   jobTemplate:
     spec:
-      backoffLimit: 2
+      backoffLimit: 4
       activeDeadlineSeconds: 3600
       template:
         metadata:
@@ -86,6 +88,7 @@ spec:
             app.kubernetes.io/name: cost-insight-refresh-attribution-daily
             app.kubernetes.io/part-of: cost-insight
         spec:
+          automountServiceAccountToken: false
           restartPolicy: Never
           containers:
             - name: refresh-attribution-daily
@@ -96,11 +99,18 @@ spec:
                 - -ec
               args:
                 - |
-                  start_date="$(date -u -d '7 days ago' +%F)"
-                  end_date="$(date -u -d 'yesterday' +%F)"
+                  dates="$(python - <<'PY'
+                  from datetime import datetime, timedelta, timezone
+
+                  end_date = datetime.now(timezone.utc).date() - timedelta(days=1)
+                  start_date = end_date - timedelta(days=6)
+                  print(start_date.isoformat(), end_date.isoformat())
+                  PY
+                  )"
+                  set -- ${dates}
                   cost-insight refresh-cost-attribution-daily \
-                    --start-date "${start_date}" \
-                    --end-date "${end_date}" \
+                    --start-date "$1" \
+                    --end-date "$2" \
                     --split-by-day
               envFrom:
                 - secretRef:

--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -1,0 +1,119 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cost-insight-sync-gcp-billing-export
+  namespace: apps
+  labels:
+    app.kubernetes.io/name: cost-insight-sync-gcp-billing-export
+    app.kubernetes.io/part-of: cost-insight
+spec:
+  schedule: "10 10 * * *"
+  timeZone: Asia/Shanghai
+  suspend: false
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 1800
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 7200
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: cost-insight-sync-gcp-billing-export
+            app.kubernetes.io/part-of: cost-insight
+        spec:
+          # Reuse the existing Workload Identity path; the bound GSA must have
+          # BigQuery jobUser plus billing export dataset read access.
+          serviceAccountName: ci-dashboard
+          restartPolicy: Never
+          containers:
+            - name: sync-gcp-billing-export
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.5.17-4-ge7e0ea6
+              imagePullPolicy: IfNotPresent
+              args:
+                - sync-gcp-billing-export
+              envFrom:
+                - secretRef:
+                    name: ci-dashboard-eq-prd-insight-db
+              env:
+                - name: PYTHONUNBUFFERED
+                  value: "1"
+                - name: COST_INSIGHT_LOG_LEVEL
+                  value: INFO
+                - name: GOOGLE_CLOUD_PROJECT
+                  value: pingcap-testing-account
+                - name: COST_INSIGHT_GCP_ACCOUNT_ID
+                  value: pingcap-testing-account
+                - name: COST_INSIGHT_GCP_BILLING_TABLE
+                  value: gcp-digital-bi.gcp_billing_detailed.gcp_billing_export_resource_v1_01D088_8F9CF2_8AF1C6
+                - name: COST_INSIGHT_SYNC_OVERLAP_DAYS
+                  value: "7"
+                - name: COST_INSIGHT_SYNC_PAGE_SIZE
+                  value: "5000"
+              resources:
+                requests:
+                  cpu: "500m"
+                  memory: 1Gi
+                limits:
+                  cpu: "2"
+                  memory: 4Gi
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cost-insight-refresh-attribution-daily
+  namespace: apps
+  labels:
+    app.kubernetes.io/name: cost-insight-refresh-attribution-daily
+    app.kubernetes.io/part-of: cost-insight
+spec:
+  schedule: "40 12 * * *"
+  timeZone: Asia/Shanghai
+  suspend: false
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 1800
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 3600
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: cost-insight-refresh-attribution-daily
+            app.kubernetes.io/part-of: cost-insight
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: refresh-attribution-daily
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.5.17-4-ge7e0ea6
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -ec
+              args:
+                - |
+                  start_date="$(date -u -d '7 days ago' +%F)"
+                  end_date="$(date -u -d 'yesterday' +%F)"
+                  cost-insight refresh-cost-attribution-daily \
+                    --start-date "${start_date}" \
+                    --end-date "${end_date}" \
+                    --split-by-day
+              envFrom:
+                - secretRef:
+                    name: ci-dashboard-eq-prd-insight-db
+              env:
+                - name: PYTHONUNBUFFERED
+                  value: "1"
+                - name: COST_INSIGHT_LOG_LEVEL
+                  value: INFO
+              resources:
+                requests:
+                  cpu: "500m"
+                  memory: 1Gi
+                limits:
+                  cpu: "2"
+                  memory: 4Gi

--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: cost-insight-sync-gcp-billing-export
     app.kubernetes.io/part-of: cost-insight
 spec:
-  schedule: "10 10 * * *"
+  schedule: "10 21 * * *"
   timeZone: Asia/Shanghai
   suspend: false
   concurrencyPolicy: Forbid
@@ -69,7 +69,7 @@ metadata:
     app.kubernetes.io/name: cost-insight-refresh-attribution-daily
     app.kubernetes.io/part-of: cost-insight
 spec:
-  schedule: "40 12 * * *"
+  schedule: "10 23 * * *"
   timeZone: Asia/Shanghai
   suspend: false
   concurrencyPolicy: Forbid

--- a/apps/gcp/cost-insight/kustomization.yaml
+++ b/apps/gcp/cost-insight/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cronjobs.yaml

--- a/apps/gcp/kustomization.yaml
+++ b/apps/gcp/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - kafka
   - cloudevents-server
   - ci-dashboard
+  - cost-insight
   - roster
   # workloads
   - acr-runners


### PR DESCRIPTION
## What

Enable cost-insight CronJobs in the GCP apps cluster:

- `cost-insight-sync-gcp-billing-export`: sync GCP detailed billing export into `cost_raw_details` daily at 10:10 Asia/Shanghai.
- `cost-insight-refresh-attribution-daily`: refresh `cost_attribution_daily` for the last 7 days daily at 12:40 Asia/Shanghai.

Both jobs use `ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.5.17-4-ge7e0ea6`, built by https://github.com/PingCAP-QE/ee-apps/actions/runs/26139495205.

## Notes

- DB credentials reuse the existing `ci-dashboard-eq-prd-insight-db` secret. The live secret has the `TIDB_*` keys expected by cost-insight.
- The sync job reuses the existing `ci-dashboard` Kubernetes service account for Workload Identity.
- Before the sync job can succeed, `ci-dashboard@pingcap-testing-account.iam.gserviceaccount.com` needs BigQuery permissions for the billing export query path: `roles/bigquery.jobUser` on `pingcap-testing-account` and read access to `gcp-digital-bi:gcp_billing_detailed`.

## Validation

- `kubectl kustomize apps/gcp/cost-insight`
- `kubectl kustomize apps/gcp`
- `kubectl apply --dry-run=server -k apps/gcp/cost-insight`
- `docker manifest inspect ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.5.17-4-ge7e0ea6`

Docker runtime smoke test was not run because the local Docker daemon is not running.
