### PR TITLE
feat(jenkins-artifact-s3): add jenkins-artifact-s3 ExternalSecret for AWS credentials

### DIFF
--- a/apps/gcp/jenkins/beta/pre/kustomization.yaml
+++ b/apps/gcp/jenkins/beta/pre/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - secret-docs-cn.yaml
   - secret-ks3util.yaml
   - secret-tidbx-docker-config.yaml
+  - secret-jenkins-artifact-s3.yaml

--- a/apps/gcp/jenkins/beta/pre/secret-jenkins-artifact-s3.yaml
+++ b/apps/gcp/jenkins/beta/pre/secret-jenkins-artifact-s3.yaml
@@ -1,0 +1,26 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: jenkins-artifact-s3
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: ee-gcp-sm
+    kind: ClusterSecretStore
+  target:
+    name: jenkins-artifact-s3
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      type: Opaque
+      metadata:
+        labels:
+          jenkins.io/credentials-type: AwsCredentials
+        annotations:
+          jenkins.io/credentials-description: AWS credentials for gcloud bucket
+      data:
+        accessKey: "{{ .accessKey }}"
+        secretKey: "{{ .accessSecret }}"
+  dataFrom:
+    - extract:
+        key: "${JENKINS_CACHE_S3_JSON}"

--- a/apps/gcp/jenkins/beta/release/staging/values-JCasC.yaml
+++ b/apps/gcp/jenkins/beta/release/staging/values-JCasC.yaml
@@ -336,12 +336,12 @@ controller:
                   provider: s3
         aws:
           awsCredentials:
-            credentialsId: jenkins-cache-s3
+            credentialsId: jenkins-artifact-s3
           s3:
             container: ${jenkins-cache-bucket}
             prefix: "jenkins-artifacts-staging/"
             # artifact-manager-s3 validates customEndpoint as host[:port].
             customEndpoint: ${jenkins-cache-endpoint-host}
             customSigningRegion: ${jenkins-cache-region}
-            usePathStyleUrl: true
+            usePathStyleUrl: false
             disableSessionToken: true

--- a/apps/prod2/jenkins/beta/pre/kustomization.yaml
+++ b/apps/prod2/jenkins/beta/pre/kustomization.yaml
@@ -1,10 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - secret-google-oauth.yaml
-  - secret-jenkins-cache.yaml
-  - secret-github.yaml
   - secret-codecov.yaml
-  - secret-harbor.yaml
   - secret-docs-cn.yaml
+  - secret-github.yaml
+  - secret-google-oauth.yaml
+  - secret-harbor.yaml
+  - secret-jenkins-artifact-s3.yaml
+  - secret-jenkins-cache.yaml
   - secret-ks3util.yaml

--- a/apps/prod2/jenkins/beta/pre/secret-jenkins-artifact-s3.yaml
+++ b/apps/prod2/jenkins/beta/pre/secret-jenkins-artifact-s3.yaml
@@ -1,0 +1,26 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: jenkins-artifact-s3
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: ee-gcp-sm
+    kind: ClusterSecretStore
+  target:
+    name: jenkins-artifact-s3
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      type: Opaque
+      metadata:
+        labels:
+          jenkins.io/credentials-type: AwsCredentials
+        annotations:
+          jenkins.io/credentials-description: AWS credentials for gcloud bucket
+      data:
+        accessKey: "{{ .accessKey }}"
+        secretKey: "{{ .accessSecret }}"
+  dataFrom:
+    - extract:
+        key: "${JENKINS_CACHE_S3_JSON}"

--- a/apps/prod2/jenkins/beta/release/values-JCasC.yaml
+++ b/apps/prod2/jenkins/beta/release/values-JCasC.yaml
@@ -266,7 +266,7 @@ controller:
                   provider: s3
         aws:
           awsCredentials:
-            credentialsId: jenkins-cache-s3
+            credentialsId: jenkins-artifact-s3
           s3:
             container: ${jenkins-cache-bucket}
             prefix: "jenkins-artifacts/"


### PR DESCRIPTION
Add `jenkins-artifact-s3` ExternalSecret in both gcp and prod2 Jenkins beta pre clusters to create AWS credentials from the same remote secret (${JENKINS_CACHE_S3_JSON}) used by `jenkins-cache`.

Also update JCasC config to change `credentialsId` from `jenkins-cache-s3` to `jenkins-artifact-s3` and fix `usePathStyleUrl` to `false`.