### PR TITLE
chore(gcp/jenkins): add pd agent namespace

### DIFF
--- a/apps/gcp/jenkins/beta/post/pd/kustomization.yaml
+++ b/apps/gcp/jenkins/beta/post/pd/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: jenkins-pd
 resources:
-  - pd
-  - ticdc
-  - tidb
+  - namespace.yaml
+  - ../_base
+  - policies.yaml

--- a/apps/gcp/jenkins/beta/post/pd/namespace.yaml
+++ b/apps/gcp/jenkins/beta/post/pd/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: jenkins-pd

--- a/apps/gcp/jenkins/beta/post/pd/policies.yaml
+++ b/apps/gcp/jenkins/beta/post/pd/policies.yaml
@@ -1,0 +1,19 @@
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: restrict-to-node-instance-types
+spec:
+  rules:
+    - name: restrict-pods-running-on-spot-nodes
+      match:
+        resources:
+          kinds:
+            - Pod
+      mutate:
+        patchStrategicMerge:
+          metadata:
+            annotations:
+              cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+          spec:
+            nodeSelector:
+              cloud.google.com/compute-class: ci-worker

--- a/apps/gcp/jenkins/beta/release/values-agent.yaml
+++ b/apps/gcp/jenkins/beta/release/values-agent.yaml
@@ -16,5 +16,6 @@ agent:
     enabled: true
     timeout: 300
     namespaces: |-
+      jenkins-pd
       jenkins-tiflow
       jenkins-tidb


### PR DESCRIPTION
Prepare the GCP Jenkins runtime resources for PD presubmit jobs.

Changes include:

- Add `jenkins-pd` namespace under GCP Jenkins beta post resources.
- Apply the shared Jenkins agent scheduling RBAC to `jenkins-pd`.
- Add the same Kyverno scheduling policy used by TiDB/TiCDC agent namespaces.
- Include `jenkins-pd` in Jenkins agent garbage collection namespaces.