### PR TITLE
refactor(apps/gcp/jenkins): switch the ci worker node to spot instance for ticdc

### DIFF
--- a/apps/gcp/jenkins/beta/post/_base/kustomization.yaml
+++ b/apps/gcp/jenkins/beta/post/_base/kustomization.yaml
@@ -2,4 +2,3 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - rbac.yaml
-  - policies.yaml

--- a/apps/gcp/jenkins/beta/post/_global/compute-class-jenkins-worker-bigdisk.yaml
+++ b/apps/gcp/jenkins/beta/post/_global/compute-class-jenkins-worker-bigdisk.yaml
@@ -1,0 +1,32 @@
+apiVersion: cloud.google.com/v1
+kind: ComputeClass
+metadata:
+  name: jenkins-worker-bigdisk
+spec:
+  nodePoolAutoCreation:
+    enabled: true
+  whenUnsatisfiable: ScaleUpAnyway
+  priorities:
+    # --------- spot types -----------
+    - machineType: c4d-standard-16
+      spot: true
+      storage:
+        bootDiskType: hyperdisk-balanced
+        bootDiskSize: 500
+    - machineType: c4-standard-16
+      spot: true
+      storage:
+        bootDiskType: hyperdisk-balanced
+        bootDiskSize: 500
+
+    # --------- on-demand types -----------
+    - machineType: c4d-standard-16
+      spot: false
+      storage:
+        bootDiskType: hyperdisk-balanced
+        bootDiskSize: 500
+    - machineType: c4-standard-16
+      spot: false
+      storage:
+        bootDiskType: hyperdisk-balanced
+        bootDiskSize: 500

--- a/apps/gcp/jenkins/beta/post/_global/compute-class-jenkins-worker.yaml
+++ b/apps/gcp/jenkins/beta/post/_global/compute-class-jenkins-worker.yaml
@@ -1,0 +1,36 @@
+apiVersion: cloud.google.com/v1
+kind: ComputeClass
+metadata:
+  name: jenkins-worker
+spec:
+  nodePoolAutoCreation:
+    enabled: true
+  whenUnsatisfiable: ScaleUpAnyway
+  priorities:
+    # --------- spot types -----------
+    - machineFamily: c4d
+      spot: true
+      storage:
+        bootDiskType: hyperdisk-balanced
+    - machineFamily: c4
+      spot: true
+      storage:
+        bootDiskType: hyperdisk-balanced
+    - machineFamily: c4a
+      spot: true
+      storage:
+        bootDiskType: hyperdisk-balanced
+
+    # --------- on-demand types -----------
+    - machineFamily: c4d
+      spot: false
+      storage:
+        bootDiskType: hyperdisk-balanced
+    - machineFamily: c4
+      spot: false
+      storage:
+        bootDiskType: hyperdisk-balanced
+    - machineFamily: c4a
+      spot: false
+      storage:
+        bootDiskType: hyperdisk-balanced

--- a/apps/gcp/jenkins/beta/post/_global/kustomization.yaml
+++ b/apps/gcp/jenkins/beta/post/_global/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - compute-class-jenkins-worker.yaml
+  - compute-class-jenkins-worker-bigdisk.yaml

--- a/apps/gcp/jenkins/beta/post/kustomization.yaml
+++ b/apps/gcp/jenkins/beta/post/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - _global
   - ticdc
   - tidb

--- a/apps/gcp/jenkins/beta/post/ticdc/kustomization.yaml
+++ b/apps/gcp/jenkins/beta/post/ticdc/kustomization.yaml
@@ -4,3 +4,4 @@ namespace: jenkins-tiflow
 resources:
   - namespace.yaml
   - ../_base
+  - policies.yaml

--- a/apps/gcp/jenkins/beta/post/ticdc/policies.yaml
+++ b/apps/gcp/jenkins/beta/post/ticdc/policies.yaml
@@ -1,0 +1,28 @@
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: restrict-to-node-instance-types
+spec:
+  rules:
+    - name: restrict-pods-running-on-spot-nodes
+      match:
+        resources:
+          kinds:
+            - Pod
+      mutate:
+        patchStrategicMerge:
+          metadata:
+            annotations:
+              cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+          spec:
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: cloud.google.com/gke-provisioning
+                          operator: In
+                          values: ["spot"]
+                        - key: cloud.google.com/machine-family
+                          operator: In
+                          values: [c4d, c4, c4a]

--- a/apps/gcp/jenkins/beta/post/tidb/kustomization.yaml
+++ b/apps/gcp/jenkins/beta/post/tidb/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - namespace.yaml
   - serviceaccount.yaml
   - ../_base
+  - policies.yaml
 configMapGenerator:
   - name: bazel
     options:

--- a/apps/gcp/jenkins/beta/post/tidb/policies.yaml
+++ b/apps/gcp/jenkins/beta/post/tidb/policies.yaml
@@ -25,4 +25,4 @@ spec:
                           values: ["spot"]
                         - key: cloud.google.com/machine-family
                           operator: In
-                          values: [c4, c4a]
+                          values: [c4d, c4, c4a]


### PR DESCRIPTION
## Summary
- add global `ComputeClass` resources for default and bigdisk Jenkins workers
- include the global compute classes in the beta post overlay
- split scheduling policies for `tidb` and `ticdc` workloads under beta post

## Validation
- `kustomize build apps/gcp/jenkins/beta/post`
- `kustomize build apps/gcp/jenkins/beta/post/tidb`
- `kustomize build apps/gcp/jenkins/beta/post/ticdc`