### PR TITLE
chore(gcp/jenkins): add tikv agent namespace

### DIFF
--- a/apps/gcp/jenkins/beta/post/tikv/kustomization.yaml
+++ b/apps/gcp/jenkins/beta/post/tikv/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: jenkins-tikv
 resources:
-  - pd
-  - ticdc
-  - tidb
-  - tiflash
-  - tikv
+  - namespace.yaml
+  - ../_base

--- a/apps/gcp/jenkins/beta/post/tikv/namespace.yaml
+++ b/apps/gcp/jenkins/beta/post/tikv/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: jenkins-tikv

--- a/apps/gcp/jenkins/beta/release/staging/values-agent.yaml
+++ b/apps/gcp/jenkins/beta/release/staging/values-agent.yaml
@@ -17,3 +17,4 @@ agent:
       jenkins-tiflow
       jenkins-tidb
       jenkins-tiflash
+      jenkins-tikv

--- a/apps/gcp/jenkins/beta/release/values-agent.yaml
+++ b/apps/gcp/jenkins/beta/release/values-agent.yaml
@@ -17,3 +17,4 @@ agent:
       jenkins-tiflow
       jenkins-tidb
       jenkins-tiflash
+      jenkins-tikv


### PR DESCRIPTION
Prepare the GCP Jenkins runtime resources for tikv presubmit jobs.