### PR TITLE
feat(github-actions-secrets): switch lakesql homebrew to app client id

### DIFF
--- a/docs/github-actions-secrets/tidbcloud/lakesql/release-homebrew-secrets.md
+++ b/docs/github-actions-secrets/tidbcloud/lakesql/release-homebrew-secrets.md
@@ -8,15 +8,17 @@ These GitHub Actions environment secrets are delivered by External Secrets Opera
 
 The source of truth in GCP Secret Manager is two shared system secrets:
 
-- `gha__system__github_app_id`
+- `gha__system__github_app_client_id`
 - `gha__system__github_app_private_key`
 
 They are pushed into the GitHub environment as:
 
 | GitHub secret name | GCP secret name | Expected value |
 | --- | --- | --- |
-| `HOMEBREW_TAP_GITHUB_APP_ID` | `gha__system__github_app_id` | decimal GitHub App ID for the shared GitHub App installed on `tidbcloud/homebrew-tap` |
+| `HOMEBREW_TAP_GITHUB_APP_CLIENT_ID` | `gha__system__github_app_client_id` | GitHub App client ID for the shared GitHub App installed on `tidbcloud/homebrew-tap` |
 | `HOMEBREW_TAP_GITHUB_APP_PRIVATE_KEY` | `gha__system__github_app_private_key` | PEM-encoded private key for the same shared GitHub App |
+
+Although the value is a client ID rather than a sensitive credential, this repo still delivers it through a GitHub Actions environment secret because the current centralized `ee-ops` delivery path manages GitHub Actions secrets, not variables.
 
 ## Required GitHub App permissions
 
@@ -29,7 +31,7 @@ This workflow reuses the shared company GitHub App. Confirm that its `tidbcloud/
 
 ## Source of truth in GCP Secret Manager
 
-These shared system secrets (gha__system__github_app_id and gha__system__github_app_private_key) are managed globally. They should not be created or rotated from this repository-specific runbook, as doing so may affect other repositories and workflows that rely on the same shared GitHub App.
+These shared system secrets (gha__system__github_app_client_id and gha__system__github_app_private_key) are managed globally. They should not be created or rotated from this repository-specific runbook, as doing so may affect other repositories and workflows that rely on the same shared GitHub App.
 
 If you need to verify or update these shared secrets, please refer to the central platform administration runbook or contact the platform team.
 ## Delivery mapping in ee-ops
@@ -42,7 +44,7 @@ The GitOps objects for this environment live under:
 
 After the two shared GCP secrets are present in Secret Manager and Flux reconciles the manifests, ESO will:
 
-- extract the two values into cluster-local source secrets: `src-homebrew-tap-github-app-id` and `src-homebrew-tap-github-app-private-key`
+- extract the two values into cluster-local source secrets: `src-homebrew-tap-github-app-client-id` and `src-homebrew-tap-github-app-private-key`
 - push them into GitHub environment `tidbcloud/lakesql:release-homebrew`
 
 This environment is intended for the release workflow step that opens or updates formula PRs in `tidbcloud/homebrew-tap`.

--- a/infrastructure/gcp/github-actions-secrets/repos/tidbcloud/lakesql/01-source-secrets/es-src-homebrew-tap-github-app-client-id.yaml
+++ b/infrastructure/gcp/github-actions-secrets/repos/tidbcloud/lakesql/01-source-secrets/es-src-homebrew-tap-github-app-client-id.yaml
@@ -1,23 +1,23 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: es-src-homebrew-tap-github-app-id
+  name: es-src-homebrew-tap-github-app-client-id
   labels:
     ee.pingcap.com/owner-team: platform
     ee.pingcap.com/managed-by: fluxcd
     ee.pingcap.com/github-org: tidbcloud
   annotations:
-    ee.pingcap.com/source-secret-id: gha__system__github_app_id
-    ee.pingcap.com/github-secret-name: HOMEBREW_TAP_GITHUB_APP_ID
+    ee.pingcap.com/source-secret-id: gha__system__github_app_client_id
+    ee.pingcap.com/github-secret-name: HOMEBREW_TAP_GITHUB_APP_CLIENT_ID
 spec:
   refreshInterval: 1h
   secretStoreRef:
     name: gcp-sm-github-actions
     kind: SecretStore
   target:
-    name: src-homebrew-tap-github-app-id
+    name: src-homebrew-tap-github-app-client-id
     creationPolicy: Owner
   data:
     - secretKey: value
       remoteRef:
-        key: gha__system__github_app_id
+        key: gha__system__github_app_client_id

--- a/infrastructure/gcp/github-actions-secrets/repos/tidbcloud/lakesql/02-deliveries/ps-homebrew-tap-github-app-client-id-release-homebrew.yaml
+++ b/infrastructure/gcp/github-actions-secrets/repos/tidbcloud/lakesql/02-deliveries/ps-homebrew-tap-github-app-client-id-release-homebrew.yaml
@@ -1,13 +1,13 @@
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
-  name: ps-homebrew-tap-github-app-id-release-homebrew
+  name: ps-homebrew-tap-github-app-client-id-release-homebrew
   labels:
     ee.pingcap.com/owner-team: platform
     ee.pingcap.com/managed-by: fluxcd
     ee.pingcap.com/github-org: tidbcloud
   annotations:
-    ee.pingcap.com/github-secret-name: HOMEBREW_TAP_GITHUB_APP_ID
+    ee.pingcap.com/github-secret-name: HOMEBREW_TAP_GITHUB_APP_CLIENT_ID
 spec:
   deletionPolicy: Delete
   refreshInterval: 1h
@@ -16,9 +16,9 @@ spec:
       kind: SecretStore
   selector:
     secret:
-      name: src-homebrew-tap-github-app-id
+      name: src-homebrew-tap-github-app-client-id
   data:
     - match:
         secretKey: value
         remoteRef:
-          remoteKey: HOMEBREW_TAP_GITHUB_APP_ID
+          remoteKey: HOMEBREW_TAP_GITHUB_APP_CLIENT_ID

--- a/infrastructure/gcp/github-actions-secrets/repos/tidbcloud/lakesql/kustomization.yaml
+++ b/infrastructure/gcp/github-actions-secrets/repos/tidbcloud/lakesql/kustomization.yaml
@@ -2,10 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - 00-target-stores/gh-environments.yaml
-  - 01-source-secrets/es-src-homebrew-tap-github-app-id.yaml
+  - 01-source-secrets/es-src-homebrew-tap-github-app-client-id.yaml
   - 01-source-secrets/es-src-homebrew-tap-github-app-private-key.yaml
   - 01-source-secrets/es-src-lakesql-release-s3-bundle.yaml
-  - 02-deliveries/ps-homebrew-tap-github-app-id-release-homebrew.yaml
+  - 02-deliveries/ps-homebrew-tap-github-app-client-id-release-homebrew.yaml
   - 02-deliveries/ps-homebrew-tap-github-app-private-key-release-homebrew.yaml
   - 02-deliveries/ps-lakesql-package-apk-passphrase-release-s3.yaml
   - 02-deliveries/ps-lakesql-package-apk-private-key-b64-release-s3.yaml


### PR DESCRIPTION
## Summary
- rename the LakeSQL release-homebrew GitHub Actions secret contract from `HOMEBREW_TAP_GITHUB_APP_ID` to `HOMEBREW_TAP_GITHUB_APP_CLIENT_ID`
- point the source ExternalSecret at the new shared GCP secret `gha__system__github_app_client_id`
- update the LakeSQL Homebrew secret runbook to describe the new client-id based delivery contract
