### PR TITLE
chore(cost-insight): enable gcs cache last-seen sync

### DIFF
--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -106,9 +106,7 @@ spec:
   # Interpreted with timeZone below: 22:20 Asia/Shanghai, after the other daily cost jobs.
   schedule: "20 22 * * *"
   timeZone: Asia/Shanghai
-  # Keep suspended until the ee-apps image tag is updated to a release that includes
-  # the new GCS cache cleanup commands.
-  suspend: true
+  suspend: false
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 1800
   successfulJobsHistoryLimit: 5


### PR DESCRIPTION
## Summary
- unsuspend the daily `cost-insight-sync-gcs-cache-last-seen` CronJob now that the ee-apps image is released and BigQuery dataset permissions are in place
- keep `cost-insight-cleanup-gcs-cache-dry-run` suspended for now

## Verification
- confirmed `ci-dashboard` Workload Identity has `bigquery.jobUser` at project level and dataset-level writer access on `ci_bazel_cache_logs`
- kubectl kustomize apps/gcp/cost-insight