### PR TITLE
fix(apps/gcp/tekton/configs): fix pod policies

### DIFF
--- a/apps/gcp/jenkins-agents/policies.yaml
+++ b/apps/gcp/jenkins-agents/policies.yaml
@@ -1,25 +1,16 @@
 apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
-  name: restrict-to-node-instance-types
+  name: run-with-autopilot-spot-pod
 spec:
   rules:
-    - name: restrict-pods-running-on-spot-nodes
+    - name: add-compute-class
       match:
         resources:
           kinds:
             - Pod
       mutate:
         patchStrategicMerge:
-          metadata:
-            annotations:
-              cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
           spec:
-            affinity:
-              nodeAffinity:
-                requiredDuringSchedulingIgnoredDuringExecution:
-                  nodeSelectorTerms:
-                    - matchExpressions:
-                        - key: cloud.google.com/gke-provisioning
-                          operator: In
-                          values: ["spot"]
+            nodeSelector:
+              cloud.google.com/compute-class: autopilot-spot

--- a/apps/gcp/jenkins/beta/post/pd/policies.yaml
+++ b/apps/gcp/jenkins/beta/post/pd/policies.yaml
@@ -1,10 +1,10 @@
 apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
-  name: restrict-to-node-instance-types
+  name: set-pod-node-selector
 spec:
   rules:
-    - name: set-ci-worker-pod-defaults
+    - name: add-compute-class-and-annotations
       match:
         resources:
           kinds:

--- a/apps/gcp/jenkins/beta/post/ticdc/policies.yaml
+++ b/apps/gcp/jenkins/beta/post/ticdc/policies.yaml
@@ -1,10 +1,10 @@
 apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
-  name: restrict-to-node-instance-types
+  name: set-pod-node-selector
 spec:
   rules:
-    - name: set-ci-worker-pod-defaults
+    - name: add-compute-class-and-annotations
       match:
         resources:
           kinds:

--- a/apps/gcp/jenkins/beta/post/tidb/policies.yaml
+++ b/apps/gcp/jenkins/beta/post/tidb/policies.yaml
@@ -1,10 +1,10 @@
 apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
-  name: restrict-to-node-instance-types
+  name: set-pod-node-selector
 spec:
   rules:
-    - name: set-ci-worker-pod-defaults
+    - name: add-compute-class-and-annotations
       match:
         resources:
           kinds:

--- a/apps/gcp/jenkins/beta/post/tiflash/policies.yaml
+++ b/apps/gcp/jenkins/beta/post/tiflash/policies.yaml
@@ -1,10 +1,10 @@
 apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
-  name: restrict-to-node-instance-types
+  name: set-pod-node-selector
 spec:
   rules:
-    - name: set-ci-worker-pod-defaults
+    - name: add-compute-class-and-annotations
       match:
         resources:
           kinds:

--- a/apps/gcp/tekton/configs/policies.yaml
+++ b/apps/gcp/tekton/configs/policies.yaml
@@ -1,41 +1,10 @@
 apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
-  name: restrict-to-node-instance-types
+  name: set-node-selector-tekton-taskrun-pods
 spec:
   rules:
-    - name: restrict-non-el-pods-to-c4-c4a
-      match:
-        resources:
-          kinds:
-            - Pod
-      exclude:
-        resources:
-          names:
-            - "el-*"
-      mutate:
-        patchStrategicMerge:
-          spec:
-            affinity:
-              nodeAffinity:
-                requiredDuringSchedulingIgnoredDuringExecution:
-                  nodeSelectorTerms:
-                    - matchExpressions:
-                        - key: cloud.google.com/machine-family
-                          operator: In
-                          values: [c4, c4a]
-                        - key: cloud.google.com/gke-provisioning
-                          operator: In
-                          values: ["spot"]
-
----
-apiVersion: kyverno.io/v1
-kind: Policy
-metadata:
-  name: protect-tekton-taskruns
-spec:
-  rules:
-    - name: inject-annotation-for-tekton-taskrun-pod
+    - name: add-compute-class-and-annotations
       match:
         resources:
           kinds:
@@ -49,3 +18,18 @@ spec:
           metadata:
             annotations:
               cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+          spec:
+            nodeSelector:
+              cloud.google.com/compute-class: ci-worker
+
+---
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: protect-tekton-taskruns
+spec:
+  rules:
+    - name: inject-annotation-for-tekton-taskrun-pod
+
+      mutate:
+        patchStrategicMerge:


### PR DESCRIPTION
This pull request updates several Kyverno policy files to standardize pod scheduling and node selection across multiple components. The main changes involve renaming policies and rules for clarity, simplifying node selection logic, and ensuring consistent use of node selectors and annotations for pod scheduling.

Policy and rule renaming for clarity:
* Updated policy and rule names in `jenkins` and `tekton` policy files to be more descriptive and consistent, such as changing names to `set-pod-node-selector` or `add-compute-class-and-annotations`. [[1]](diffhunk://#diff-e693b0850cb895cb124c54f43f85028b06ebce83d8a7764a3214100f1a4ccf3cL4-R7) [[2]](diffhunk://#diff-97ec1704d6a57677fc2cba0cc6405a6df999ec2b39f6d02170164037bf41ee68L4-R23)

Node selection and scheduling logic updates:
* Simplified node selection by replacing complex `affinity` and `nodeAffinity` configurations with direct `nodeSelector` usage, targeting specific compute classes (e.g., `autopilot-spot` or `ci-worker`). [[1]](diffhunk://#diff-2b4acdb731953430244fab10dc5b976ecfed68a5075f78604b1d43cf8cd845eeL4-R16) [[2]](diffhunk://#diff-97ec1704d6a57677fc2cba0cc6405a6df999ec2b39f6d02170164037bf41ee68L4-R23)
* Added or updated annotations like `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` to relevant pod specifications to control pod eviction behavior.

Selector and match expression improvements:
* Updated `match` and `selector` expressions to more precisely target pods, such as using `tekton.dev/taskRun` to match Tekton TaskRun pods.
* Removed redundant or overly broad match/exclude logic to streamline policy application. [[1]](diffhunk://#diff-97ec1704d6a57677fc2cba0cc6405a6df999ec2b39f6d02170164037bf41ee68L4-R23) [[2]](diffhunk://#diff-97ec1704d6a57677fc2cba0cc6405a6df999ec2b39f6d02170164037bf41ee68L39-L51)