### PR TITLE
fix(apps/gcp): correct ci-dashboard release tag

### DIFF
--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/ci-dashboard
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/ci-dashboard versioning=semver
-      tag: v2026.6.7-14-g28522eb
+      tag: v2026.6.7-8-g28522eb
     resources:
       requests:
         cpu: "2"


### PR DESCRIPTION
## Summary

- correct the `ci-dashboard` release tag from `v2026.6.7-14-g28522eb` to the actual image tag published by the successful ee-apps release workflow: `v2026.6.7-8-g28522eb`
- restore pulls for `ci-dashboard-jobs`, which is currently stuck in `ImagePullBackOff` because `v2026.6.7-14-g28522eb` does not exist in GHCR

## Evidence

- [PingCAP-QE/ee-apps/actions/runs/27467309845](https://github.com/PingCAP-QE/ee-apps/actions/runs/27467309845) generated:
  - `ghcr.io/pingcap-qe/ee-apps/ci-dashboard:v2026.6.7-8-g28522eb`
  - `ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.6.7-8-g28522eb`
- `docker manifest inspect` succeeds for both `...:v2026.6.7-8-g28522eb`
- the cluster currently reports `ImagePullBackOff` for `ci-dashboard-jobs:v2026.6.7-14-g28522eb`

## Validation

- `git diff --check`
- `kubectl kustomize apps/gcp/ci-dashboard`
- `docker manifest inspect ghcr.io/pingcap-qe/ee-apps/ci-dashboard:v2026.6.7-8-g28522eb`
- `docker manifest inspect ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.6.7-8-g28522eb`
