### PR TITLE
chore(ci-dashboard): deploy v2026.5.21-9-gd6fedb8

### DIFF
--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/ci-dashboard
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/ci-dashboard versioning=semver
-      tag: v2026.5.17-8-geb6d9db
+      tag: v2026.5.21-9-gd6fedb8
     resources:
       requests:
         cpu: "2"


### PR DESCRIPTION
## Summary
- deploy ci-dashboard image tag `v2026.5.21-9-gd6fedb8`
- roll app and jobs workloads together via the existing kustomize replacements
- release merged ee-apps changes from PingCAP-QE/ee-apps#459

## Verification
- confirmed `kubectl kustomize apps/gcp/ci-dashboard` rewrites jobs images to `v2026.5.21-9-gd6fedb8`
- ee-apps image publish workflow for `d6fedb8` is in progress: https://github.com/PingCAP-QE/ee-apps/actions/runs/26222388012
- image existence in GHCR is pending workflow completion
