### PR TITLE
fix(dashboard): Hotfix ci-dashboard rollout affinity conflict

### DIFF
--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -28,6 +28,21 @@ spec:
   test:
     enable: true
     ignoreFailures: false
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: ci-dashboard
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: ci-dashboard
+              spec:
+                template:
+                  spec:
+                    affinity: null
   values:
     replicaCount: 1
     nodeSelector:


### PR DESCRIPTION
## Summary
- hotfix the `ci-dashboard` HelmRelease rollout in GKE
- clear the legacy `spec.template.spec.affinity` from the rendered `Deployment/ci-dashboard` via Helm post-render patch
- let the app align with the new `cloud.google.com/compute-class=ee-application` policy path instead of mixing old `machine-family` affinity with the new compute class

## Why
The previous release updated the HelmRelease image tag, but the main `ci-dashboard` deployment stayed on `v2026.6.7-5-g1049a4c` because Flux upgrades were blocked by GKE Warden:
- `ccc-node-affinity-selector-limitation`
- live deployment still carried a legacy `cloud.google.com/machine-family` affinity
- apps namespace now also injects `cloud.google.com/compute-class=ee-application`
- the combination is rejected on update

## Verification
- `kubectl apply --dry-run=server -f apps/gcp/ci-dashboard/release.yaml`
- `kubectl -n apps patch deploy ci-dashboard --type merge --dry-run=server -p {spec:{template:{spec:{affinity:null}}}}`\n  - admission passed; previous Warden rejection did not reproduce\n- inspected live workloads and confirmed `ci-dashboard-jenkins-worker` and `ci-dashboard-pod-watcher` already run on the `ee-application` compute-class path\n\n## Scope\n- no image tag change\n- no job spec change\n- only unblocks the main app rollout