### PR TITLE
feat(cost-insight): roll out cas gc v2 cronjobs

### DIFF
--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -31,7 +31,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-1-g45db1ba
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-2-g32e23c9
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -127,7 +127,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcs-cache-last-seen
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-1-g45db1ba
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-2-g32e23c9
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -194,7 +194,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcs-cache-ac-references
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-1-g45db1ba
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-2-g32e23c9
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -258,7 +258,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-dry-run
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-1-g45db1ba
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-2-g32e23c9
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -329,7 +329,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-delete-cas
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-1-g45db1ba
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-2-g32e23c9
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -404,7 +404,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-1-g45db1ba
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-2-g32e23c9
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -483,7 +483,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-1-g45db1ba
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-2-g32e23c9
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -573,7 +573,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-1-g45db1ba
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-2-g32e23c9
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh

--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -31,7 +31,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.14-9-g305637e
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-1-g45db1ba
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -127,7 +127,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcs-cache-last-seen
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.14-9-g305637e
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-1-g45db1ba
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -150,6 +150,8 @@ spec:
                   value: ci_bazel_cache_logs
                 - name: COST_INSIGHT_GCS_CACHE_AUDIT_LOG_TABLE
                   value: cloudaudit_googleapis_com_data_access
+                - name: COST_INSIGHT_GCS_CACHE_LAST_SEEN_EXCLUDED_GET_USER_AGENT
+                  value: TransferService
                 - name: COST_INSIGHT_GCS_CACHE_LAST_SEEN_EXCLUDED_GET_PRINCIPAL_EMAIL
                   value: ci-dashboard@pingcap-testing-account.iam.gserviceaccount.com
               resources:
@@ -163,16 +165,81 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
+  name: cost-insight-sync-gcs-cache-ac-references
+  namespace: apps
+  labels:
+    app.kubernetes.io/name: cost-insight-sync-gcs-cache-ac-references
+    app.kubernetes.io/part-of: cost-insight
+spec:
+  # Interpreted with timeZone below: 21:40 Asia/Shanghai, after the daily
+  # last-seen sync. Keep suspended until the initial bootstrap is complete.
+  schedule: "40 21 * * *"
+  timeZone: Asia/Shanghai
+  suspend: true
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 1800
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      backoffLimit: 4
+      activeDeadlineSeconds: 14400
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: cost-insight-sync-gcs-cache-ac-references
+            app.kubernetes.io/part-of: cost-insight
+        spec:
+          serviceAccountName: ci-dashboard
+          restartPolicy: Never
+          containers:
+            - name: sync-gcs-cache-ac-references
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-1-g45db1ba
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -ec
+              args:
+                - |
+                  cost-insight sync-gcs-cache-ac-references \
+                    --mode incremental
+              env:
+                - name: PYTHONUNBUFFERED
+                  value: "1"
+                - name: COST_INSIGHT_LOG_LEVEL
+                  value: INFO
+                - name: GOOGLE_CLOUD_PROJECT
+                  value: pingcap-testing-account
+                - name: COST_INSIGHT_GCS_CACHE_PROJECT_ID
+                  value: pingcap-testing-account
+                - name: COST_INSIGHT_GCS_CACHE_BUCKET_NAME
+                  value: pingcap-ci-bazel-remote-cache-us-central1
+                - name: COST_INSIGHT_GCS_CACHE_DATASET
+                  value: ci_bazel_cache_logs
+                - name: COST_INSIGHT_GCS_CACHE_AUDIT_LOG_TABLE
+                  value: cloudaudit_googleapis_com_data_access
+              resources:
+                requests:
+                  cpu: "1"
+                  memory: 2Gi
+                limits:
+                  cpu: "2"
+                  memory: 4Gi
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
   name: cost-insight-cleanup-gcs-cache-dry-run
   namespace: apps
   labels:
     app.kubernetes.io/name: cost-insight-cleanup-gcs-cache-dry-run
     app.kubernetes.io/part-of: cost-insight
 spec:
-  # Interpreted with timeZone below: daily 19:40 Asia/Shanghai.
-  schedule: "40 19 * * *"
+  # Interpreted with timeZone below: daily 22:00 Asia/Shanghai, after the AC
+  # reference incremental sync. Keep suspended until bootstrap is complete.
+  schedule: "0 22 * * *"
   timeZone: Asia/Shanghai
-  suspend: false
+  suspend: true
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 1800
   successfulJobsHistoryLimit: 5
@@ -191,7 +258,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-dry-run
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.14-9-g305637e
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-1-g45db1ba
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -200,7 +267,7 @@ spec:
                 - |
                   cost-insight cleanup-gcs-cache \
                     --mode dry-run \
-                    --execute-kind all
+                    --execute-kind cas
               env:
                 - name: PYTHONUNBUFFERED
                   value: "1"
@@ -216,90 +283,12 @@ spec:
                   value: ci_bazel_cache_logs
                 - name: COST_INSIGHT_GCS_CACHE_AUDIT_LOG_TABLE
                   value: cloudaudit_googleapis_com_data_access
-                - name: COST_INSIGHT_GCS_CACHE_AC_RETENTION_DAYS
-                  value: "14"
                 - name: COST_INSIGHT_GCS_CACHE_CAS_RETENTION_DAYS
-                  value: "14"
+                  value: "21"
                 - name: COST_INSIGHT_GCS_CACHE_SAFETY_BUFFER_DAYS
                   value: "1"
                 - name: COST_INSIGHT_GCS_CACHE_CLEANUP_SAMPLE_LIMIT
                   value: "10"
