### PR TITLE
feat(dashboard): Release ci-dashboard v2026.6.7-7-g4e0ddfa

### DIFF
--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/ci-dashboard
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/ci-dashboard versioning=semver
-      tag: v2026.6.7-5-g1049a4c
+      tag: v2026.6.7-7-g4e0ddfa
     resources:
       requests:
         cpu: "2"


### PR DESCRIPTION
## Summary
- Release ci-dashboard image tag from `v2026.6.7-5-g1049a4c` to `v2026.6.7-7-g4e0ddfa`
- This tag includes PingCAP-QE/ee-apps#485 (`4e0ddfa`)
- Kustomize replacements propagate the same tag to ci-dashboard-jobs cronjobs/workers/pod-watcher images

## Verification
- Confirmed upstream ee-apps tag distance: `v2026.6.7-7-g4e0ddfa`
- Release workflow succeeded: https://github.com/PingCAP-QE/ee-apps/actions/runs/27459019352
- Verified GHCR manifests exist for:
  - `ghcr.io/pingcap-qe/ee-apps/ci-dashboard:v2026.6.7-7-g4e0ddfa`
  - `ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.6.7-7-g4e0ddfa`
- `kubectl kustomize apps/gcp/ci-dashboard`

## Notes
- App pod resources are intentionally unchanged in this release PR. Current API resources are already `requests: 2 CPU / 4Gi`, `limits: 4 CPU / 8Gi`, with `replicaCount: 1`. If API latency is mostly slow SQL / TiDB-bound, larger pods may not help much; a separate metrics-backed scaling PR would be safer.