### PR TITLE
feat(ci-dashboard): release ci-dashboard v2026.6.21-21-g786318a

### DIFF
--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/ci-dashboard
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/ci-dashboard versioning=semver
-      tag: v2026.6.21-18-gc1cc175
+      tag: v2026.6.21-21-g786318a
     resources:
       requests:
         cpu: "2"


### PR DESCRIPTION
## Summary
- release CI Dashboard to `v2026.6.21-21-g786318a`
- includes PingCAP-QE/ee-apps#523: flaky weekly table sticky-column/layout fix

## Source
- ee-apps workflow: https://github.com/PingCAP-QE/ee-apps/actions/runs/28103298416
- workflow result: success
- workflow head: `786318a437bb101556373170390ae15c8bbdd594`
- generated images from workflow log:
  - `ghcr.io/pingcap-qe/ee-apps/ci-dashboard:v2026.6.21-21-g786318a`
  - `ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.6.21-21-g786318a`

## Verification
- `docker manifest inspect ghcr.io/pingcap-qe/ee-apps/ci-dashboard:v2026.6.21-21-g786318a`
- `docker manifest inspect ghcr.io/pingcap-qe/ee-apps/ci-dashboard-jobs:v2026.6.21-21-g786318a`
- `kubectl kustomize apps/gcp/ci-dashboard | rg "image: ghcr.io/pingcap-qe/ee-apps/ci-dashboard|tag: v2026|repository: ghcr.io/pingcap-qe/ee-apps/ci-dashboard"`
- `kubectl kustomize apps/gcp/ci-dashboard | rg "replaced-by-kustomize"` returned no matches
