### PR TITLE
fix(prow): use serving port for tichi health check

### DIFF
--- a/apps/gcp/prow/release/http-routes.yaml
+++ b/apps/gcp/prow/release/http-routes.yaml
@@ -13,7 +13,7 @@ spec:
       type: HTTP
       httpHealthCheck:
         requestPath: /tichi
-        port: 80
+        portSpecification: USE_SERVING_PORT
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute


### PR DESCRIPTION
## Summary
- use USE_SERVING_PORT for the prow-tichi-web HealthCheckPolicy
- keep the health check path on /tichi so GCP probes the service backend port instead of fixed port 80

## Validation
- kubectl kustomize apps/gcp/prow/release
- git diff --check