### PR TITLE
feat(apps/prod2/tekton/configs): add FluxCD ConfigMap for delivery configs

### DIFF
--- a/apps/prod2/tekton/configs/configmaps/delivery-config.yaml
+++ b/apps/prod2/tekton/configs/configmaps/delivery-config.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: tekton-config-delivery-config
+spec:
+  interval: 1m0s
+  sourceRef:
+    kind: GitRepository
+    name: artifacts
+    namespace: flux-system
+  path: ./packages
+  prune: true
+  targetNamespace: ee-cd

--- a/apps/prod2/tekton/configs/configmaps/kustomization.yaml
+++ b/apps/prod2/tekton/configs/configmaps/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - delivery-config.yaml

--- a/apps/prod2/tekton/configs/kustomization.yaml
+++ b/apps/prod2/tekton/configs/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - 0-namespace.yaml
   - secrets
   - rbac
+  - configmaps
   - tasks/config.yaml
   - pipelines/config.yaml
   - triggers


### PR DESCRIPTION
## Summary

Add FluxCD Kustomization CR to generate `delivery-config` ConfigMap from the `artifacts` GitRepository. This eliminates runtime GitHub downloads for delivery configs in Tekton tasks.

## Changes

- Create `apps/prod2/tekton/configs/configmaps/` directory
- Add `delivery-config.yaml` FluxCD Kustomization CR referencing `artifacts` GitRepository
- Add `kustomization.yaml` to aggregate configmaps resources
- Update parent `kustomization.yaml` to include configmaps directory

## Testing

- Verified kustomize build with the new resources
- FluxCD will generate `delivery-config` ConfigMap in `ee-cd` namespace
- ConfigMap will auto-update within 1min of artifacts repo changes

## Risk

Low - additive change only. No existing resources are modified.

## Related

- FLA-210 PR1: FluxCD ConfigMap generation for delivery configs
- FLA-180: CD config map requirement
- Depends on: https://github.com/PingCAP-QE/artifacts/pull/1017