### PR TITLE
feat(apps/gcp/jenkins): enable artifact manager S3 cleanup on staging

### DIFF
--- a/apps/gcp/jenkins/beta/release/staging/values-controller.yaml
+++ b/apps/gcp/jenkins/beta/release/staging/values-controller.yaml
@@ -26,6 +26,8 @@ controller:
     -XX:+DisableExplicitGC -XX:+UnlockExperimentalVMOptions
     -XX:+UnlockDiagnosticVMOptions -XX:+HeapDumpOnOutOfMemoryError
     -Xlog:gc*=info,gc+heap=debug,gc+ref*=debug,gc+ergo*=trace,gc+age*=trace:file=/var/jenkins_home/logs/gc-%t.log:utctime,pid,level,tags:filecount=2,filesize=100M
+    -Dio.jenkins.plugins.artifact_manager_jclouds.s3.S3BlobStoreConfig.deleteArtifacts=true
+    -Dio.jenkins.plugins.artifact_manager_jclouds.s3.S3BlobStoreConfig.deleteStashes=true
 
   # Optionally specify additional init-containers
   customInitContainers:


### PR DESCRIPTION
## Summary
- enable artifact deletion for Jenkins staging by setting the artifact-manager-s3 JVM flag
- enable stash deletion for Jenkins staging by setting the artifact-manager-s3 JVM flag
- keep the change scoped to `apps/gcp/jenkins/beta/release/staging/values-controller.yaml` only

## Verification
- parsed the updated YAML with `yq`
- confirmed the diff only adds the two required JVM system properties