### PR TITLE
feat(apps/gcp/prow/release): bump tide image tag to v20260520-5d43b45c8

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -84,7 +84,7 @@ spec:
     tide:
       image:
         repository: ghcr.io/ti-community-infra/prow/tide
-        tag: v20260224-5ba85b827
+        tag: v20260520-5d43b45c8
       additionalArgs:
         - --sync-hourly-tokens=1200 # default is 800
         - --status-hourly-tokens=600 # default is 400


### PR DESCRIPTION
[Copilot is generating a summary...]