### PR TITLE
fix(apps): use flux HelmRelease v2 for dl

### DIFF
--- a/apps/gcp/dl/release.yaml
+++ b/apps/gcp/dl/release.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: dl


### PR DESCRIPTION
## Summary
- switch `apps/gcp/dl/release.yaml` from `helm.toolkit.fluxcd.io/v2beta1` to `helm.toolkit.fluxcd.io/v2`
- unblock `flux-system/apps` reconciliation, which is currently failing dry-run on the `dl` HelmRelease
- keep the change intentionally minimal so the existing cost-insight rollout can reconcile normally again

## Testing
- not run (manifest apiVersion fix only)
- verified in-cluster that the live API served by Flux is `helm.toolkit.fluxcd.io/v2`