### PR TITLE
feat(infrastructure/gcp): deliver lakesql release-homebrew secrets

### DIFF
--- a/docs/github-actions-secrets/README.md
+++ b/docs/github-actions-secrets/README.md
@@ -222,6 +222,7 @@ infrastructure/gcp/github-actions-secrets/
 
 ## Repo-specific runbooks
 
+- `tidbcloud/lakesql` `release-homebrew` cross-repo PR secrets: `docs/github-actions-secrets/lakesql-release-homebrew-secrets.md`
 - `tidbcloud/lakesql` `release-s3` package-signing secrets: `docs/github-actions-secrets/lakesql-release-s3-secrets.md`
 
 ## References

--- a/docs/github-actions-secrets/lakesql-release-homebrew-secrets.md
+++ b/docs/github-actions-secrets/lakesql-release-homebrew-secrets.md
@@ -1,0 +1,79 @@
+# LakeSQL release-homebrew Secrets
+
+This document defines the GitHub Actions secrets required by `tidbcloud/lakesql` environment `release-homebrew`, how they are mapped in `ee-ops`, and the GitHub App permissions required for cross-repo Homebrew PR automation.
+
+## Managed secrets
+
+These GitHub Actions environment secrets are delivered by External Secrets Operator to `tidbcloud/lakesql` environment `release-homebrew`.
+
+The source of truth in GCP Secret Manager is two string secrets:
+
+- `gha__env__tidbcloud__lakesql__release-homebrew__homebrew_tap_github_app_id`
+- `gha__env__tidbcloud__lakesql__release-homebrew__homebrew_tap_github_app_private_key`
+
+They are pushed into the GitHub environment as:
+
+| GitHub secret name | GCP secret name | Expected value |
+| --- | --- | --- |
+| `HOMEBREW_TAP_GITHUB_APP_ID` | `gha__env__tidbcloud__lakesql__release-homebrew__homebrew_tap_github_app_id` | decimal GitHub App ID for the app installed on `tidbcloud/homebrew-tap` |
+| `HOMEBREW_TAP_GITHUB_APP_PRIVATE_KEY` | `gha__env__tidbcloud__lakesql__release-homebrew__homebrew_tap_github_app_private_key` | PEM-encoded private key for the same GitHub App |
+
+## Required GitHub App permissions
+
+The GitHub App referenced by these secrets must be installed on `tidbcloud/homebrew-tap` and have at minimum:
+
+- repository permission `Contents`: `Read and write`
+- repository permission `Pull requests`: `Read and write`
+
+If the company-wide GitHub App is reused for this workflow, confirm that its `tidbcloud/homebrew-tap` installation has those permissions before publishing the secrets. If a dedicated app is preferred, store that app's ID and private key in the two GCP secrets above.
+
+## Create or update the source of truth in GCP Secret Manager
+
+Set the project first:
+
+```bash
+export PROJECT_ID=pingcap-testing-account
+```
+
+Create the two secrets if they do not already exist:
+
+```bash
+gcloud secrets create gha__env__tidbcloud__lakesql__release-homebrew__homebrew_tap_github_app_id \
+  --project="${PROJECT_ID}" \
+  --replication-policy=automatic
+
+gcloud secrets create gha__env__tidbcloud__lakesql__release-homebrew__homebrew_tap_github_app_private_key \
+  --project="${PROJECT_ID}" \
+  --replication-policy=automatic
+```
+
+Add or rotate the secret versions:
+
+```bash
+printf '%s' '123456' | gcloud secrets versions add \
+  gha__env__tidbcloud__lakesql__release-homebrew__homebrew_tap_github_app_id \
+  --project="${PROJECT_ID}" \
+  --data-file=-
+
+gcloud secrets versions add \
+  gha__env__tidbcloud__lakesql__release-homebrew__homebrew_tap_github_app_private_key \
+  --project="${PROJECT_ID}" \
+  --data-file=/secure/path/homebrew-tap-github-app.private-key.pem
+```
+
+The private key file should contain the original PEM payload exactly as issued by GitHub App settings.
+
+## Delivery mapping in ee-ops
+
+The GitOps objects for this environment live under:
+
+- `infrastructure/gcp/github-actions-secrets/repos/tidbcloud/lakesql/00-target-stores`
+- `infrastructure/gcp/github-actions-secrets/repos/tidbcloud/lakesql/01-source-secrets`
+- `infrastructure/gcp/github-actions-secrets/repos/tidbcloud/lakesql/02-deliveries`
+
+After the two GCP secrets are present in Secret Manager and Flux reconciles the manifests, ESO will:
+
+- extract the two values into cluster-local source secrets: `src-homebrew-tap-github-app-id` and `src-homebrew-tap-github-app-private-key`
+- push them into GitHub environment `tidbcloud/lakesql:release-homebrew`
+
+This environment is intended for the release workflow step that opens or updates formula PRs in `tidbcloud/homebrew-tap`.

