### PR TITLE
feat(gcp/prow): add docs-cn secret for post jobs

### DIFF
--- a/apps/gcp/prow/post.yaml
+++ b/apps/gcp/prow/post.yaml
@@ -18,3 +18,4 @@ spec:
   postBuild:
     substitute:
       TEST_PODS_NAMESPACE: prow-test-pods
+      DOCS_CN_S3_JSON: prod2_jenkins_beta_docs_cn_s3_json

--- a/apps/gcp/prow/post.yaml
+++ b/apps/gcp/prow/post.yaml
@@ -18,4 +18,4 @@ spec:
   postBuild:
     substitute:
       TEST_PODS_NAMESPACE: prow-test-pods
-      DOCS_CN_S3_JSON: prod2_jenkins_beta_docs_cn_s3_json
+      DOCS_CN_S3_JSON: gcp_prow_docs_cn_s3_json

--- a/apps/gcp/prow/post/job-ns/secrets/docs-cn.yaml
+++ b/apps/gcp/prow/post/job-ns/secrets/docs-cn.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: docs-cn
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: ee-gcp-sm
+    kind: ClusterSecretStore
+  target:
+    name: docs-cn
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: "${DOCS_CN_S3_JSON}" # json object

--- a/apps/gcp/prow/post/job-ns/secrets/kustomization.yaml
+++ b/apps/gcp/prow/post/job-ns/secrets/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - gcs-credentials.yaml
   - github-token.yaml
   - codecov-token.yaml
+  - docs-cn.yaml


### PR DESCRIPTION
This pull request introduces a new external secret for the `docs-cn` S3 JSON configuration in the Prow post jobs. The changes ensure that the secret is managed via External Secrets and is properly referenced in the job's configuration.

Secret management improvements:

* Added a new `ExternalSecret` resource definition for `docs-cn`, which pulls the S3 JSON configuration from the secret manager using the `${DOCS_CN_S3_JSON}` variable. (`apps/gcp/prow/post/job-ns/secrets/docs-cn.yaml`)
* Updated the `kustomization.yaml` to include the new `docs-cn.yaml` secret resource, ensuring it is deployed with the other secrets. (`apps/gcp/prow/post/job-ns/secrets/kustomization.yaml`)

Configuration updates:

* Added the `DOCS_CN_S3_JSON` substitution variable to the `postBuild` configuration to support the new secret. (`apps/gcp/prow/post.yaml`)