### PR TITLE
chore(gcp/jenkins): add tiflash agent namespace

### DIFF
--- a/apps/gcp/jenkins/beta/post/kustomization.yaml
+++ b/apps/gcp/jenkins/beta/post/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - pd
   - ticdc
   - tidb
+  - tiflash

--- a/apps/gcp/jenkins/beta/post/pd/policies.yaml
+++ b/apps/gcp/jenkins/beta/post/pd/policies.yaml
@@ -4,7 +4,7 @@ metadata:
   name: restrict-to-node-instance-types
 spec:
   rules:
-    - name: restrict-pods-running-on-spot-nodes
+    - name: set-ci-worker-pod-defaults
       match:
         resources:
           kinds:

--- a/apps/gcp/jenkins/beta/post/ticdc/policies.yaml
+++ b/apps/gcp/jenkins/beta/post/ticdc/policies.yaml
@@ -4,7 +4,7 @@ metadata:
   name: restrict-to-node-instance-types
 spec:
   rules:
-    - name: restrict-pods-running-on-spot-nodes
+    - name: set-ci-worker-pod-defaults
       match:
         resources:
           kinds:

--- a/apps/gcp/jenkins/beta/post/tidb/policies.yaml
+++ b/apps/gcp/jenkins/beta/post/tidb/policies.yaml
@@ -4,7 +4,7 @@ metadata:
   name: restrict-to-node-instance-types
 spec:
   rules:
-    - name: restrict-pods-running-on-spot-nodes
+    - name: set-ci-worker-pod-defaults
       match:
         resources:
           kinds:

--- a/apps/gcp/jenkins/beta/post/tiflash/kustomization.yaml
+++ b/apps/gcp/jenkins/beta/post/tiflash/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: jenkins-tiflash
+resources:
+  - namespace.yaml
+  - ../_base
+  - policies.yaml

--- a/apps/gcp/jenkins/beta/post/tiflash/namespace.yaml
+++ b/apps/gcp/jenkins/beta/post/tiflash/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: jenkins-tiflash

--- a/apps/gcp/jenkins/beta/post/tiflash/policies.yaml
+++ b/apps/gcp/jenkins/beta/post/tiflash/policies.yaml
@@ -4,7 +4,7 @@ metadata:
   name: restrict-to-node-instance-types
 spec:
   rules:
-    - name: restrict-pods-running-on-spot-nodes
+    - name: set-ci-worker-pod-defaults
       match:
         resources:
           kinds:

--- a/apps/gcp/jenkins/beta/post/tiflash/policies.yaml
+++ b/apps/gcp/jenkins/beta/post/tiflash/policies.yaml
@@ -1,0 +1,19 @@
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: restrict-to-node-instance-types
+spec:
+  rules:
+    - name: restrict-pods-running-on-spot-nodes
+      match:
+        resources:
+          kinds:
+            - Pod
+      mutate:
+        patchStrategicMerge:
+          metadata:
+            annotations:
+              cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+          spec:
+            nodeSelector:
+              cloud.google.com/compute-class: ci-worker

--- a/apps/gcp/jenkins/beta/release/values-agent.yaml
+++ b/apps/gcp/jenkins/beta/release/values-agent.yaml
@@ -19,3 +19,4 @@ agent:
       jenkins-pd
       jenkins-tiflow
       jenkins-tidb
+      jenkins-tiflash


### PR DESCRIPTION
Prepare the GCP Jenkins runtime resources for tiflash presubmit jobs.

ref: https://github.com/PingCAP-QE/ee-ops/pull/1982