### PR TITLE
feat(apps/gcp/jenkins): override compute class for jenkins retried pods

### DIFF
--- a/apps/gcp/jenkins/beta/post/_base/policies/inject-ci-labels.yaml
+++ b/apps/gcp/jenkins/beta/post/_base/policies/inject-ci-labels.yaml
@@ -14,7 +14,6 @@ spec:
             matchExpressions:
               - key: kubernetes.jenkins.io/controller
                 operator: Exists
-
       context:
         - name: parsed_refs
           variable:

--- a/apps/gcp/jenkins/beta/post/_base/policies/inject-ci-labels.yaml
+++ b/apps/gcp/jenkins/beta/post/_base/policies/inject-ci-labels.yaml
@@ -12,9 +12,9 @@ spec:
             - Pod
           selector:
             matchExpressions:
-              - key: jenkins/jenkins-jenkins-agent
-                operator: In
-                values: ["true"]
+              - key: kubernetes.jenkins.io/controller
+                operator: Exists
+
       context:
         - name: parsed_refs
           variable:
@@ -25,7 +25,6 @@ spec:
           - key: "{{ request.object.metadata.annotations.ci_refs || '' }}"
             operator: NotEquals
             value: ""
-
       mutate:
         patchStrategicMerge:
           metadata:

--- a/apps/gcp/jenkins/beta/post/_base/policies/set-pod-compute-class.yaml
+++ b/apps/gcp/jenkins/beta/post/_base/policies/set-pod-compute-class.yaml
@@ -13,7 +13,6 @@ spec:
             matchExpressions:
               - key: kubernetes.jenkins.io/controller
                 operator: Exists
-
       mutate:
         patchStrategicMerge:
           metadata:
@@ -32,7 +31,6 @@ spec:
             matchExpressions:
               - key: kubernetes.jenkins.io/controller
                 operator: Exists
-
       context:
         - name: ci_refs_raw
           variable:
@@ -61,6 +59,8 @@ spec:
             nodeSelector:
               cloud.google.com/compute-class: ci-worker-ondemand
 
+    # Override compute class for retried Jenkins pods to ensure they
+    # run on on-demand CI workers.
     - name: override-compute-class-for-retried-pods
       match:
         resources:
@@ -73,7 +73,6 @@ spec:
               - key: kubernetes.jenkins.io/retry
                 operator: In
                 values: ["true"]
-
       mutate:
         patchStrategicMerge:
           spec:

--- a/apps/gcp/jenkins/beta/post/_base/policies/set-pod-compute-class.yaml
+++ b/apps/gcp/jenkins/beta/post/_base/policies/set-pod-compute-class.yaml
@@ -61,7 +61,7 @@ spec:
 
     # Override compute class for retried Jenkins pods to ensure they
     # run on on-demand CI workers.
-    - name: override-compute-class-for-retried-pods
+    - name: override-compute-class-retried
       match:
         resources:
           kinds:

--- a/apps/gcp/jenkins/beta/post/_base/policies/set-pod-compute-class.yaml
+++ b/apps/gcp/jenkins/beta/post/_base/policies/set-pod-compute-class.yaml
@@ -11,9 +11,9 @@ spec:
             - Pod
           selector:
             matchExpressions:
-              - key: jenkins/jenkins-jenkins-agent
-                operator: In
-                values: ["true"]
+              - key: kubernetes.jenkins.io/controller
+                operator: Exists
+
       mutate:
         patchStrategicMerge:
           metadata:
@@ -30,9 +30,9 @@ spec:
             - Pod
           selector:
             matchExpressions:
-              - key: jenkins/jenkins-jenkins-agent
-                operator: In
-                values: ["true"]
+              - key: kubernetes.jenkins.io/controller
+                operator: Exists
+
       context:
         - name: ci_refs_raw
           variable:
@@ -55,6 +55,25 @@ spec:
           - key: "{{ is_hotfix_branch }}"
             operator: Equals
             value: true
+      mutate:
+        patchStrategicMerge:
+          spec:
+            nodeSelector:
+              cloud.google.com/compute-class: ci-worker-ondemand
+
+    - name: override-compute-class-for-retried-pods
+      match:
+        resources:
+          kinds:
+            - Pod
+          selector:
+            matchExpressions:
+              - key: kubernetes.jenkins.io/controller
+                operator: Exists
+              - key: kubernetes.jenkins.io/retry
+                operator: In
+                values: ["true"]
+
       mutate:
         patchStrategicMerge:
           spec:

