### PR TITLE
feat(job-ns): add tidbx-puller ServiceAccount for GAR image pull

### DIFF
--- a/apps/gcp/prow/post/job-ns/rbac.yaml
+++ b/apps/gcp/prow/post/job-ns/rbac.yaml
@@ -31,3 +31,10 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: k8s-pod-full
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tidbx-puller
+  annotations:
+    iam.gke.io/gcp-service-account: tidbx-gar-reader@pingcap-testing-account.iam.gserviceaccount.com


### PR DESCRIPTION
Add a dedicated ServiceAccount `tidbx-puller` in the test-pods namespace with GKE Workload Identity annotation.

This allows Prow pods to authenticate as `tidbx-gar-reader@pingcap-testing-account.iam.gserviceaccount.com` when pulling container images from the private `tidbx` GAR repository (`us-docker.pkg.dev/pingcap-testing-account/tidbx`).

Usage in Prow jobs:
```yaml
spec:
  serviceAccountName: tidbx-puller
```

Requires a corresponding IAM binding in ee-infra to allow workload identity federation.