### PR TITLE
feat(apps/gcp/prow/pre/secrets): add prow-kubeconfig external secret

### DIFF
--- a/apps/gcp/prow/pre/secrets/kustomization.yaml
+++ b/apps/gcp/prow/pre/secrets/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 resources:
   - prow-github.yaml
   - prow-gcs-credentials.yaml
+  - prow-kubeconfig.yaml
   - prow-jenkins-operator-auths.yaml

--- a/apps/gcp/prow/pre/secrets/prow-kubeconfig.yaml
+++ b/apps/gcp/prow/pre/secrets/prow-kubeconfig.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: prow-kubeconfig
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: ee-gcp-sm
+    kind: ClusterSecretStore
+  target:
+    name: prow-kubeconfig
+    creationPolicy: Owner
+  data:
+    - secretKey: config
+      remoteRef:
+        key: gcp_prow_external_cluster_kce_kubeconfig


### PR DESCRIPTION
## Summary
- add `ExternalSecret` for `prow-kubeconfig`
- sync from GCP Secret Manager key `gcp_prow_external_cluster_kce_kubeconfig`
- include the manifest in `apps/gcp/prow/pre/secrets/kustomization.yaml`

## Validation
- `kustomize build apps/gcp/prow/pre`
- checked the live cluster secret metadata in `apps/prow-kubeconfig`

## Notes
- the live `apps/prow-kubeconfig` secret already exists and has no `ownerReferences`, so ESO can take ownership with `creationPolicy: Owner`
- the live secret content and the GCP secret content currently differ; this PR intentionally accepts the first sync overwrite