--- a/infrastructure/gcp/github-actions-secrets/repos/tidbcloud/lakesql/00-target-stores/gh-environments.yaml
+++ b/infrastructure/gcp/github-actions-secrets/repos/tidbcloud/lakesql/00-target-stores/gh-environments.yaml
@@ -23,6 +23,27 @@ spec:
 apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
+  name: gh-env-tidbcloud-lakesql-release-homebrew
+  labels:
+    ee.pingcap.com/owner-team: platform
+    ee.pingcap.com/managed-by: fluxcd
+    ee.pingcap.com/github-org: tidbcloud
+spec:
+  provider:
+    github:
+      appID: 214286
+      installationID: 65036159
+      organization: tidbcloud
+      repository: lakesql
+      environment: release-homebrew
+      auth:
+        privateKey:
+          name: github-app-private-key
+          key: privateKey.pem
+---
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
   name: gh-env-tidbcloud-lakesql-release-npm
   labels:
     ee.pingcap.com/owner-team: platform

--- a/infrastructure/gcp/github-actions-secrets/repos/tidbcloud/lakesql/01-source-secrets/es-src-homebrew-tap-github-app-id.yaml
+++ b/infrastructure/gcp/github-actions-secrets/repos/tidbcloud/lakesql/01-source-secrets/es-src-homebrew-tap-github-app-id.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: es-src-homebrew-tap-github-app-id
+  labels:
+    ee.pingcap.com/owner-team: platform
+    ee.pingcap.com/managed-by: fluxcd
+    ee.pingcap.com/github-org: tidbcloud
+  annotations:
+    ee.pingcap.com/source-secret-id: gha__env__tidbcloud__lakesql__release-homebrew__homebrew_tap_github_app_id
+    ee.pingcap.com/github-secret-name: HOMEBREW_TAP_GITHUB_APP_ID
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcp-sm-github-actions
+    kind: SecretStore
+  target:
+    name: src-homebrew-tap-github-app-id
+    creationPolicy: Owner
+  data:
+    - secretKey: value
+      remoteRef:
+        key: gha__env__tidbcloud__lakesql__release-homebrew__homebrew_tap_github_app_id

--- a/infrastructure/gcp/github-actions-secrets/repos/tidbcloud/lakesql/01-source-secrets/es-src-homebrew-tap-github-app-private-key.yaml
+++ b/infrastructure/gcp/github-actions-secrets/repos/tidbcloud/lakesql/01-source-secrets/es-src-homebrew-tap-github-app-private-key.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: es-src-homebrew-tap-github-app-private-key
+  labels:
+    ee.pingcap.com/owner-team: platform
+    ee.pingcap.com/managed-by: fluxcd
+    ee.pingcap.com/github-org: tidbcloud
+  annotations:
+    ee.pingcap.com/source-secret-id: gha__env__tidbcloud__lakesql__release-homebrew__homebrew_tap_github_app_private_key
+    ee.pingcap.com/github-secret-name: HOMEBREW_TAP_GITHUB_APP_PRIVATE_KEY
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcp-sm-github-actions
+    kind: SecretStore
+  target:
+    name: src-homebrew-tap-github-app-private-key
+    creationPolicy: Owner
+  data:
+    - secretKey: value
+      remoteRef:
+        key: gha__env__tidbcloud__lakesql__release-homebrew__homebrew_tap_github_app_private_key

