### PR TITLE
chore(ci-dashboard): deploy v2026.5.17-4-ge7e0ea6

### DIFF
--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/ci-dashboard
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/ci-dashboard versioning=semver
-      tag: v2026.5.10-4-g6882668
+      tag: v2026.5.17-4-ge7e0ea6
     resources:
       requests:
         cpu: "2"
@@ -48,6 +48,8 @@ spec:
         value: INFO
       - name: CI_DASHBOARD_ENABLE_RUNTIME_INSIGHTS
         value: "true"
+      - name: CI_DASHBOARD_ENABLE_COST_DASHBOARD
+        value: "false"
     serviceAccount:
       annotations:
         iam.gke.io/gcp-service-account: ci-dashboard@pingcap-testing-account.iam.gserviceaccount.com


### PR DESCRIPTION
## Summary
- deploy CI Dashboard image `v2026.5.17-4-ge7e0ea6`
- keep Runtime Insights enabled
- explicitly keep `CI_DASHBOARD_ENABLE_COST_DASHBOARD=false` so the new cost dashboard code is rolled out but the Cost tab stays hidden for now

## Validation
- rendered `apps/gcp/ci-dashboard` with `kubectl kustomize`
- confirmed HelmRelease renders `CI_DASHBOARD_ENABLE_COST_DASHBOARD`
- confirmed app/jobs/pod-watcher render with tag `v2026.5.17-4-ge7e0ea6`
