### PR TITLE
feat(cost-insight): enable daily GCS cache cascade cleanup

### DIFF
--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/ci-dashboard
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/ci-dashboard versioning=semver
-      tag: v2026.6.21-21-g786318a
+      tag: v2026.6.21-22-g7e11485
     resources:
       requests:
         cpu: "2"

--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -311,10 +311,9 @@ metadata:
     app.kubernetes.io/part-of: cost-insight
 spec:
   # Interpreted with timeZone below: daily 22:20 Asia/Shanghai, after dry-run.
-  # Keep suspended until manual v3 canary validation is complete.
   schedule: "20 22 * * *"
   timeZone: Asia/Shanghai
-  suspend: true
+  suspend: false
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 1800
   successfulJobsHistoryLimit: 5
@@ -322,7 +321,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 4
-      activeDeadlineSeconds: 7200
+      activeDeadlineSeconds: 43200
       template:
         metadata:
           labels:
@@ -367,20 +366,20 @@ spec:
                 - name: COST_INSIGHT_GCS_CACHE_SAFETY_BUFFER_DAYS
                   value: "1"
                 - name: COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_OBJECTS
-                  value: "500"
+                  value: "5000000"
                 - name: COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_CAS_OBJECTS
-                  value: "500"
+                  value: "1000000"
                 - name: COST_INSIGHT_GCS_CACHE_CLEANUP_MANIFEST_BUCKET
                   value: pingcap-ci-console-logs-us-central1
                 - name: COST_INSIGHT_GCS_CACHE_CLEANUP_MANIFEST_PREFIX
                   value: gcs-cache-steady-state-delete
               resources:
                 requests:
-                  cpu: "500m"
-                  memory: 1Gi
+                  cpu: "4"
+                  memory: 8Gi
                 limits:
-                  cpu: "2"
-                  memory: 4Gi
+                  cpu: "8"
+                  memory: 16Gi
 ---
 apiVersion: batch/v1
 kind: CronJob


### PR DESCRIPTION
## Summary

Enable the daily AC-driven CAS cleanup CronJob after manual v3 canary validation, roll out the `ci-dashboard` image built from `ee-apps#525`, and bump `cost-insight-jobs` to include the BigQuery cleanup staging quota fix from `ee-apps#529`.

Changes:
- Unsuspend `cost-insight-cleanup-gcs-cache-delete-cas`.
- Raise AC seed hard cap from the canary value `500` to `5,000,000`.
- Raise CAS delete hard cap from `500` to `1,000,000`, so the job is not effectively limited to 500 CAS objects per day while still keeping a safety cap.
- Increase the cleanup job deadline and resources for the larger daily run.
- Bump `ci-dashboard` image tag to `v2026.6.21-22-g7e11485` from the successful `ee-apps` workflow run `28140431255` for `ee-apps#525`.
- Bump all `cost-insight-jobs` CronJobs to `v2026.6.21-28-ge2c9b20` from the successful `ee-apps` workflow run `28214995791` for `ee-apps#529`.

## Notes

The last large manual canary selected `493,404` AC objects and `107,446` CAS objects, and ran for about `2h22m`.

A `5,000,000` AC cap is intentionally a hard upper bound, not an expected daily volume. If the job reaches the cap, it can run much longer than the canary, so this PR also increases `activeDeadlineSeconds` to `12h` and raises CPU/memory requests and limits.

The CAS cap is set to `1,000,000` as a separate hard guard. Leaving it at `500` would make the daily cleanup ineffective even when many eligible CAS objects are discovered from the selected AC set.

For the app image bumps, the release tags are taken from successful push workflow outputs, not inferred from merge time:
- `ci-dashboard` workflow run: `28140431255`
- `ci-dashboard` image tag: `v2026.6.21-22-g7e11485`
- `cost-insight` workflow run: `28214995791`
- `cost-insight-jobs` image tag: `v2026.6.21-28-ge2c9b20`

## Validation

- `git diff --check`
- `kubectl kustomize apps/gcp/cost-insight`
- `kubectl kustomize apps/gcp/ci-dashboard`
- Verified the rendered delete CronJob keeps `suspend: false`, AC cap `5000000`, CAS cap `1000000`, and `activeDeadlineSeconds: 43200`.
- Verified all rendered `cost-insight` CronJobs use `ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-28-ge2c9b20`.
- Verified the rendered `ci-dashboard` HelmRelease uses image tag `v2026.6.21-22-g7e11485`.
