### PR TITLE
feat(ci-dashboard): release ci-dashboard v2026.6.21-15-g76d38e8

### DIFF
--- a/apps/gcp/ci-dashboard/cronjobs.yaml
+++ b/apps/gcp/ci-dashboard/cronjobs.yaml
@@ -312,3 +312,63 @@ spec:
                 limits:
                   cpu: "1"
                   memory: 2Gi
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ci-dashboard-data-freshness-check
+  namespace: apps
+  labels:
+    app.kubernetes.io/name: ci-dashboard-data-freshness-check
+    app.kubernetes.io/part-of: ci-dashboard
+spec:
+  schedule: "10 9 * * *"
+  timeZone: Asia/Shanghai
+  suspend: false
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 600
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 600
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: ci-dashboard-data-freshness-check
+            app.kubernetes.io/part-of: ci-dashboard
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: check-data-freshness
+              image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:replaced-by-kustomize
+              imagePullPolicy: IfNotPresent
+              args: ["check-data-freshness"]
+              envFrom:
+                - secretRef:
+                    name: ci-dashboard-eq-prd-insight-db
+              env:
+                - name: PYTHONUNBUFFERED
+                  value: "1"
+                - name: CI_DASHBOARD_LOG_LEVEL
+                  value: INFO
+                - name: LARK_APP_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: roster-lark
+                      key: ROSTER_LARK_APP_ID
+                - name: LARK_APP_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: roster-lark
+                      key: ROSTER_LARK_APP_SECRET
+                - name: FRESHNESS_NOTIFY_OPEN_ID
+                  value: "ou_305fc38fd60e3f64a60296cf9afeb7f7"
+              resources:
+                requests:
+                  cpu: "100m"
+                  memory: 256Mi
+                limits:
+                  cpu: "500m"
+                  memory: 512Mi

--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/ci-dashboard
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/ci-dashboard versioning=semver
-      tag: v2026.6.21-9-g0998751
+      tag: v2026.6.21-15-g76d38e8
     resources:
       requests:
         cpu: "2"

--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/ci-dashboard
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/ci-dashboard versioning=semver
-      tag: v2026.6.21-15-g76d38e8
+      tag: v2026.6.21-18-gc1cc175
     resources:
       requests:
         cpu: "2"


### PR DESCRIPTION
## Summary

Add `ci-dashboard-data-freshness-check` CronJob that runs `check-data-freshness` daily at 09:10 Asia/Shanghai.

### Details
- Queries ci_l1_*, cost_*, roster tables against production TiDB
- Uses `roster-lark` secret for Lark IM API credentials (`LARK_APP_ID` / `LARK_APP_SECRET`)
- Sends DM to Dillon (`ou_305fc38fd60e3f64a60296cf9afeb7f7`) only when failures detected
- Resource: 100m/256Mi request, 500m/512Mi limit (lightweight SQL-only job)

### Canary verified
- Connected to production TiDB ✓
- 8 failures detected (expected at 23:17 CST) ✓
- Lark DM received by Dillon ✓

### Files changed
| File | Change |
|------|--------|
| `apps/gcp/ci-dashboard/cronjobs.yaml` | +60 lines — new CronJob entry |

### Depends on
- [ee-apps #514](https://github.com/PingCAP-QE/ee-apps/pull/514) — `check-data-freshness` CLI subcommand and image

🤖 Generated with [Claude Code](https://claude.com/claude-code)