### PR TITLE
fix(apps/gcp/ci-dashboard): deploy v2026.5.17-11-ga655183

### DIFF
--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/ci-dashboard
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/ci-dashboard versioning=semver
-      tag: v2026.5.17-10-g64d0270
+      tag: v2026.5.17-11-ga655183
     resources:
       requests:
         cpu: "2"


### PR DESCRIPTION
## Summary
- bump ci-dashboard HelmRelease image tag to `v2026.5.17-11-ga655183`
- roll the same tag to ci-dashboard cronjobs, jenkins worker, and pod watcher via kustomize replacements
- release the error classification fixes merged in PingCAP-QE/ee-apps#461

## Verification
- `docker manifest inspect ghcr.io/pingcap-qe/ee-apps/ci-dashboard:v2026.5.17-11-ga655183`
- `docker manifest inspect ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.5.17-11-ga655183`
- `kubectl kustomize apps/gcp/ci-dashboard | rg "v2026.5.17-11-ga655183"`
- `./scripts/validate_k8s_yaml.sh apps/gcp/ci-dashboard` currently fails on pre-existing `charts/prow/templates/tests/test-connection.yaml` YAML issue, unrelated to this change