### PR TITLE
fix(dashboard): release latest ee-apps images

### DIFF
--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/ci-dashboard
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/ci-dashboard versioning=semver
-      tag: v2026.6.21-7-g45c72a9
+      tag: v2026.6.21-9-g0998751
     resources:
       requests:
         cpu: "2"

--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -31,7 +31,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-8-g7708e63
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-9-g0998751
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -127,7 +127,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcs-cache-last-seen
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-8-g7708e63
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-9-g0998751
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -194,7 +194,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcs-cache-ac-references
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-8-g7708e63
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-9-g0998751
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -258,7 +258,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-dry-run
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-8-g7708e63
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-9-g0998751
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -331,7 +331,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-delete-cas
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-8-g7708e63
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-9-g0998751
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -410,7 +410,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-8-g7708e63
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-9-g0998751
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -489,7 +489,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-8-g7708e63
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-9-g0998751
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -579,7 +579,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-8-g7708e63
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-9-g0998751
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh

--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -31,7 +31,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-6-g30392c1
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-8-g7708e63
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -127,7 +127,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcs-cache-last-seen
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-6-g30392c1
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-8-g7708e63
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -194,7 +194,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcs-cache-ac-references
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-6-g30392c1
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-8-g7708e63
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -258,7 +258,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-dry-run
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-6-g30392c1
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-8-g7708e63
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -331,7 +331,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-delete-cas
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-6-g30392c1
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-8-g7708e63
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -363,7 +363,7 @@ spec:
                 - name: COST_INSIGHT_GCS_CACHE_SAFETY_BUFFER_DAYS
                   value: "1"
                 - name: COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_OBJECTS
-                  value: "10000000"
+                  value: "500"
                 - name: COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_CAS_OBJECTS
                   value: "500"
                 - name: COST_INSIGHT_GCS_CACHE_CLEANUP_MANIFEST_BUCKET
@@ -410,7 +410,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-6-g30392c1
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-8-g7708e63
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -489,7 +489,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-6-g30392c1
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-8-g7708e63
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -579,7 +579,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-6-g30392c1
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-8-g7708e63
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh


### PR DESCRIPTION
## Summary

Release the latest ee-apps images from main, including:

- PingCAP-QE/ee-apps#507 / run https://github.com/PingCAP-QE/ee-apps/actions/runs/28016695859
  - fixes the CAS GC v3 canary blocker where metadata stage table DDL statements were concatenated without semicolon separators
- PingCAP-QE/ee-apps#508 / run https://github.com/PingCAP-QE/ee-apps/actions/runs/28024080979
  - adds the target branch cost dimension changes

Images:

- `ci-dashboard:v2026.6.21-9-g0998751`
- `ci-dashboard-jobs:v2026.6.21-9-g0998751`
- `cost-insight-jobs:v2026.6.21-9-g0998751`

## Changes

- Bump `apps/gcp/ci-dashboard/release.yaml` from `v2026.6.21-7-g45c72a9` to `v2026.6.21-9-g0998751`.
- Bump all cost-insight CronJobs to `cost-insight-jobs:v2026.6.21-9-g0998751`.
- Keep the suspended `cost-insight-cleanup-gcs-cache-delete-cas` canary-safe caps:
  - `COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_OBJECTS=500`
  - `COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_CAS_OBJECTS=500`

The seed cap keeps the suspended delete-cas CronJob safe to use as the source for a manual v3 canary. The previous `10,000,000` value caused BigQuery `ORDER BY` memory pressure during the canary attempt.

## Validation

```bash
python - <<'PY'
from pathlib import Path
import yaml
for path in ['apps/gcp/ci-dashboard/release.yaml', 'apps/gcp/cost-insight/cronjobs.yaml']:
    items = list(yaml.safe_load_all(Path(path).read_text()))
    print(path, len([x for x in items if x]))
PY

kubectl kustomize apps/gcp/ci-dashboard >/tmp/ci-dashboard-kustomize.yaml
kubectl kustomize apps/gcp/cost-insight >/tmp/cost-insight-kustomize.yaml
rg 'v2026\.6\.21-9-g0998751|COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_OBJECTS' /tmp/ci-dashboard-kustomize.yaml /tmp/cost-insight-kustomize.yaml

git diff --check
```
