### PR TITLE
fix(cost-insight): release GCS cleanup schema fix image

### DIFF
--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -31,7 +31,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-9-g0998751
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-10-gdfbc0ea
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -127,7 +127,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcs-cache-last-seen
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-9-g0998751
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-10-gdfbc0ea
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -194,7 +194,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcs-cache-ac-references
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-9-g0998751
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-10-gdfbc0ea
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -258,7 +258,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-dry-run
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-9-g0998751
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-10-gdfbc0ea
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -331,7 +331,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-delete-cas
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-9-g0998751
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-10-gdfbc0ea
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -410,7 +410,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-9-g0998751
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-10-gdfbc0ea
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -489,7 +489,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-9-g0998751
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-10-gdfbc0ea
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -579,7 +579,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-9-g0998751
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-10-gdfbc0ea
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh


### PR DESCRIPTION
## Summary

Release PingCAP-QE/ee-apps#509 / run https://github.com/PingCAP-QE/ee-apps/actions/runs/28026751759 for cost-insight GCS cleanup.

Image:

- `cost-insight-jobs:v2026.6.21-10-gdfbc0ea`

This includes the CAS GC v3 run reference table schema fix for the canary failure:

```text
Field ac_object_name has changed mode from REQUIRED to NULLABLE
```

## Changes

- Bump all cost-insight CronJobs from `v2026.6.21-9-g0998751` to `v2026.6.21-10-gdfbc0ea`.
- Keep `cost-insight-cleanup-gcs-cache-delete-cas` canary-safe caps:
  - `COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_OBJECTS=500`
  - `COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_CAS_OBJECTS=500`

## Validation

```bash
python - <<'PY'
from pathlib import Path
import yaml
items = list(yaml.safe_load_all(Path('apps/gcp/cost-insight/cronjobs.yaml').read_text()))
print(len([x for x in items if x]))
PY

kubectl kustomize apps/gcp/cost-insight >/tmp/cost-insight-v3-schema-fix-kustomize.yaml
rg 'v2026\.6\.21-10-gdfbc0ea|COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_OBJECTS|COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_CAS_OBJECTS' /tmp/cost-insight-v3-schema-fix-kustomize.yaml

git diff --check
```
