### PR TITLE
fix(ci-dashboard): deploy v2026.5.17-5-g3f7a193

### DIFF
--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/ci-dashboard
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/ci-dashboard versioning=semver
-      tag: v2026.5.17-4-ge7e0ea6
+      tag: v2026.5.17-5-g3f7a193
     resources:
       requests:
         cpu: "2"


### PR DESCRIPTION
## Summary
- switch ci-dashboard release tag to `v2026.5.17-5-g3f7a193`
- keep `CI_DASHBOARD_ENABLE_COST_DASHBOARD=false` during rollout
- fix ImagePullBackOff caused by the previous nonexistent jobs image tag

## Root cause
The previous ops rollout used `v2026.5.17-4-ge7e0ea6`, which came from `build(cost-insight): publish jobs image (#453)` instead of the merged ci-dashboard feature commit `3f7a19338b46e2e322990ec30c7c73433bc9806f` (`feat(ci-dashboard): add cost dashboard insights (#454)`).

`ee-apps` release CI completed successfully for `3f7a193`, and the correct release tag is `v2026.5.17-5-g3f7a193`.

## Validation
- `kubectl -n apps describe pod ci-dashboard-sync-pr-events-29655435-j5zt6` showed `ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.5.17-4-ge7e0ea6: not found`
- `kubectl kustomize apps/gcp/ci-dashboard` now renders `ci-dashboard` and `ci-dashboard-jobs` with `v2026.5.17-5-g3f7a193`
- cost dashboard flag remains disabled