### PR TITLE
chore(ci-dashboard): deploy v2026.5.17-8-geb6d9db

### DIFF
--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/ci-dashboard
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/ci-dashboard versioning=semver
-      tag: v2026.5.17-7-g4161283
+      tag: v2026.5.17-8-geb6d9db
     resources:
       requests:
         cpu: "2"


### PR DESCRIPTION
## Summary
- deploy ci-dashboard image tag `v2026.5.17-8-geb6d9db`
- roll app and jobs workloads together via the existing kustomize replacements
- release merged ee-apps changes from PingCAP-QE/ee-apps#458

## Verification
- confirmed `ghcr.io/pingcap-qe/ee-apps/ci-dashboard:v2026.5.17-8-geb6d9db` exists
- confirmed `ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.5.17-8-geb6d9db` exists
- confirmed `kubectl kustomize apps/gcp/ci-dashboard` rewrites jobs images to the same tag