--- a/apps/gcp/jenkins/beta/post/_base/policies/tests/set-pod-compute-class/kyverno-test.yaml
+++ b/apps/gcp/jenkins/beta/post/_base/policies/tests/set-pod-compute-class/kyverno-test.yaml
@@ -9,6 +9,7 @@ resources:
   - resource-empty-ci-refs.yaml
   - resource-non-release.yaml
   - resource-release.yaml
+  - resource-retry.yaml
 results:
   - policy: set-pod-compute-class
     rule: add-compute-class-and-annotations
@@ -69,3 +70,18 @@ results:
     kind: Pod
     result: pass
     patchedResources: patched-release.yaml
+
+  - policy: set-pod-compute-class
+    rule: add-compute-class-and-annotations
+    resources:
+      - pod-retry
+    kind: Pod
+    result: pass
+
+  - policy: set-pod-compute-class
+    rule: override-compute-class-for-retried-pods
+    resources:
+      - pod-retry
+    kind: Pod
+    result: pass
+    patchedResources: patched-retry.yaml

--- a/apps/gcp/jenkins/beta/post/_base/policies/tests/set-pod-compute-class/patched-retry.yaml
+++ b/apps/gcp/jenkins/beta/post/_base/policies/tests/set-pod-compute-class/patched-retry.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: pod-non-release
+  name: pod-retry
   namespace: jenkins-pd
-  labels:
-    kubernetes.jenkins.io/controller: ""
   annotations:
-    ci_refs: '{"org":"pingcap","repo":"tidb","base_ref":"master"}'
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
 spec:
   containers:
     - name: main
       image: busybox:1.36
       command: ["sh", "-c", "sleep 3600"]
+  nodeSelector:
+    cloud.google.com/compute-class: ci-worker-ondemand

--- a/apps/gcp/jenkins/beta/post/_base/policies/tests/set-pod-compute-class/resource-empty-ci-refs.yaml
+++ b/apps/gcp/jenkins/beta/post/_base/policies/tests/set-pod-compute-class/resource-empty-ci-refs.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pod-empty-ci-refs
   namespace: jenkins-pd
   labels:
-    jenkins/jenkins-jenkins-agent: "true"
+    kubernetes.jenkins.io/controller: ""
   annotations:
     ci_refs: ""
 spec:

--- a/apps/gcp/jenkins/beta/post/_base/policies/tests/set-pod-compute-class/resource-no-ci-refs.yaml
+++ b/apps/gcp/jenkins/beta/post/_base/policies/tests/set-pod-compute-class/resource-no-ci-refs.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pod-no-ci-refs
   namespace: jenkins-pd
   labels:
-    jenkins/jenkins-jenkins-agent: "true"
+    kubernetes.jenkins.io/controller: ""
 spec:
   containers:
     - name: main

--- a/apps/gcp/jenkins/beta/post/_base/policies/tests/set-pod-compute-class/resource-release.yaml
+++ b/apps/gcp/jenkins/beta/post/_base/policies/tests/set-pod-compute-class/resource-release.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pod-release
   namespace: jenkins-pd
   labels:
-    jenkins/jenkins-jenkins-agent: "true"
+    kubernetes.jenkins.io/controller: ""
   annotations:
     ci_refs: '{"org":"pingcap","repo":"tidb","base_ref":"release-8.5-20260301-v8.5.6"}'
 spec:

--- a/apps/gcp/jenkins/beta/post/_base/policies/tests/set-pod-compute-class/resource-retry.yaml
+++ b/apps/gcp/jenkins/beta/post/_base/policies/tests/set-pod-compute-class/resource-retry.yaml
@@ -1,12 +1,11 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: pod-non-release
+  name: pod-retry
   namespace: jenkins-pd
   labels:
     kubernetes.jenkins.io/controller: ""
-  annotations:
-    ci_refs: '{"org":"pingcap","repo":"tidb","base_ref":"master"}'
+    kubernetes.jenkins.io/retry: "true"
 spec:
   containers:
     - name: main


### PR DESCRIPTION
## Summary

Switch Kyverno policy pod selectors from `jenkins/jenkins-jenkins-agent` label to `kubernetes.jenkins.io/controller` using `Exists` operator.

## Changes

### `inject-ci-labels.yaml`
- Replace selector from `jenkins/jenkins-jenkins-agent: "true"` to check for existence of `kubernetes.jenkins.io/controller`

### `set-pod-compute-class.yaml`
- Replace selector from `jenkins/jenkins-jenkins-agent: "true"` to check for existence of `kubernetes.jenkins.io/controller` in both rules
- Add new `override-compute-class-for-retried-pods` rule that matches pods with `kubernetes.jenkins.io/retry: "true"` and assigns `ci-worker-ondemand` compute class