### PR TITLE
feat(dashboard): release cost insight and dashboard images

### DIFF
--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/ci-dashboard
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/ci-dashboard versioning=semver
-      tag: v2026.6.21-4-g6d8b476
+      tag: v2026.6.21-7-g45c72a9
     resources:
       requests:
         cpu: "2"

--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -31,7 +31,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-2-g32e23c9
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-6-g30392c1
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -127,7 +127,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcs-cache-last-seen
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-2-g32e23c9
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-6-g30392c1
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -194,7 +194,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcs-cache-ac-references
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-2-g32e23c9
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-6-g30392c1
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -235,8 +235,8 @@ metadata:
     app.kubernetes.io/name: cost-insight-cleanup-gcs-cache-dry-run
     app.kubernetes.io/part-of: cost-insight
 spec:
-  # Interpreted with timeZone below: daily 22:00 Asia/Shanghai, after the AC
-  # reference incremental sync. Keep suspended until bootstrap is complete.
+  # Interpreted with timeZone below: daily 22:00 Asia/Shanghai.
+  # Keep suspended until manual v3 canary validation is complete.
   schedule: "0 22 * * *"
   timeZone: Asia/Shanghai
   suspend: true
@@ -258,7 +258,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-dry-run
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-2-g32e23c9
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-6-g30392c1
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -283,8 +283,10 @@ spec:
                   value: ci_bazel_cache_logs
                 - name: COST_INSIGHT_GCS_CACHE_AUDIT_LOG_TABLE
                   value: cloudaudit_googleapis_com_data_access
+                - name: COST_INSIGHT_GCS_CACHE_AC_RETENTION_DAYS
+                  value: "10"
                 - name: COST_INSIGHT_GCS_CACHE_CAS_RETENTION_DAYS
-                  value: "21"
+                  value: "15"
                 - name: COST_INSIGHT_GCS_CACHE_SAFETY_BUFFER_DAYS
                   value: "1"
                 - name: COST_INSIGHT_GCS_CACHE_CLEANUP_SAMPLE_LIMIT
@@ -307,7 +309,7 @@ metadata:
     app.kubernetes.io/part-of: cost-insight
 spec:
   # Interpreted with timeZone below: daily 22:20 Asia/Shanghai, after dry-run.
-  # Keep suspended until bootstrap and canary validation are complete.
+  # Keep suspended until manual v3 canary validation is complete.
   schedule: "20 22 * * *"
   timeZone: Asia/Shanghai
   suspend: true
@@ -329,7 +331,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-delete-cas
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-2-g32e23c9
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-6-g30392c1
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -354,12 +356,16 @@ spec:
                   value: ci_bazel_cache_logs
                 - name: COST_INSIGHT_GCS_CACHE_AUDIT_LOG_TABLE
                   value: cloudaudit_googleapis_com_data_access
+                - name: COST_INSIGHT_GCS_CACHE_AC_RETENTION_DAYS
+                  value: "10"
                 - name: COST_INSIGHT_GCS_CACHE_CAS_RETENTION_DAYS
-                  value: "21"
+                  value: "15"
                 - name: COST_INSIGHT_GCS_CACHE_SAFETY_BUFFER_DAYS
                   value: "1"
                 - name: COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_OBJECTS
                   value: "10000000"
+                - name: COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_CAS_OBJECTS
+                  value: "500"
                 - name: COST_INSIGHT_GCS_CACHE_CLEANUP_MANIFEST_BUCKET
                   value: pingcap-ci-console-logs-us-central1
                 - name: COST_INSIGHT_GCS_CACHE_CLEANUP_MANIFEST_PREFIX
@@ -404,7 +410,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-2-g32e23c9
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-6-g30392c1
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -483,7 +489,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-2-g32e23c9
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-6-g30392c1
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -573,7 +579,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-2-g32e23c9
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-6-g30392c1
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh


### PR DESCRIPTION
## Summary

Release the latest ee-apps images:

- `ci-dashboard`: `v2026.6.21-7-g45c72a9`
  - built by https://github.com/PingCAP-QE/ee-apps/actions/runs/28013245764
- `cost-insight-jobs`: `v2026.6.21-6-g30392c1`
  - built by https://github.com/PingCAP-QE/ee-apps/actions/runs/28011099273

Cost-insight cleanup config is aligned with CAS GC v3 rollout defaults:

- `AC_RETENTION_DAYS=10`
- `CAS_RETENTION_DAYS=15`
- `SAFETY_BUFFER_DAYS=1`
- `MAX_DELETE_CAS_OBJECTS=500`

The GCS cleanup dry-run/delete CronJobs remain suspended for manual canary validation after Flux applies the new image.

## Validation

- `docker manifest inspect ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-6-g30392c1`
- `docker manifest inspect ghcr.io/pingcap-qe/ee-apps/ci-dashboard:v2026.6.21-7-g45c72a9`
- `docker manifest inspect ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.6.21-7-g45c72a9`
- `kubectl kustomize apps/gcp/ci-dashboard`
- `kubectl kustomize apps/gcp/cost-insight`
- `git diff --check`
