### PR TITLE
feat(infra/gcp): add n4a Arm64 machine family to CI worker compute classes

### DIFF
--- a/infrastructure/gcp/compute-classes/ci-worker-ondemand.yaml
+++ b/infrastructure/gcp/compute-classes/ci-worker-ondemand.yaml
@@ -24,8 +24,14 @@ spec:
       storage:
         bootDiskType: hyperdisk-balanced
         bootDiskSize: 100
-    - machineFamily: c4a
+    - machineFamily: c4a # Arm64
       priorityScore: 85
+      spot: false
+      storage:
+        bootDiskType: hyperdisk-balanced
+        bootDiskSize: 100
+    - machineFamily: n4a # Arm64
+      priorityScore: 75
       spot: false
       storage:
         bootDiskType: hyperdisk-balanced

--- a/infrastructure/gcp/compute-classes/ci-worker.yaml
+++ b/infrastructure/gcp/compute-classes/ci-worker.yaml
@@ -24,8 +24,14 @@ spec:
       storage:
         bootDiskType: hyperdisk-balanced
         bootDiskSize: 100
-    - machineFamily: c4a
+    - machineFamily: c4a # Arm64
       priorityScore: 85
+      spot: true
+      storage:
+        bootDiskType: hyperdisk-balanced
+        bootDiskSize: 100
+    - machineFamily: n4a # Arm64
+      priorityScore: 75
       spot: true
       storage:
         bootDiskType: hyperdisk-balanced
@@ -55,8 +61,14 @@ spec:
       storage:
         bootDiskType: hyperdisk-balanced
         bootDiskSize: 100
-    - machineFamily: c4a
+    - machineFamily: c4a # Arm64
       priorityScore: 40
+      spot: false
+      storage:
+        bootDiskType: hyperdisk-balanced
+        bootDiskSize: 100
+    - machineFamily: n4a # Arm64
+      priorityScore: 35
       spot: false
       storage:
         bootDiskType: hyperdisk-balanced


### PR DESCRIPTION
Add n4a machine family as an additional Arm64 option for CI worker compute classes.