### PR TITLE
chore(ci-dashboard): deploy v2026.5.24-9-g4c81401

### DIFF
--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/ci-dashboard
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/ci-dashboard versioning=semver
-      tag: v2026.5.24-3-g4e98920
+      tag: v2026.5.24-9-g4c81401
     resources:
       requests:
         cpu: "2"


### PR DESCRIPTION
## Summary
- bump CI Dashboard release tag to `v2026.5.24-9-g4c81401`
- roll out the merged ee-apps changes from #467 and #470
- keep worker and cronjob images aligned through existing kustomize replacements

## Verification
- derived tag from merged ee-apps commit `4c814011b74c7972b6fdc81ee9593e3828e642b8` with `git describe --tags --long`
- confirmed ee-apps release workflow published both `ci-dashboard` and `ci-dashboard-jobs` images for `v2026.5.24-9-g4c81401`
- rendered `apps/gcp/ci-dashboard` with `kubectl kustomize` and verified jobs images resolve to the new tag