### PR TITLE
feat(apps/gcp/jenkins): use kubernetes plugin release 4437.vd64141124d8f in gcp staging

### DIFF
--- a/apps/gcp/jenkins/beta/release/staging/values-controller-plugins.yaml
+++ b/apps/gcp/jenkins/beta/release/staging/values-controller-plugins.yaml
@@ -14,6 +14,7 @@ controller:
     - http_request:1.25
     - jenkins-pipeline-cache:0.2.0:https://github.com/j3t/jenkins-pipeline-cache-plugin/releases/download/0.2.0/jenkins-pipeline-cache-0.2.0.hpi
     - job-dsl:3654.vdf58f53e2d15
+    - kubernetes:4437.vd64141124d8f:https://github.com/wuhuizuo/jenkins-kubernetes-plugin/releases/download/4437.vd64141124d8f/kubernetes-4437.vd64141124d8f.hpi
     - kubernetes-credentials-provider:1.303.vdfcf47fb_b_fef
     - lockable-resources:1469.v52dff5a_80e32
     - pipeline-graph-view:836.v68ef091500dd


### PR DESCRIPTION
## Summary
- add a staging-only Jenkins plugin override for kubernetes
- pin the plugin version to 4437.vd64141124d8f
- fetch the HPI from the GitHub release asset built from the upstream change

## Release
- https://github.com/wuhuizuo/jenkins-kubernetes-plugin/releases/tag/4437.vd64141124d8f
- https://github.com/wuhuizuo/jenkins-kubernetes-plugin/releases/download/4437.vd64141124d8f/kubernetes-4437.vd64141124d8f.hpi

## Upstream PR
- https://github.com/jenkinsci/kubernetes-plugin/pull/2841