### PR TITLE
feat(dashboard): roll out cost dashboard v2

### DIFF
--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/ci-dashboard
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/ci-dashboard versioning=semver
-      tag: v2026.5.17-11-ga655183
+      tag: v2026.5.24-3-g4e98920
     resources:
       requests:
         cpu: "2"
@@ -49,7 +49,7 @@ spec:
       - name: CI_DASHBOARD_ENABLE_RUNTIME_INSIGHTS
         value: "true"
       - name: CI_DASHBOARD_ENABLE_COST_DASHBOARD
-        value: "false"
+        value: "true"
     serviceAccount:
       annotations:
         iam.gke.io/gcp-service-account: ci-dashboard@pingcap-testing-account.iam.gserviceaccount.com

--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -31,7 +31,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.5.24-2-g7f5f498
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.5.24-3-g4e98920
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -120,7 +120,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.5.24-2-g7f5f498
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.5.24-3-g4e98920
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh


### PR DESCRIPTION
## Summary
- Roll out ee-apps cost dashboard v2 image tag `v2026.5.24-3-g4e98920` for ci-dashboard app and jobs.
- Enable `CI_DASHBOARD_ENABLE_COST_DASHBOARD` in the GCP ci-dashboard HelmRelease.
- Update cost-insight cronjob images to the same ee-apps release tag.

## Validation
- Derived tag from ee-apps merge commit `4e9892076337d4cd7a890ec344f81bdbe498d933`: `v2026.5.24-3-g4e98920`.
- Confirmed ee-apps Skaffold release run succeeded.
- Confirmed GHCR manifests exist for `ci-dashboard`, `ci-dashboard-jobs`, and `cost-insight-jobs` at the new tag.
- Ran `kubectl kustomize apps/gcp/ci-dashboard` and `kubectl kustomize apps/gcp/cost-insight`.

Upstream app PR: PingCAP-QE/ee-apps#464