### PR TITLE
feat(apps/prod2/chatops-lark): predeploy chatops-lark

### DIFF
--- a/apps/prod2/chatops-lark/external-secret-github.yaml
+++ b/apps/prod2/chatops-lark/external-secret-github.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: github
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: ee-gcp-sm
+    kind: ClusterSecretStore
+  target:
+    name: github
+    creationPolicy: Owner
+  data:
+    - secretKey: bot-token
+      remoteRef:
+        key: github-bot-token

--- a/apps/prod2/chatops-lark/external-secret.yaml
+++ b/apps/prod2/chatops-lark/external-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: chatops-lark
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: ee-gcp-sm
+    kind: ClusterSecretStore
+  target:
+    name: chatops-lark
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        # json object contains keys:
+        # - app-id
+        # - app-secret
+        # - config.yaml
+        key: prod2_chatops_lark_json

--- a/apps/prod2/chatops-lark/kustomization.yaml
+++ b/apps/prod2/chatops-lark/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: chatops-lark
+resources:
+  - namespace.yaml
+  - external-secret.yaml
+  - external-secret-github.yaml
+  - release-mcp-tool-github.yaml
+  - release.yaml

--- a/apps/prod2/chatops-lark/namespace.yaml
+++ b/apps/prod2/chatops-lark/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chatops-lark

--- a/apps/prod2/chatops-lark/release-mcp-tool-github.yaml
+++ b/apps/prod2/chatops-lark/release-mcp-tool-github.yaml
@@ -1,0 +1,52 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: chatops-lark-mcp-tool-github
+spec:
+  chart:
+    spec:
+      chart: mcp-tool
+      version: 0.1.0
+      sourceRef:
+        kind: HelmRepository
+        name: ee-ops
+        namespace: flux-system
+  interval: 5m
+  timeout: 5m
+  install:
+    remediation:
+      retries: 3
+  rollback:
+    cleanupOnFail: true
+    recreate: true
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  test:
+    enable: false
+    ignoreFailures: true
+  values:
+    replicaCount: 1
+    resources:
+      limits:
+        cpu: "500m"
+        memory: 512Mi
+    nodeSelector:
+      kubernetes.io/arch: amd64
+    image:
+      repository: golang
+      tag: "1.23"
+    livenessProbe: false
+    readinessProbe: false
+    command:
+      - go
+      - run
+      - github.com/github/github-mcp-server/cmd/github-mcp-server@http-sse
+    args: [http, --port=80, --read-only, --enable-command-logging]
+    env:
+      - name: GITHUB_PERSONAL_ACCESS_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: github
+            key: bot-token

--- a/apps/prod2/chatops-lark/release.yaml
+++ b/apps/prod2/chatops-lark/release.yaml
@@ -1,0 +1,47 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: chatops-lark
+spec:
+  releaseName: chatops-lark
+  chart:
+    spec:
+      chart: chatops-lark
+      version: 0.1.2
+      sourceRef:
+        kind: HelmRepository
+        name: ee-apps
+        namespace: flux-system
+  interval: 5m
+  timeout: 5m
+  install:
+    remediation:
+      retries: 3
+  rollback:
+    cleanupOnFail: true
+    recreate: true
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  test:
+    enable: false
+    ignoreFailures: true
+  values:
+    # Keep prod2 predeployed but inactive until the cutover PR removes prod.
+    replicaCount: 0
+    resources:
+      limits:
+        cpu: "500m"
+        memory: 512Mi
+    nodeSelector:
+      kubernetes.io/arch: amd64
+    image:
+      repository: ghcr.io/pingcap-qe/ee-apps/chatops-lark
+      # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/chatops-lark versioning=semver
+      tag: v2025.11.30-13-g64b3e50
+    server:
+      secretName: chatops-lark
+      appIdSecretKey: app-id
+      appSecretSecretKey: app-secret
+      configFileSecretKey: config.yaml

--- a/apps/prod2/kustomization.yaml
+++ b/apps/prod2/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - publisher
   - zot
   - cloudevents-server
+  - chatops-lark
   - cache
   - dl
   - tibuild # experiment for v2


### PR DESCRIPTION
## Summary
- add `apps/prod2/chatops-lark` with a dedicated namespace, HelmRelease, GitHub MCP HelmRelease, and ExternalSecrets
- wire the new app into `apps/prod2/kustomization.yaml`
- keep `chatops-lark` predeployed but inactive on `prod2` via `replicaCount: 0` and disabled Helm tests until the cutover PR removes `prod`

## Notes
- `chatops-lark` is sourced from `prod2_chatops_lark_json` in `ee-gcp-sm`, expected to contain `app-id`, `app-secret`, and `config.yaml`
- the GitHub MCP tool uses `github-bot-token` to materialize the namespace-local `github` secret with `bot-token`

## Validation
- `yq` parse check for all new YAML files
- `git diff --check`
