### PR TITLE
chore(ci-dashboard): deploy v2026.5.17-10-g64d0270

### DIFF
--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/ci-dashboard
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/ci-dashboard versioning=semver
-      tag: v2026.5.21-9-gd6fedb8
+      tag: v2026.5.17-10-g64d0270
     resources:
       requests:
         cpu: "2"


### PR DESCRIPTION
## Summary
- deploy ci-dashboard release `v2026.5.17-10-g64d0270`
- update the HelmRelease tag in `apps/gcp/ci-dashboard/release.yaml`
- let kustomize replacements propagate the same tag to workers and cronjobs

## Source
- ee-apps PR: https://github.com/PingCAP-QE/ee-apps/pull/460
- merge commit: `64d02701852f7db1b5e925ee2023833d643e3b3e`
- derived tag: `git describe --tags --long <merge-sha>` -> `v2026.5.17-10-g64d0270`

## Validation
- `Skaffold - release` succeeded: https://github.com/PingCAP-QE/ee-apps/actions/runs/26225871170
- confirmed GHCR manifests exist for:
  - `ghcr.io/pingcap-qe/ee-apps/ci-dashboard:v2026.5.17-10-g64d0270`
  - `ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.5.17-10-g64d0270`
- `kubectl kustomize apps/gcp/ci-dashboard` shows the new tag on the app HelmRelease and propagated jobs/workers
