### PR TITLE
feat(apps/gcp/dl,apps/prod2/dl): upgrade dl image to v2026.6.14-12-g65aa9a2

### DIFF
--- a/apps/gcp/dl/release.yaml
+++ b/apps/gcp/dl/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/dl
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/dl versioning=docker
-      tag: v2026.6.14-8-g988cf92
+      tag: v2026.6.14-12-g65aa9a2
     server:
       args: [--ks3-config=/config/ks3.yaml, --oci-config=/config/oci.yaml]
       volumes:

--- a/apps/prod2/dl/release.yaml
+++ b/apps/prod2/dl/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/dl
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/dl versioning=docker
-      tag: v2025.12.7-4-ga926ebb
+      tag: v2026.6.14-12-g65aa9a2
     server:
       args: [--ks3-config=/config/ks3.yaml, --oci-config=/config/oci.yaml]
       volumes:


### PR DESCRIPTION
## Summary
Upgrade dl service image to include HEAD request support for oci-file endpoint (PR #497).

## Changes
- apps/gcp/dl/release.yaml: update image tag from v2026.6.14-8-g988cf92 to v2026.6.14-12-g65aa9a2
- apps/prod2/dl/release.yaml: update image tag from v2025.12.7-4-ga926ebb to v2026.6.14-12-g65aa9a2

## Testing
- Image built and pushed by release workflow (run 27761229493)
- HEAD request support tested in PR #497

## Risk
- Low: standard image upgrade, no config changes
- Rollback: revert to previous image tags

Ref: FLA-204