### PR TITLE
feat(apps/gcp/jenkins): enable prod artifact manager s3 and update kubernetes plugin

### DIFF
--- a/apps/gcp/jenkins/beta/release/staging/values-agent.yaml
+++ b/apps/gcp/jenkins/beta/release/staging/values-agent.yaml
@@ -3,9 +3,6 @@ agent:
   maxRequestsPerHostStr: "10" # need to restart controller after updated it.
   containerCap: 10
   resources:
-    requests:
-      cpu: 100m
-      memory: 256Mi
     limits:
       cpu: 200m
       memory: 512Mi

--- a/apps/gcp/jenkins/beta/release/values-JCasC.yaml
+++ b/apps/gcp/jenkins/beta/release/values-JCasC.yaml
@@ -30,6 +30,7 @@ controller:
     - { name: jenkins-cache, keyName: region }
     - { name: jenkins-cache, keyName: bucket }
     - { name: jenkins-cache, keyName: endpoint }
+    - { name: jenkins-cache, keyName: endpoint-host }
     - { name: jenkins-cache, keyName: access-key }
     - { name: jenkins-cache, keyName: access-secret }
 
@@ -327,3 +328,21 @@ controller:
                   refreshTimeMinutes: 60
                   includedVersionsStr: "main"
                   excludedVersionsStr: "feature/ fix/ bugfix/"
+
+      artifact-manager-s3: |
+        unclassified:
+          artifactManager:
+            artifactManagerFactories:
+              - jclouds:
+                  provider: s3
+        aws:
+          awsCredentials:
+            credentialsId: jenkins-artifact-s3
+          s3:
+            container: ${jenkins-cache-bucket}
+            prefix: "jenkins-artifacts/"
+            # artifact-manager-s3 validates customEndpoint as host[:port].
+            customEndpoint: ${jenkins-cache-endpoint-host}
+            customSigningRegion: ${jenkins-cache-region}
+            usePathStyleUrl: true
+            disableSessionToken: true

--- a/apps/gcp/jenkins/beta/release/values-agent.yaml
+++ b/apps/gcp/jenkins/beta/release/values-agent.yaml
@@ -3,9 +3,6 @@ agent:
   maxRequestsPerHostStr: "400" # need to restart controller after updated it.
   containerCap: 400
   resources:
-    requests:
-      cpu: 100m
-      memory: 256Mi
     limits:
       cpu: 200m
       memory: 512Mi

--- a/apps/gcp/jenkins/beta/release/values-controller-plugins.yaml
+++ b/apps/gcp/jenkins/beta/release/values-controller-plugins.yaml
@@ -6,6 +6,7 @@ controller:
   additionalPlugins:
     # Ref: https://github.com/jenkinsci/plugin-installation-manager-tool#plugin-input-format
     # but without outer `plugin` key.
+    - artifact-manager-s3:973.v6a_51253e896b_
     - build-failure-analyzer::https://github.com/PingCAP-QE/build-failure-analyzer-plugin/releases/download/v2.4.2-jobname/build-failure-analyzer.hpi
     - cdevents::https://github.com/dillon-zheng/cdevents-plugin/releases/download/cdevents-1-40-pingcap-1/cdevents-1-40-pingcap-1.hpi
     - generic-webhook-trigger:2.4.1

--- a/apps/gcp/jenkins/beta/release/values-controller-plugins.yaml
+++ b/apps/gcp/jenkins/beta/release/values-controller-plugins.yaml
@@ -14,6 +14,7 @@ controller:
     - http_request:1.25
     - jenkins-pipeline-cache:0.2.0:https://github.com/j3t/jenkins-pipeline-cache-plugin/releases/download/0.2.0/jenkins-pipeline-cache-0.2.0.hpi
     - job-dsl:3654.vdf58f53e2d15
+    - kubernetes:4437.vd64141124d8f:https://github.com/wuhuizuo/jenkins-kubernetes-plugin/releases/download/4437.vd64141124d8f/kubernetes-4437.vd64141124d8f.hpi
     - kubernetes-credentials-provider:1.303.vdfcf47fb_b_fef
     - lockable-resources:1469.v52dff5a_80e32
     - pipeline-graph-view:836.v68ef091500dd

--- a/apps/gcp/jenkins/beta/release/values-controller.yaml
+++ b/apps/gcp/jenkins/beta/release/values-controller.yaml
@@ -26,6 +26,8 @@ controller:
     -XX:+DisableExplicitGC -XX:+UnlockExperimentalVMOptions
     -XX:+UnlockDiagnosticVMOptions -XX:+HeapDumpOnOutOfMemoryError
     -Xlog:gc*=info,gc+heap=debug,gc+ref*=debug,gc+ergo*=trace,gc+age*=trace:file=/var/jenkins_home/logs/gc-%t.log:utctime,pid,level,tags:filecount=2,filesize=100M
+    -Dio.jenkins.plugins.artifact_manager_jclouds.s3.S3BlobStoreConfig.deleteArtifacts=true
+    -Dio.jenkins.plugins.artifact_manager_jclouds.s3.S3BlobStoreConfig.deleteStashes=true
 
   # Optionally specify additional init-containers
   customInitContainers:


### PR DESCRIPTION
## Summary
- enable the `artifact-manager-s3` plugin and prod JCasC/controller settings for Jenkins artifact storage
- update the prod Jenkins Kubernetes plugin to the custom `4437.vd64141124d8f` build
- remove default agent resource requests from both prod and staging beta release values

## Details
- add `artifact-manager-s3` to the prod controller plugin list
- expose `jenkins-cache-endpoint-host` to JCasC and configure the S3-compatible GCS endpoint with the `jenkins-artifacts/` prefix
- enable artifact and stash cleanup through controller JVM flags
- override the prod Kubernetes plugin download URL with the custom release asset
- drop `agent.resources.requests` from `values-agent.yaml` and `staging/values-agent.yaml`, keeping the existing limits

## Verification
- verified the configuration on the staging Jenkins instance
- parsed all updated YAML files with `yq e "true"`
- reviewed `git diff origin/main...HEAD` to confirm the PR only changes the five Jenkins beta release files