### PR TITLE
feat(apps/prod2/dl,apps/gcp/dl): upgrade dl image to v2026.6.14-14-g78ff672

### DIFF
--- a/apps/gcp/dl/release.yaml
+++ b/apps/gcp/dl/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/dl
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/dl versioning=docker
-      tag: v2026.6.14-12-g65aa9a2
+      tag: v2026.6.14-14-g78ff672
     server:
       args: [--ks3-config=/config/ks3.yaml, --oci-config=/config/oci.yaml]
       volumes:

--- a/apps/prod2/dl/release.yaml
+++ b/apps/prod2/dl/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/dl
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/dl versioning=docker
-      tag: v2026.6.14-12-g65aa9a2
+      tag: v2026.6.14-14-g78ff672
     server:
       args: [--ks3-config=/config/ks3.yaml, --oci-config=/config/oci.yaml]
       volumes:


### PR DESCRIPTION
## Summary

Upgrade dl service image to include Content-Disposition fix for wget filename support.

## Changes

- Updated image tag from `v2026.6.14-12-g65aa9a2` to `v2026.6.14-14-g78ff672` in both prod2 and gcp clusters
- Includes fix: Content-Disposition header now includes both `filename` (ASCII fallback) and `filename*` (UTF-8 encoded) per RFC 6266
- Ensures `wget --content-disposition` saves files with correct OCI layer title

## Testing

- Image built and tested in ee-apps CI (Skaffold Build, CodeQL, pre-commit.ci all pass)
- Unit tests verify header format for ASCII, UTF-8, and special characters

Ref: FLA-204