### PR TITLE
fix(dashboard): migrate ci-dashboard scheduling with Kyverno

### DIFF
--- a/apps/gcp/ci-dashboard/kustomization.yaml
+++ b/apps/gcp/ci-dashboard/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - release.yaml
+  - scheduling-policy.yaml
   - cronjobs.yaml
   - jenkins-worker.yaml
   - pod-watcher.yaml

--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -28,21 +28,6 @@ spec:
   test:
     enable: true
     ignoreFailures: false
-  postRenderers:
-    - kustomize:
-        patches:
-          - target:
-              kind: Deployment
-              name: ci-dashboard
-            patch: |
-              apiVersion: apps/v1
-              kind: Deployment
-              metadata:
-                name: ci-dashboard
-              spec:
-                template:
-                  spec:
-                    affinity: null
   values:
     replicaCount: 1
     nodeSelector:

--- a/apps/gcp/ci-dashboard/scheduling-policy.yaml
+++ b/apps/gcp/ci-dashboard/scheduling-policy.yaml
@@ -1,0 +1,22 @@
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: ci-dashboard-scheduling
+  namespace: apps
+spec:
+  rules:
+    - name: migrate-app-to-compute-class
+      match:
+        resources:
+          kinds:
+            - Deployment
+          names:
+            - ci-dashboard
+      mutate:
+        patchStrategicMerge:
+          spec:
+            template:
+              spec:
+                affinity: null
+                nodeSelector:
+                  cloud.google.com/compute-class: ee-application

--- a/apps/gcp/ci-dashboard/tests/scheduling-policy/kyverno-test.yaml
+++ b/apps/gcp/ci-dashboard/tests/scheduling-policy/kyverno-test.yaml
@@ -1,0 +1,23 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: ci-dashboard-scheduling
+policies:
+  - ../../scheduling-policy.yaml
+resources:
+  - legacy-deployment.yaml
+  - unrelated-deployment.yaml
+results:
+  - policy: ci-dashboard-scheduling
+    rule: migrate-app-to-compute-class
+    resources:
+      - ci-dashboard
+    kind: Deployment
+    result: pass
+    patchedResources: migrated-deployment.yaml
+  - policy: ci-dashboard-scheduling
+    rule: migrate-app-to-compute-class
+    resources:
+      - unrelated-app
+    kind: Deployment
+    result: skip

--- a/apps/gcp/ci-dashboard/tests/scheduling-policy/legacy-deployment.yaml
+++ b/apps/gcp/ci-dashboard/tests/scheduling-policy/legacy-deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ci-dashboard
+  namespace: apps
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ci-dashboard
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ci-dashboard
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: cloud.google.com/machine-family
+                    operator: In
+                    values: [t2d, n2d, e2]
+                  - key: cloud.google.com/gke-provisioning
+                    operator: NotIn
+                    values: ["spot"]
+      containers:
+        - name: ci-dashboard
+          image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard:test
+      nodeSelector:
+        kubernetes.io/arch: amd64

--- a/apps/gcp/ci-dashboard/tests/scheduling-policy/migrated-deployment.yaml
+++ b/apps/gcp/ci-dashboard/tests/scheduling-policy/migrated-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ci-dashboard
+  namespace: apps
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ci-dashboard
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ci-dashboard
+    spec:
+      containers:
+        - name: ci-dashboard
+          image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard:test
+      nodeSelector:
+        cloud.google.com/compute-class: ee-application
+        kubernetes.io/arch: amd64

--- a/apps/gcp/ci-dashboard/tests/scheduling-policy/unrelated-deployment.yaml
+++ b/apps/gcp/ci-dashboard/tests/scheduling-policy/unrelated-deployment.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: unrelated-app
+  namespace: apps
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: unrelated-app
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: unrelated-app
+    spec:
+      containers:
+        - name: unrelated-app
+          image: busybox:1.36


### PR DESCRIPTION
## Summary
- add a namespaced Kyverno scheduling policy for `Deployment/ci-dashboard`
- remove the legacy `machine-family` node affinity during admission
- set `cloud.google.com/compute-class=ee-application`, following the Jenkins/Prow policy-driven scheduling pattern
- remove the ineffective Helm post-render patch from #2033

## Root cause
The post-render patch changed Helm's desired manifest, but Helm client-side three-way merge preserved the legacy affinity that had previously been injected into the live Deployment. GKE Warden therefore still received an update containing both the legacy `cloud.google.com/machine-family` affinity and the new Custom Compute Class selector, and rejected it with `ccc-node-affinity-selector-limitation`.

This policy mutates the actual admission request before Warden validation, which is the same layer used by the Jenkins and Prow scheduling policies. It is scoped only to `apps/Deployment/ci-dashboard`.

## Verification
- Kyverno CLI `v1.14.4` (same as the cluster): 2 tests passed
  - legacy ci-dashboard Deployment: affinity removed and `ee-application` selector added
  - unrelated Deployment: excluded
- `kubectl kustomize apps/gcp/ci-dashboard`
- full rendered manifest accepted by `kubectl apply --dry-run=server`
- raw Policy and HelmRelease accepted by server-side dry-run

## Rollout expectation
Removing the previous `postRenderers` block increments the HelmRelease generation and triggers a fresh upgrade. The new Kyverno policy strips the retained legacy affinity from the Helm update before GKE Warden validates it.