### PR TITLE
chore(ci-dashboard): deploy v2026.5.17-7-g4161283

### DIFF
--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/ci-dashboard
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/ci-dashboard versioning=semver
-      tag: v2026.5.17-5-g3f7a193
+      tag: v2026.5.17-7-g4161283
     resources:
       requests:
         cpu: "2"


### PR DESCRIPTION
## Summary
- bump `apps/gcp/ci-dashboard` to `ghcr.io/pingcap-qe/ee-apps/ci-dashboard:v2026.5.17-7-g4161283`
- roll the same tag to ci-dashboard jobs, jenkins worker, and pod watcher via the existing kustomize replacements
- release the ci-dashboard changes from PingCAP-QE/ee-apps#457 and PingCAP-QE/ee-apps#456

## Upstream
- ee-apps release run: https://github.com/PingCAP-QE/ee-apps/actions/runs/26212032219
- merged app PRs:
  - https://github.com/PingCAP-QE/ee-apps/pull/457
  - https://github.com/PingCAP-QE/ee-apps/pull/456

## Test
- `kubectl kustomize apps/gcp/ci-dashboard > /tmp/ci-dashboard-rendered.yaml`
- `rg -n "ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.5.17-7-g4161283" /tmp/ci-dashboard-rendered.yaml`
- confirmed the ee-apps release workflow for `41612835be4a03b446c5eb0ea775e310fac7a770` completed successfully