### PR TITLE
chore(deps): bump chatops-lark and tibuild v1 images

### DIFF
--- a/apps/prod2/chatops-lark/release.yaml
+++ b/apps/prod2/chatops-lark/release.yaml
@@ -38,7 +38,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/chatops-lark
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/chatops-lark versioning=semver
-      tag: v2025.11.30-13-g64b3e50
+      tag: v2026.5.24-5-g705bf25
     server:
       secretName: chatops-lark
       appIdSecretKey: app-id

--- a/apps/prod2/tibuild/v1/deployment.yaml
+++ b/apps/prod2/tibuild/v1/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app: tibuild
     spec:
       containers:
-        - image: ghcr.io/pingcap-qe/ee-apps/tibuild:v2026.3.15-8-g82732fa
+        - image: ghcr.io/pingcap-qe/ee-apps/tibuild:v2026.5.24-4-g7eea746
           imagePullPolicy: Always
           name: tibuild
           ports:


### PR DESCRIPTION
## Changes

- **chatops-lark**: `v2025.11.30-13-g64b3e50` → `v2026.5.24-5-g705bf25`
- **tibuild v1**: `v2026.3.15-8-g82732fa` → `v2026.5.24-4-g7eea746`

Both images were published from the latest ee-apps main branch commits (via skaffold release workflow).

## Related

Closes FLA-159