### PR TITLE
chore(cost-insight): enable steady-state gcs cache cleanup

### DIFF
--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -242,11 +242,10 @@ metadata:
     app.kubernetes.io/name: cost-insight-cleanup-gcs-cache-delete-ac
     app.kubernetes.io/part-of: cost-insight
 spec:
-  # Interpreted with timeZone below: daily 23:00 Asia/Shanghai. Keep suspended
-  # until the manual first wave has been reviewed.
+  # Interpreted with timeZone below: daily 23:00 Asia/Shanghai.
   schedule: "0 23 * * *"
   timeZone: Asia/Shanghai
-  suspend: true
+  suspend: false
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 1800
   successfulJobsHistoryLimit: 5
@@ -275,6 +274,82 @@ spec:
                   cost-insight cleanup-gcs-cache \
                     --mode delete \
                     --execute-kind ac
+              env:
+                - name: PYTHONUNBUFFERED
+                  value: "1"
+                - name: COST_INSIGHT_LOG_LEVEL
+                  value: INFO
+                - name: GOOGLE_CLOUD_PROJECT
+                  value: pingcap-testing-account
+                - name: COST_INSIGHT_GCS_CACHE_PROJECT_ID
+                  value: pingcap-testing-account
+                - name: COST_INSIGHT_GCS_CACHE_BUCKET_NAME
+                  value: pingcap-ci-bazel-remote-cache-us-central1
+                - name: COST_INSIGHT_GCS_CACHE_DATASET
+                  value: ci_bazel_cache_logs
+                - name: COST_INSIGHT_GCS_CACHE_AUDIT_LOG_TABLE
+                  value: cloudaudit_googleapis_com_data_access
+                - name: COST_INSIGHT_GCS_CACHE_AC_RETENTION_DAYS
+                  value: "14"
+                - name: COST_INSIGHT_GCS_CACHE_CAS_RETENTION_DAYS
+                  value: "14"
+                - name: COST_INSIGHT_GCS_CACHE_SAFETY_BUFFER_DAYS
+                  value: "1"
+                - name: COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_OBJECTS
+                  value: "10000000"
+                - name: COST_INSIGHT_GCS_CACHE_CLEANUP_MANIFEST_BUCKET
+                  value: pingcap-ci-console-logs-us-central1
+                - name: COST_INSIGHT_GCS_CACHE_CLEANUP_MANIFEST_PREFIX
+                  value: gcs-cache-steady-state-delete
+              resources:
+                requests:
+                  cpu: "500m"
+                  memory: 1Gi
+                limits:
+                  cpu: "2"
+                  memory: 4Gi
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cost-insight-cleanup-gcs-cache-delete-cas
+  namespace: apps
+  labels:
+    app.kubernetes.io/name: cost-insight-cleanup-gcs-cache-delete-cas
+    app.kubernetes.io/part-of: cost-insight
+spec:
+  # Interpreted with timeZone below: daily 23:20 Asia/Shanghai, after delete-ac.
+  schedule: "20 23 * * *"
+  timeZone: Asia/Shanghai
+  suspend: false
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 1800
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      backoffLimit: 4
+      activeDeadlineSeconds: 7200
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: cost-insight-cleanup-gcs-cache-delete-cas
+            app.kubernetes.io/part-of: cost-insight
+        spec:
+          serviceAccountName: ci-dashboard
+          restartPolicy: Never
+          containers:
+            - name: cleanup-gcs-cache-delete-cas
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.14-9-g305637e
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -ec
+              args:
+                - |
+                  cost-insight cleanup-gcs-cache \
+                    --mode delete \
+                    --execute-kind cas
               env:
                 - name: PYTHONUNBUFFERED
                   value: "1"

--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -169,9 +169,8 @@ metadata:
     app.kubernetes.io/name: cost-insight-cleanup-gcs-cache-dry-run
     app.kubernetes.io/part-of: cost-insight
 spec:
-  # Interpreted with timeZone below: daily 21:40 Asia/Shanghai, after the daily
-  # last-seen sync has refreshed the previous UTC day.
-  schedule: "40 21 * * *"
+  # Interpreted with timeZone below: daily 19:40 Asia/Shanghai.
+  schedule: "40 19 * * *"
   timeZone: Asia/Shanghai
   suspend: false
   concurrencyPolicy: Forbid
@@ -242,8 +241,8 @@ metadata:
     app.kubernetes.io/name: cost-insight-cleanup-gcs-cache-delete-ac
     app.kubernetes.io/part-of: cost-insight
 spec:
-  # Interpreted with timeZone below: daily 23:00 Asia/Shanghai.
-  schedule: "0 23 * * *"
+  # Interpreted with timeZone below: daily 20:10 Asia/Shanghai.
+  schedule: "10 20 * * *"
   timeZone: Asia/Shanghai
   suspend: false
   concurrencyPolicy: Forbid
@@ -318,8 +317,8 @@ metadata:
     app.kubernetes.io/name: cost-insight-cleanup-gcs-cache-delete-cas
     app.kubernetes.io/part-of: cost-insight
 spec:
-  # Interpreted with timeZone below: daily 23:20 Asia/Shanghai, after delete-ac.
-  schedule: "20 23 * * *"
+  # Interpreted with timeZone below: daily 21:20 Asia/Shanghai, after delete-ac.
+  schedule: "20 21 * * *"
   timeZone: Asia/Shanghai
   suspend: false
   concurrencyPolicy: Forbid

--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -220,7 +220,7 @@ spec:
                 - name: COST_INSIGHT_GCS_CACHE_AC_RETENTION_DAYS
                   value: "14"
                 - name: COST_INSIGHT_GCS_CACHE_CAS_RETENTION_DAYS
-                  value: "21"
+                  value: "14"
                 - name: COST_INSIGHT_GCS_CACHE_SAFETY_BUFFER_DAYS
                   value: "1"
                 - name: COST_INSIGHT_GCS_CACHE_CLEANUP_SAMPLE_LIMIT
@@ -293,7 +293,7 @@ spec:
                 - name: COST_INSIGHT_GCS_CACHE_AC_RETENTION_DAYS
                   value: "14"
                 - name: COST_INSIGHT_GCS_CACHE_CAS_RETENTION_DAYS
-                  value: "21"
+                  value: "14"
                 - name: COST_INSIGHT_GCS_CACHE_SAFETY_BUFFER_DAYS
                   value: "1"
                 - name: COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_OBJECTS


### PR DESCRIPTION
## Summary
- change `COST_INSIGHT_GCS_CACHE_CAS_RETENTION_DAYS` from `21` to `14`
- unsuspend the existing `cost-insight-cleanup-gcs-cache-delete-ac` cronjob
- add a new `cost-insight-cleanup-gcs-cache-delete-cas` cronjob
- move the steady-state schedules earlier:
  - dry-run: `19:40 Asia/Shanghai`
  - delete-ac: `20:10 Asia/Shanghai`
  - delete-cas: `21:20 Asia/Shanghai`

## Notes
- live cluster has been temporarily patched so `delete-ac` is already enabled, `CAS_RETENTION_DAYS=14` is in effect, and the existing schedules already match the new dry-run/delete-ac times before this PR merges
- this PR makes the GitOps state match the intended live configuration

## Testing
- not run (ops manifest change only)
- manual `ac` and `cas` delete jobs both succeeded in-cluster before enabling automation