### PR TITLE
chore(cost-insight): roll out transfer service filter

### DIFF
--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -31,7 +31,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.14-6-gbc890d2
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.14-9-g305637e
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -127,7 +127,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcs-cache-last-seen
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.14-6-gbc890d2
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.14-9-g305637e
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -150,6 +150,8 @@ spec:
                   value: ci_bazel_cache_logs
                 - name: COST_INSIGHT_GCS_CACHE_AUDIT_LOG_TABLE
                   value: cloudaudit_googleapis_com_data_access
+                - name: COST_INSIGHT_GCS_CACHE_LAST_SEEN_EXCLUDED_GET_PRINCIPAL_EMAIL
+                  value: ci-dashboard@pingcap-testing-account.iam.gserviceaccount.com
               resources:
                 requests:
                   cpu: "500m"
@@ -190,7 +192,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-dry-run
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.14-6-gbc890d2
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.14-9-g305637e
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -263,7 +265,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-delete-ac
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.14-6-gbc890d2
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.14-9-g305637e
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -340,7 +342,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.14-6-gbc890d2
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.14-9-g305637e
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -419,7 +421,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.14-6-gbc890d2
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.14-9-g305637e
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -509,7 +511,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.14-6-gbc890d2
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.14-9-g305637e
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh


### PR DESCRIPTION
## Summary
- roll `cost-insight-jobs` to `v2026.6.14-9-g305637e`
- exclude `ci-dashboard@pingcap-testing-account.iam.gserviceaccount.com` from the GCS last-seen GET filter
- keep the rollout minimal so we can rerun sync and verify deleted objects no longer get refreshed by Storage Batch Operations

## Testing
- not run (ops manifest change only)