### PR TITLE
chore(apps/prod2/tibuild): update v1 and v2 image tags to v2026.5.24-7-gf2ffb0c

### DIFF
--- a/apps/prod2/tibuild/v1/deployment.yaml
+++ b/apps/prod2/tibuild/v1/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app: tibuild
     spec:
       containers:
-        - image: ghcr.io/pingcap-qe/ee-apps/tibuild:v2026.5.24-4-g7eea746
+        - image: ghcr.io/pingcap-qe/ee-apps/tibuild:v2026.5.24-7-gf2ffb0c
           imagePullPolicy: Always
           name: tibuild
           ports:

--- a/apps/prod2/tibuild/v2/release.yaml
+++ b/apps/prod2/tibuild/v2/release.yaml
@@ -37,7 +37,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/exp-tibuild-v2
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/exp-tibuild-v2 versioning=semver
-      tag: v2026.4.19-10-gab82bf8
+      tag: v2026.5.24-7-gf2ffb0c
     server:
       debug: false
       config:


### PR DESCRIPTION
## Summary

Update tibuild v1 and v2 image tags to the latest version `v2026.5.24-7-gf2ffb0c`.

### Changes
- **v1** (`apps/prod2/tibuild/v1/deployment.yaml`): `v2026.5.24-4-g7eea746` → `v2026.5.24-7-gf2ffb0c`
- **v2** (`apps/prod2/tibuild/v2/release.yaml`): `v2026.4.19-10-gab82bf8` → `v2026.5.24-7-gf2ffb0c`

Ref: FLA-160