### PR TITLE
ci(jenkins): add target branch pod labels

### DIFF
--- a/apps/gcp/jenkins/beta/post/_base/policies/inject-ci-labels.yaml
+++ b/apps/gcp/jenkins/beta/post/_base/policies/inject-ci-labels.yaml
@@ -53,6 +53,14 @@ spec:
                   regex_replace_all('^[-_]+|[-_]+$', @, '') |
                   regex_replace_all('^(.{0,63}).*$', @, '$1')
                 }}
+              prow.k8s.io/refs.target_branch: >-
+                {{
+                  not_null(parsed_refs.base_ref, '') |
+                  to_lower(@) |
+                  regex_replace_all('[^a-z0-9_-]', @, '_') |
+                  regex_replace_all('^[-_]+|[-_]+$', @, '') |
+                  regex_replace_all('^(.{0,63}).*$', @, '$1')
+                }}
 
               author: >-
                 {{
@@ -77,6 +85,14 @@ spec:
               repo: >-
                 {{
                   not_null(parsed_refs.repo, '') |
+                  to_lower(@) |
+                  regex_replace_all('[^a-z0-9_-]', @, '_') |
+                  regex_replace_all('^[-_]+|[-_]+$', @, '') |
+                  regex_replace_all('^(.{0,63}).*$', @, '$1')
+                }}
+              target_branch: >-
+                {{
+                  not_null(parsed_refs.base_ref, '') |
                   to_lower(@) |
                   regex_replace_all('[^a-z0-9_-]', @, '_') |
                   regex_replace_all('^[-_]+|[-_]+$', @, '') |


### PR DESCRIPTION
## Summary
- add `prow.k8s.io/refs.target_branch` to Jenkins CI pods from `ci_refs.base_ref`
- add short `target_branch` label for cost attribution and queries
- keep the existing `failurePolicy: Ignore` and annotation precondition so label injection remains best-effort

## Verification
- `yq '.' apps/gcp/jenkins/beta/post/_base/policies/inject-ci-labels.yaml >/dev/null`