### PR TITLE
feat(gcp): deploy roster weekly summary cronjob

### DIFF
--- a/apps/gcp/roster/cronjob.yaml
+++ b/apps/gcp/roster/cronjob.yaml
@@ -27,7 +27,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-roster
-              image: ghcr.io/pingcap-qe/ee-apps/roster-jobs:v2026.5.17-1-g006d4fc
+              image: ghcr.io/pingcap-qe/ee-apps/roster-jobs:v2026.5.24-2-g7f5f498
               imagePullPolicy: IfNotPresent
               args:
                 - sync-roster
@@ -41,6 +41,60 @@ spec:
                   value: "1"
                 - name: ROSTER_LOG_LEVEL
                   value: "INFO"
+              resources:
+                requests:
+                  cpu: "250m"
+                  memory: "512Mi"
+                limits:
+                  cpu: "1"
+                  memory: "1Gi"
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: roster-weekly-summary
+  namespace: apps
+  labels:
+    app.kubernetes.io/name: roster-weekly-summary
+    app.kubernetes.io/part-of: roster
+spec:
+  schedule: "10 10 * * 1"
+  timeZone: Asia/Shanghai
+  suspend: false
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 1800
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 600
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: roster-weekly-summary
+            app.kubernetes.io/part-of: roster
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: weekly-summary
+              image: ghcr.io/pingcap-qe/ee-apps/roster-jobs:v2026.5.24-2-g7f5f498
+              imagePullPolicy: IfNotPresent
+              args:
+                - weekly-summary
+                - --send-lark
+              envFrom:
+                - secretRef:
+                    name: ci-dashboard-eq-prd-insight-db
+                - secretRef:
+                    name: roster-lark
+              env:
+                - name: PYTHONUNBUFFERED
+                  value: "1"
+                - name: ROSTER_LOG_LEVEL
+                  value: "INFO"
+                - name: ROSTER_LARK_NOTIFY_OPEN_ID
+                  value: "ou_305fc38fd60e3f64a60296cf9afeb7f7"
               resources:
                 requests:
                   cpu: "250m"


### PR DESCRIPTION
## Summary
- update the roster sync CronJob to the image built from PingCAP-QE/ee-apps#462
- add `roster-weekly-summary` CronJob to run every Monday at 10:10 Asia/Shanghai after daily sync
- send the weekly summary to the configured Lark open_id

## Verification
- `kubectl kustomize apps/gcp/roster`
- `kubectl apply --dry-run=server -k apps/gcp/roster`