### PR TITLE
feat(ci-dashboard): release ci-dashboard v2026.6.21-4-g6d8b476

### DIFF
--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/ci-dashboard
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/ci-dashboard versioning=semver
-      tag: v2026.6.7-8-g28522eb
+      tag: v2026.6.21-4-g6d8b476
     resources:
       requests:
         cpu: "2"


### PR DESCRIPTION
## Summary
- release CI Dashboard to `v2026.6.21-4-g6d8b476`
- roll the app, cronjobs, jenkins worker, and pod watcher onto the image tag published by ee-apps workflow run `27957156399`

## Verification
- `gh pr view 503 --repo PingCAP-QE/ee-apps --json mergeCommit --jq '.mergeCommit.oid'` => `6d8b47673c827430ba195aa9a737b779875ffa8d`
- `gh run view 27957156399 --repo PingCAP-QE/ee-apps --log | rg "Generating tags|ci-dashboard|ci-dashboard-jobs"`
- `docker manifest inspect ghcr.io/pingcap-qe/ee-apps/ci-dashboard:v2026.6.21-4-g6d8b476 >/dev/null`
- `docker manifest inspect ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.6.21-4-g6d8b476 >/dev/null`
- `kubectl kustomize apps/gcp/ci-dashboard | rg "v2026.6.21-4-g6d8b476"`

## Next step after rollout
- run a one-off `backfill-flaky-issue-pr-links` job so `ci_l1_flaky_linked_prs` is populated immediately instead of waiting for the recurring `ci-dashboard-sync-flaky-issues` cronjob.
