### PR TITLE
feat(apps/gcp/prow): use  `ci-worker-ondemand` compute class for prow job pods

### DIFF
--- a/apps/gcp/prow/post/job-ns/policies.yaml
+++ b/apps/gcp/prow/post/job-ns/policies.yaml
@@ -16,4 +16,4 @@ spec:
               cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
           spec:
             nodeSelector:
-              cloud.google.com/compute-class: ci-worker
+              cloud.google.com/compute-class: ci-worker-ondemand

--- a/infrastructure/gcp/compute-classes/ci-worker-ondemand.yaml
+++ b/infrastructure/gcp/compute-classes/ci-worker-ondemand.yaml
@@ -1,0 +1,44 @@
+apiVersion: cloud.google.com/v1
+kind: ComputeClass
+metadata:
+  name: ci-worker-ondemand
+spec:
+  nodePoolAutoCreation:
+    enabled: true
+  whenUnsatisfiable: DoNotScaleUp
+  priorityDefaults:
+    location:
+      locationPolicy: ANY
+      zoneTypes: [STANDARD]
+  priorities:
+    # --------- on-demand types only -----------
+    - machineFamily: c4d
+      priorityScore: 100
+      spot: false
+      storage:
+        bootDiskType: hyperdisk-balanced
+        bootDiskSize: 100
+    - machineFamily: c4
+      priorityScore: 90
+      spot: false
+      storage:
+        bootDiskType: hyperdisk-balanced
+        bootDiskSize: 100
+    - machineFamily: c4a
+      priorityScore: 85
+      spot: false
+      storage:
+        bootDiskType: hyperdisk-balanced
+        bootDiskSize: 100
+    - machineFamily: c3
+      priorityScore: 60
+      spot: false
+      storage:
+        bootDiskType: hyperdisk-balanced
+        bootDiskSize: 100
+    - machineFamily: c3d
+      priorityScore: 55
+      spot: false
+      storage:
+        bootDiskType: hyperdisk-balanced
+        bootDiskSize: 100

--- a/infrastructure/gcp/compute-classes/kustomization.yaml
+++ b/infrastructure/gcp/compute-classes/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - ci-worker.yaml
   - ci-worker-bigdisk.yaml
+  - ci-worker-ondemand.yaml


### PR DESCRIPTION
This pull request introduces a new on-demand compute class for CI workers and updates the relevant configuration to use it. The main goal is to enable the use of on-demand (non-spot) instances for certain jobs, improving reliability for workloads that should not run on preemptible nodes.

**Compute class addition and configuration updates:**

* Added a new compute class definition in `ci-worker-ondemand.yaml`, specifying a set of prioritized on-demand machine families and storage options for CI workloads.
* Updated the `kustomization.yaml` to include the new `ci-worker-ondemand.yaml` file, ensuring it is deployed as part of the compute class resources.

**Job policy update:**

* Changed the `nodeSelector` for the relevant job in `policies.yaml` to use `ci-worker-ondemand` instead of `ci-worker`, so jobs are scheduled onto the new on-demand compute class.