### PR TITLE
chore(apps/gcp/prow): bump ti-community-issue-triage to v2026.6.3

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -386,7 +386,7 @@ spec:
           name: prow-hook
         image:
           repository: ticommunityinfra/tichi-issue-triage-plugin
-          tag: v2.4.5
+          tag: v2.4.6
         args:
           - --dry-run=false
           - --github-app-id=$(GITHUB_APP_ID)

--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -386,7 +386,7 @@ spec:
           name: prow-hook
         image:
           repository: ticommunityinfra/tichi-issue-triage-plugin
-          tag: v2.4.6
+          tag: v2026.6.3
         args:
           - --dry-run=false
           - --github-app-id=$(GITHUB_APP_ID)


### PR DESCRIPTION
## Summary
- bump the `ti-community-issue-triage` deployment image tag from `v2.4.5` to `v2026.6.3`
- align `ee-ops` with the fix merged in `ti-community-infra/tichi` PR #1230
- keep this PR held until a human decides when the change should take effect

## Release verification
- upstream release tag: `v2026.6.3`
- release workflow: https://github.com/ti-community-infra/tichi/actions/runs/26861526337
- published image: `ticommunityinfra/tichi-issue-triage-plugin:v2026.6.3`
