### PR TITLE
feat(cost-insight): add gcs cache cleanup cronjobs

### DIFF
--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -31,7 +31,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.5.31-3-gf1df263
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.7-3-gb764b8f
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -129,7 +129,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcs-cache-last-seen
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.5.31-3-gf1df263
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.7-3-gb764b8f
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -195,7 +195,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-dry-run
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.5.31-3-gf1df263
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.7-3-gb764b8f
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -265,7 +265,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.5.31-3-gf1df263
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.7-3-gb764b8f
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -344,7 +344,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.5.31-3-gf1df263
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.7-3-gb764b8f
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -434,7 +434,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.5.31-3-gf1df263
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.7-3-gb764b8f
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh

--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -97,6 +97,145 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
+  name: cost-insight-sync-gcs-cache-last-seen
+  namespace: apps
+  labels:
+    app.kubernetes.io/name: cost-insight-sync-gcs-cache-last-seen
+    app.kubernetes.io/part-of: cost-insight
+spec:
+  # Interpreted with timeZone below: 22:20 Asia/Shanghai, after the other daily cost jobs.
+  schedule: "20 22 * * *"
+  timeZone: Asia/Shanghai
+  # Keep suspended until the ee-apps image tag is updated to a release that includes
+  # the new GCS cache cleanup commands.
+  suspend: true
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 1800
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      backoffLimit: 4
+      activeDeadlineSeconds: 7200
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: cost-insight-sync-gcs-cache-last-seen
+            app.kubernetes.io/part-of: cost-insight
+        spec:
+          # Reuse the existing Workload Identity path; the bound GSA must have
+          # BigQuery jobUser plus read/write access to ci_bazel_cache_logs.
+          serviceAccountName: ci-dashboard
+          restartPolicy: Never
+          containers:
+            - name: sync-gcs-cache-last-seen
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.5.31-3-gf1df263
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -ec
+              args:
+                - |
+                  cost-insight sync-gcs-cache-last-seen
+              env:
+                - name: PYTHONUNBUFFERED
+                  value: "1"
+                - name: COST_INSIGHT_LOG_LEVEL
+                  value: INFO
+                - name: GOOGLE_CLOUD_PROJECT
+                  value: pingcap-testing-account
+                - name: COST_INSIGHT_GCS_CACHE_PROJECT_ID
+                  value: pingcap-testing-account
+                - name: COST_INSIGHT_GCS_CACHE_BUCKET_NAME
+                  value: pingcap-ci-bazel-remote-cache-us-central1
+                - name: COST_INSIGHT_GCS_CACHE_DATASET
+                  value: ci_bazel_cache_logs
+                - name: COST_INSIGHT_GCS_CACHE_AUDIT_LOG_TABLE
+                  value: cloudaudit_googleapis_com_data_access
+              resources:
+                requests:
+                  cpu: "500m"
+                  memory: 1Gi
+                limits:
+                  cpu: "2"
+                  memory: 4Gi
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cost-insight-cleanup-gcs-cache-dry-run
+  namespace: apps
+  labels:
+    app.kubernetes.io/name: cost-insight-cleanup-gcs-cache-dry-run
+    app.kubernetes.io/part-of: cost-insight
+spec:
+  # Interpreted with timeZone below: Monday 22:50 Asia/Shanghai, after the daily
+  # last-seen sync has refreshed the previous UTC day.
+  schedule: "50 22 * * 1"
+  timeZone: Asia/Shanghai
+  # Keep suspended until the ee-apps image tag is updated to a release that includes
+  # the new GCS cache cleanup commands.
+  suspend: true
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 1800
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      backoffLimit: 4
+      activeDeadlineSeconds: 7200
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: cost-insight-cleanup-gcs-cache-dry-run
+            app.kubernetes.io/part-of: cost-insight
+        spec:
+          # This first slice is BigQuery-only and does not perform deletes.
+          serviceAccountName: ci-dashboard
+          restartPolicy: Never
+          containers:
+            - name: cleanup-gcs-cache-dry-run
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.5.31-3-gf1df263
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -ec
+              args:
+                - |
+                  cost-insight cleanup-gcs-cache \
+                    --mode dry-run \
+                    --ac-retention-days 28 \
+                    --cas-retention-days 42
+              env:
+                - name: PYTHONUNBUFFERED
+                  value: "1"
+                - name: COST_INSIGHT_LOG_LEVEL
+                  value: INFO
+                - name: GOOGLE_CLOUD_PROJECT
+                  value: pingcap-testing-account
+                - name: COST_INSIGHT_GCS_CACHE_PROJECT_ID
+                  value: pingcap-testing-account
+                - name: COST_INSIGHT_GCS_CACHE_BUCKET_NAME
+                  value: pingcap-ci-bazel-remote-cache-us-central1
+                - name: COST_INSIGHT_GCS_CACHE_DATASET
+                  value: ci_bazel_cache_logs
+                - name: COST_INSIGHT_GCS_CACHE_AUDIT_LOG_TABLE
+                  value: cloudaudit_googleapis_com_data_access
+                - name: COST_INSIGHT_GCS_CACHE_AC_RETENTION_DAYS
+                  value: "28"
+                - name: COST_INSIGHT_GCS_CACHE_CAS_RETENTION_DAYS
+                  value: "42"
+              resources:
+                requests:
+                  cpu: "500m"
+                  memory: 1Gi
+                limits:
+                  cpu: "2"
+                  memory: 4Gi
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
   name: cost-insight-sync-gcp-unmatched-resources
   namespace: apps
   labels:


### PR DESCRIPTION
## Summary
- add suspended cost-insight CronJobs for daily GCS cache last-seen sync and weekly cleanup dry-run
- wire the new jobs with the existing ci-dashboard Workload Identity path and explicit GCS cache env vars
- keep both jobs suspended until the ee-apps image tag is updated to a release that contains the new commands

## Notes
- this PR intentionally does not add a delete CronJob yet
- the current app design still blocks delete on inventory-backed full-bucket coverage

## Testing
- kubectl kustomize apps/gcp/cost-insight