### PR TITLE
fix(prow): align tichi web health check path

### DIFF
--- a/apps/gcp/prow/release/http-routes.yaml
+++ b/apps/gcp/prow/release/http-routes.yaml
@@ -1,3 +1,20 @@
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: prow-tichi-web-health-check-policy
+  namespace: apps
+spec:
+  targetRef:
+    group: ""
+    kind: Service
+    name: prow-tichi-web
+  default:
+    config:
+      type: HTTP
+      httpHealthCheck:
+        requestPath: /tichi
+        port: 80
+---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:


### PR DESCRIPTION
## Summary
- add a GKE HealthCheckPolicy for `prow-tichi-web`
- point the load balancer health check at `/tichi`, which returns 200 for the tichi web app

## Why
The default Gateway health check uses `/`, but `tichi-web` returns 404 there and 200 at `/tichi`. This keeps the NEG readiness gate from becoming ready and causes the Prow Helm upgrade to time out.

## Validation
- YAML parse for `apps/gcp/prow/release/http-routes.yaml`
- `kubectl kustomize apps/gcp/prow/release`
- `git diff --check`
- verified in-cluster: `/` returns 404, `/tichi` returns 200 on tichi-web pods