### PR TITLE
feat(apps/prod2/jenkins): add s3 artifact manager

### DIFF
--- a/apps/prod2/jenkins/beta/release/values-JCasC.yaml
+++ b/apps/prod2/jenkins/beta/release/values-JCasC.yaml
@@ -258,7 +258,7 @@ controller:
                       password: ${harbor-tiflow-engine-password}
 
       artifact-manager-s3: |
-        unclassified:
+        aws:
           awsCredentials:
             region: ${jenkins-cache-region}
             credentialsId: jenkins-cache-s3
@@ -268,10 +268,12 @@ controller:
             customSigningRegion: ${jenkins-cache-region}
             usePathStyleUrl: true
             disableSessionToken: true
-        jenkins:
+        unclassified:
           artifactManager:
             artifactManagerFactories:
-              - s3: {}
+              - s3:
+                  config:
+                    prefix: "jenkins-artifacts/"
 
       # for jobs.
       jobs-dsl: |

--- a/apps/prod2/jenkins/beta/release/values-JCasC.yaml
+++ b/apps/prod2/jenkins/beta/release/values-JCasC.yaml
@@ -262,17 +262,16 @@ controller:
           awsCredentials:
             region: ${jenkins-cache-region}
             credentialsId: jenkins-cache-s3
-          artifactManager:
-            artifactManagerFactories:
-              - jclouds:
-                  provider:
-                    s3: {}
           s3:
             container: ${jenkins-cache-bucket}
             customEndpoint: ${jenkins-cache-endpoint}
             customSigningRegion: ${jenkins-cache-region}
             usePathStyleUrl: true
             disableSessionToken: true
+        jenkins:
+          artifactManager:
+            artifactManagerFactories:
+              - s3: {}
 
       # for jobs.
       jobs-dsl: |

--- a/apps/prod2/jenkins/beta/release/values-JCasC.yaml
+++ b/apps/prod2/jenkins/beta/release/values-JCasC.yaml
@@ -158,6 +158,12 @@ controller:
                       id: "ks3util-config"
                       fileName: "ks3util.conf"
                       secretBytes: "${base64:${ks3util-config}}"
+                  - aws:
+                      scope: GLOBAL
+                      id: jenkins-cache-s3
+                      description: S3 credentials for Jenkins artifact manager
+                      accessKey: ${jenkins-cache-access-key}
+                      secretKey: ${jenkins-cache-access-secret}
               - domain:
                   name: github.com
                   description: github ssh and open api
@@ -250,6 +256,23 @@ controller:
                       description: user/password for tiflow engine test in harbor
                       username: ${harbor-tiflow-engine-username}
                       password: ${harbor-tiflow-engine-password}
+
+      artifact-manager-s3: |
+        unclassified:
+          awsCredentials:
+            region: ${jenkins-cache-region}
+            credentialsId: jenkins-cache-s3
+          artifactManager:
+            artifactManagerFactories:
+              - jclouds:
+                  provider:
+                    s3: {}
+          s3:
+            container: ${jenkins-cache-bucket}
+            customEndpoint: ${jenkins-cache-endpoint}
+            customSigningRegion: ${jenkins-cache-region}
+            usePathStyleUrl: true
+            disableSessionToken: true
 
       # for jobs.
       jobs-dsl: |

--- a/apps/prod2/jenkins/beta/release/values-controller-plugins.yaml
+++ b/apps/prod2/jenkins/beta/release/values-controller-plugins.yaml
@@ -6,6 +6,7 @@ controller:
   additionalPlugins:
     # Ref: https://github.com/jenkinsci/plugin-installation-manager-tool#plugin-input-format
     # but without outer `plugin` key.
+    - artifact-manager-s3:845.v7a_e8f50f62dd
     - build-failure-analyzer::https://github.com/PingCAP-QE/build-failure-analyzer-plugin/releases/download/v2.4.2-jobname/build-failure-analyzer.hpi
     - cdevents::https://github.com/dillon-zheng/cdevents-plugin/releases/download/cdevents-1-40-pingcap-1/cdevents-1-40-pingcap-1.hpi
     - generic-webhook-trigger:2.4.1


### PR DESCRIPTION
This pull request adds support for storing Jenkins build artifacts in Amazon S3 by configuring the artifact manager and necessary credentials. It also ensures the required plugin is installed. The main changes are grouped below:

**Jenkins S3 Artifact Storage Configuration:**

* Added AWS credentials for S3 (`jenkins-cache-s3`) to the Jenkins configuration, including access key and secret key parameters.
* Configured the Jenkins artifact manager to use S3 as the storage backend, specifying the region, bucket, endpoint, and related settings.

**Plugin Management:**

* Added the `artifact-manager-s3` plugin to the list of Jenkins plugins to ensure S3 artifact management functionality is available.