-              resources:
-                requests:
-                  cpu: "500m"
-                  memory: 1Gi
-                limits:
-                  cpu: "2"
-                  memory: 4Gi
----
-apiVersion: batch/v1
-kind: CronJob
-metadata:
-  name: cost-insight-cleanup-gcs-cache-delete-ac
-  namespace: apps
-  labels:
-    app.kubernetes.io/name: cost-insight-cleanup-gcs-cache-delete-ac
-    app.kubernetes.io/part-of: cost-insight
-spec:
-  # Interpreted with timeZone below: daily 20:10 Asia/Shanghai.
-  schedule: "10 20 * * *"
-  timeZone: Asia/Shanghai
-  suspend: false
-  concurrencyPolicy: Forbid
-  startingDeadlineSeconds: 1800
-  successfulJobsHistoryLimit: 5
-  failedJobsHistoryLimit: 5
-  jobTemplate:
-    spec:
-      backoffLimit: 4
-      activeDeadlineSeconds: 7200
-      template:
-        metadata:
-          labels:
-            app.kubernetes.io/name: cost-insight-cleanup-gcs-cache-delete-ac
-            app.kubernetes.io/part-of: cost-insight
-        spec:
-          serviceAccountName: ci-dashboard
-          restartPolicy: Never
-          containers:
-            - name: cleanup-gcs-cache-delete-ac
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.14-9-g305637e
-              imagePullPolicy: IfNotPresent
-              command:
-                - /bin/sh
-                - -ec
-              args:
-                - |
-                  cost-insight cleanup-gcs-cache \
-                    --mode delete \
-                    --execute-kind ac
-              env:
-                - name: PYTHONUNBUFFERED
-                  value: "1"
-                - name: COST_INSIGHT_LOG_LEVEL
-                  value: INFO
-                - name: GOOGLE_CLOUD_PROJECT
-                  value: pingcap-testing-account
-                - name: COST_INSIGHT_GCS_CACHE_PROJECT_ID
-                  value: pingcap-testing-account
-                - name: COST_INSIGHT_GCS_CACHE_BUCKET_NAME
-                  value: pingcap-ci-bazel-remote-cache-us-central1
-                - name: COST_INSIGHT_GCS_CACHE_DATASET
-                  value: ci_bazel_cache_logs
-                - name: COST_INSIGHT_GCS_CACHE_AUDIT_LOG_TABLE
-                  value: cloudaudit_googleapis_com_data_access
-                - name: COST_INSIGHT_GCS_CACHE_AC_RETENTION_DAYS
-                  value: "14"
-                - name: COST_INSIGHT_GCS_CACHE_CAS_RETENTION_DAYS
-                  value: "14"
-                - name: COST_INSIGHT_GCS_CACHE_SAFETY_BUFFER_DAYS
-                  value: "1"
-                - name: COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_OBJECTS
-                  value: "10000000"
-                - name: COST_INSIGHT_GCS_CACHE_CLEANUP_MANIFEST_BUCKET
-                  value: pingcap-ci-console-logs-us-central1
-                - name: COST_INSIGHT_GCS_CACHE_CLEANUP_MANIFEST_PREFIX
-                  value: gcs-cache-steady-state-delete
               resources:
                 requests:
                   cpu: "500m"
@@ -317,8 +306,9 @@ metadata:
     app.kubernetes.io/name: cost-insight-cleanup-gcs-cache-delete-cas
     app.kubernetes.io/part-of: cost-insight
 spec:
-  # Interpreted with timeZone below: daily 21:20 Asia/Shanghai, after delete-ac.
-  schedule: "20 21 * * *"
+  # Interpreted with timeZone below: daily 22:20 Asia/Shanghai, after dry-run.
+  # Keep suspended until bootstrap and canary validation are complete.
+  schedule: "20 22 * * *"
   timeZone: Asia/Shanghai
   suspend: true
   concurrencyPolicy: Forbid
@@ -339,7 +329,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-delete-cas
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.14-9-g305637e
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-1-g45db1ba
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -364,10 +354,8 @@ spec:
                   value: ci_bazel_cache_logs
                 - name: COST_INSIGHT_GCS_CACHE_AUDIT_LOG_TABLE
                   value: cloudaudit_googleapis_com_data_access
-                - name: COST_INSIGHT_GCS_CACHE_AC_RETENTION_DAYS
-                  value: "14"
                 - name: COST_INSIGHT_GCS_CACHE_CAS_RETENTION_DAYS
-                  value: "14"
+                  value: "21"
                 - name: COST_INSIGHT_GCS_CACHE_SAFETY_BUFFER_DAYS
                   value: "1"
                 - name: COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_OBJECTS
@@ -416,7 +404,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.14-9-g305637e
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-1-g45db1ba
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -495,7 +483,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.14-9-g305637e
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-1-g45db1ba
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -585,7 +573,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.14-9-g305637e
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-1-g45db1ba
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh


### PR DESCRIPTION
## Summary
- bump `cost-insight-jobs` to `v2026.6.21-1-g45db1ba`
- add the daily `sync-gcs-cache-ac-references` CronJob for CAS GC v2
- switch GCS cache cleanup cronjobs to v2 semantics and stop the old independent AC delete path

## Details
- keep `sync-gcs-cache-last-seen` active and explicitly filter `TransferService` GET events
- add `cost-insight-sync-gcs-cache-ac-references`, suspended until bootstrap completes
- keep `cleanup-gcs-cache-dry-run` suspended and change it to `--execute-kind cas`
- keep `cleanup-gcs-cache-delete-cas` suspended for later canary/rollout
- remove the old `cleanup-gcs-cache-delete-ac` CronJob

## Validation
- parsed `apps/gcp/cost-insight/cronjobs.yaml` successfully with Python YAML
- confirmed no remaining old image tag / `execute-kind ac` / `AC_RETENTION_DAYS` entries
