### PR TITLE
chore(ci-dashboard): deploy v2026.5.24-10-g819d78c

### DIFF
--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/ci-dashboard
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/ci-dashboard versioning=semver
-      tag: v2026.5.24-9-g4c81401
+      tag: v2026.5.24-10-g819d78c
     resources:
       requests:
         cpu: "2"


### PR DESCRIPTION
## Summary
- bump CI Dashboard release tag to `v2026.5.24-10-g819d78c`
- roll out the merged ee-apps changes from #471
- keep worker and cronjob images aligned through existing kustomize replacements

## Verification
- derived tag from merged ee-apps commit `819d78cb97e2142d97f7c3564e11585a0fcb8e87` with `git describe --tags --long`
- confirmed ee-apps release workflow published both `ci-dashboard` and `ci-dashboard-jobs` images for `v2026.5.24-10-g819d78c`
- rendered `apps/gcp/ci-dashboard` with `kubectl kustomize` and verified jobs images resolve to the new tag