--- a/infrastructure/gcp/github-actions-secrets/repos/tidbcloud/lakesql/02-deliveries/ps-homebrew-tap-github-app-id-release-homebrew.yaml
+++ b/infrastructure/gcp/github-actions-secrets/repos/tidbcloud/lakesql/02-deliveries/ps-homebrew-tap-github-app-id-release-homebrew.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: ps-homebrew-tap-github-app-id-release-homebrew
+  labels:
+    ee.pingcap.com/owner-team: platform
+    ee.pingcap.com/managed-by: fluxcd
+    ee.pingcap.com/github-org: tidbcloud
+  annotations:
+    ee.pingcap.com/github-secret-name: HOMEBREW_TAP_GITHUB_APP_ID
+spec:
+  deletionPolicy: Delete
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: gh-env-tidbcloud-lakesql-release-homebrew
+      kind: SecretStore
+  selector:
+    secret:
+      name: src-homebrew-tap-github-app-id
+  data:
+    - match:
+        secretKey: value
+        remoteRef:
+          remoteKey: HOMEBREW_TAP_GITHUB_APP_ID

--- a/infrastructure/gcp/github-actions-secrets/repos/tidbcloud/lakesql/02-deliveries/ps-homebrew-tap-github-app-private-key-release-homebrew.yaml
+++ b/infrastructure/gcp/github-actions-secrets/repos/tidbcloud/lakesql/02-deliveries/ps-homebrew-tap-github-app-private-key-release-homebrew.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: ps-homebrew-tap-github-app-private-key-release-homebrew
+  labels:
+    ee.pingcap.com/owner-team: platform
+    ee.pingcap.com/managed-by: fluxcd
+    ee.pingcap.com/github-org: tidbcloud
+  annotations:
+    ee.pingcap.com/github-secret-name: HOMEBREW_TAP_GITHUB_APP_PRIVATE_KEY
+spec:
+  deletionPolicy: Delete
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: gh-env-tidbcloud-lakesql-release-homebrew
+      kind: SecretStore
+  selector:
+    secret:
+      name: src-homebrew-tap-github-app-private-key
+  data:
+    - match:
+        secretKey: value
+        remoteRef:
+          remoteKey: HOMEBREW_TAP_GITHUB_APP_PRIVATE_KEY

--- a/infrastructure/gcp/github-actions-secrets/repos/tidbcloud/lakesql/kustomization.yaml
+++ b/infrastructure/gcp/github-actions-secrets/repos/tidbcloud/lakesql/kustomization.yaml
@@ -2,7 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - 00-target-stores/gh-environments.yaml
+  - 01-source-secrets/es-src-homebrew-tap-github-app-id.yaml
+  - 01-source-secrets/es-src-homebrew-tap-github-app-private-key.yaml
   - 01-source-secrets/es-src-lakesql-release-s3-bundle.yaml
+  - 02-deliveries/ps-homebrew-tap-github-app-id-release-homebrew.yaml
+  - 02-deliveries/ps-homebrew-tap-github-app-private-key-release-homebrew.yaml
   - 02-deliveries/ps-lakesql-package-apk-passphrase-release-s3.yaml
   - 02-deliveries/ps-lakesql-package-apk-private-key-b64-release-s3.yaml
   - 02-deliveries/ps-lakesql-package-apk-public-key-b64-release-s3.yaml


### PR DESCRIPTION
## Summary
- add a `release-homebrew` GitHub environment store for `tidbcloud/lakesql`
- deliver `HOMEBREW_TAP_GITHUB_APP_ID` and `HOMEBREW_TAP_GITHUB_APP_PRIVATE_KEY` from GCP Secret Manager into that environment
- document the required `tidbcloud/homebrew-tap` GitHub App permissions and provisioning steps

## Testing
- `yq eval "."` on the changed YAML manifests
- `git diff --check`
- kustomization path existence check

`kustomize` and `kubectl` are not installed in this environment, so the full manifest build is deferred to CI.