### PR TITLE
fix(prow): clear legacy affinity after compute class migration

### DIFF
--- a/apps/gcp/prow/release/release.yaml
+++ b/apps/gcp/prow/release/release.yaml
@@ -31,6 +31,21 @@ spec:
   test:
     enable: true
     ignoreFailures: false
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              labelSelector: app.kubernetes.io/part-of=prow
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: ignored
+              spec:
+                template:
+                  spec:
+                    affinity: null
   values:
     podLabels:
       env: cicd


### PR DESCRIPTION
## Summary
- add a Helm post-render patch for the Prow HelmRelease
- clear legacy `spec.template.spec.affinity` from rendered Prow Deployments
- let Prow use the `cloud.google.com/compute-class=ee-application` scheduling path without mixing the old `machine-family` affinity

## Why
This follows the same pattern as #2033. Prow Deployments still carried the legacy Kyverno-injected affinity:
- `cloud.google.com/machine-family in [t2d,n2d,e2]`
- `cloud.google.com/gke-provisioning NotIn [spot]`

After the GKE node upgrade on 2026-06-23, Prow Pods were evicted and new Pods were rejected by GKE Warden with `ccc-node-affinity-selector-limitation` because the apps namespace now also injects `cloud.google.com/compute-class=ee-application`.

## Verification
- `kubectl apply --dry-run=server -f apps/gcp/prow/release/release.yaml`
- live patched Prow Deployments to remove the stale affinity
- confirmed live Prow Deployments no longer contain `cloud.google.com/machine-family` affinity
- confirmed `prow-hook` and both `prow-jenkins-operator` deployments are Ready and have endpoints
