### PR TITLE
fix(apps/gcp/publisher): update FluxCD API versions to match GCP cluster

### DIFF
--- a/apps/gcp/publisher/publisher-packages-config.yaml
+++ b/apps/gcp/publisher/publisher-packages-config.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: publisher-packages-config

--- a/apps/gcp/publisher/redis/release.yaml
+++ b/apps/gcp/publisher/redis/release.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: redis

--- a/apps/gcp/publisher/releases.yaml
+++ b/apps/gcp/publisher/releases.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: publisher-releases

--- a/apps/gcp/publisher/releases/publisher.yaml
+++ b/apps/gcp/publisher/releases/publisher.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: publisher

--- a/apps/gcp/publisher/releases/worker-tiup-prod.yaml
+++ b/apps/gcp/publisher/releases/worker-tiup-prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: publisher-worker-tiup-prod

--- a/apps/gcp/publisher/releases/worker-tiup-staging.yaml
+++ b/apps/gcp/publisher/releases/worker-tiup-staging.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: publisher-worker-tiup-staging


### PR DESCRIPTION
fix(apps/gcp/publisher): update FluxCD API versions to match GCP cluster

- HelmRelease: v2beta1 → v2
- Kustomization: v1beta2 → v1