### PR TITLE
feat(apps/gcp/dl): add HealthCheckPolicy for dl service NEG health check

### DIFF
--- a/apps/gcp/dl/health-check-policy.yaml
+++ b/apps/gcp/dl/health-check-policy.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: dl-health-check-policy
+spec:
+  default:
+    config:
+      httpHealthCheck:
+        port: 80
+        requestPath: /healthz
+      type: HTTP
+  targetRef:
+    group: ""
+    kind: Service
+    name: dl

--- a/apps/gcp/dl/kustomization.yaml
+++ b/apps/gcp/dl/kustomization.yaml
@@ -4,5 +4,6 @@ namespace: dl
 resources:
   - namespace.yaml
   - external-secrets
+  - health-check-policy.yaml
   - http-route.yaml
   - release.yaml


### PR DESCRIPTION
## Problem

The GKE Gateway auto-derived NEG health check was failing for the `dl` service, causing a cascade of issues:

1. Pod readiness gate `cloud.google.com/load-balancer-neg-ready` never passed
2. Service endpoints remained empty (pods excluded due to failing readiness gate)
3. GCP LB returned HTTP 503 `unconditional drop overload` for all requests

Root cause: the NEG had a sync failure (`endpoint counts from endpointData and endpointPodMap should be equal`) during initial deployment, leaving it in a broken state even after the HTTPRoute timeout issue was resolved.

## Solution

- Add an explicit `HealthCheckPolicy` resource targeting `/healthz` on port 80, matching the pod's readiness probe
- Register it in the kustomization alongside the existing HTTPRoute and HelmRelease

This aligns the GCP LB health check with the container's actual health endpoint, preventing the readiness-gate deadlock.

## Files Changed

- **New:** `apps/gcp/dl/health-check-policy.yaml` — GKE HealthCheckPolicy for the `dl` Service
- **Modified:** `apps/gcp/dl/kustomization.yaml` — include the new resource