### PR TITLE
feat(apps/prod2/tekton/configs): add FluxCD ConfigMap for CI configs

### DIFF
--- a/apps/prod2/tekton/configs/configmaps/ci-configs.yaml
+++ b/apps/prod2/tekton/configs/configmaps/ci-configs.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: tekton-config-ci-configs
+spec:
+  interval: 1m0s
+  sourceRef:
+    kind: GitRepository
+    name: ci
+    namespace: flux-system
+  path: ./configs/error-log-review
+  prune: true
+  targetNamespace: ee-cd

--- a/apps/prod2/tekton/configs/configmaps/kustomization.yaml
+++ b/apps/prod2/tekton/configs/configmaps/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - delivery-config.yaml
+  - ci-configs.yaml


### PR DESCRIPTION
## Summary

Add FluxCD Kustomization CR to generate `error-log-review-config` ConfigMap from the `ci` GitRepository. This eliminates runtime GitHub downloads for error log review configuration in Tekton tasks.

## Changes

- Add `ci-configs.yaml` FluxCD Kustomization CR referencing `ci` GitRepository
- Update `configmaps/kustomization.yaml` to include `ci-configs` resource

## Testing

- Verified kustomize build with the new resources
- FluxCD will generate `error-log-review-config` ConfigMap in `ee-cd` namespace
- ConfigMap will auto-update within 1min of ci repo changes

## Risk

Low - additive change only. No existing resources are modified.

## Related

- FLA-210 PR2: FluxCD ConfigMap generation for CI configs
- FLA-180: CD config map requirement
- Depends on: https://github.com/PingCAP-QE/ci/pull/4745