### PR TITLE
feat(apps/gcp/dl): deploy dl service to GCP cluster

### DIFF
--- a/apps/gcp/dl/external-secrets/dl-config.yaml
+++ b/apps/gcp/dl/external-secrets/dl-config.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dl-config
+spec:
+  secretStoreRef:
+    name: ee-gcp-sm
+    kind: ClusterSecretStore
+  refreshInterval: 1h
+  target:
+    name: dl-config
+  dataFrom:
+    - extract:
+        # json object contains keys:
+        # - ks3.yaml
+        # - oci.yaml
+        key: gcp_dl_config_json

--- a/apps/gcp/dl/external-secrets/kustomization.yaml
+++ b/apps/gcp/dl/external-secrets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - dl-config.yaml

--- a/apps/gcp/dl/http-route.yaml
+++ b/apps/gcp/dl/http-route.yaml
@@ -1,0 +1,29 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: dl
+spec:
+  parentRefs:
+    - kind: Gateway
+      name: external-https
+      namespace: infra
+  hostnames:
+    - prow.tidb.net
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /dl
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
+      # Large artifact downloads are streamed for minutes, so the default
+      # Gateway/Envoy request timeout must be disabled on this route.
+      timeouts:
+        request: 0s
+      backendRefs:
+        - name: dl
+          port: 80

--- a/apps/gcp/dl/kustomization.yaml
+++ b/apps/gcp/dl/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: dl
+resources:
+  - namespace.yaml
+  - external-secrets
+  - http-route.yaml
+  - release.yaml

--- a/apps/gcp/dl/namespace.yaml
+++ b/apps/gcp/dl/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dl

--- a/apps/gcp/dl/release.yaml
+++ b/apps/gcp/dl/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/dl
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/dl versioning=docker
-      tag: v2025.12.7-4-ga926ebb
+      tag: v2026.6.14-8-g988cf92
     server:
       args: [--ks3-config=/config/ks3.yaml, --oci-config=/config/oci.yaml]
       volumes:

--- a/apps/gcp/dl/release.yaml
+++ b/apps/gcp/dl/release.yaml
@@ -1,0 +1,51 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: dl
+spec:
+  chart:
+    spec:
+      chart: dl
+      version: 0.2.1
+      sourceRef:
+        kind: HelmRepository
+        name: ee-apps
+        namespace: flux-system
+  interval: 5m
+  timeout: 5m
+  install:
+    remediation:
+      retries: 3
+  rollback:
+    cleanupOnFail: true
+    recreate: true
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  test:
+    enable: true
+    ignoreFailures: false
+  values:
+    replicaCount: 1
+    resources:
+      limits:
+        cpu: "500m"
+        memory: 512Mi
+    image:
+      repository: ghcr.io/pingcap-qe/ee-apps/dl
+      # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/dl versioning=docker
+      tag: v2025.12.7-4-ga926ebb
+    server:
+      args: [--ks3-config=/config/ks3.yaml, --oci-config=/config/oci.yaml]
+      volumes:
+        - name: config
+          secret:
+            secretName: dl-config
+      volumeMounts:
+        - name: config
+          mountPath: /config
+    serviceAccount:
+      create: false
+    httpRoute:
+      enabled: false

--- a/apps/gcp/kustomization.yaml
+++ b/apps/gcp/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - cloudevents-server
   - ci-dashboard
   - cost-insight
+  - dl
   - roster
   - publisher
   # workloads


### PR DESCRIPTION
## Summary

Deploy the `dl` service to the GCP cluster, making it accessible at `https://prow.tidb.net/dl`.

## Changes

- Create `apps/gcp/dl/` directory with namespace, kustomization, HelmRelease, HTTPRoute, and ExternalSecret
- HelmRelease uses `dl` chart v0.2.1 from `ee-apps` HelmRepository
- HTTPRoute maps `prow.tidb.net/dl` → dl service with URL rewrite (`/dl` → `/`)
- **No docker registry credentials mounted** (security requirement to prevent private repo access)
- ExternalSecret pulls `dl-config` only from GCP Secret Manager (`gcp_dl_config_json`)

## Testing

- Kustomize build validation
- FluxCD reconciliation after merge
- Verify `https://prow.tidb.net/dl` serves OCI artifacts from public repos

## Risk

- **Low**: Missing `gcp_dl_config_json` secret in GCP Secret Manager (PR2 handles this)
- **Rollback**: Remove `apps/gcp/dl/` directory; FluxCD auto-cleans resources