### PR TITLE
chore(apps/prod2/chatops-lark): bump image tag to v2026.6.14-10-ge96ec3c

### DIFF
--- a/apps/prod2/chatops-lark/release.yaml
+++ b/apps/prod2/chatops-lark/release.yaml
@@ -38,7 +38,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/chatops-lark
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/chatops-lark versioning=semver
-      tag: v2026.5.24-11-g8879283
+      tag: v2026.6.14-10-ge96ec3c
     server:
       secretName: chatops-lark
       appIdSecretKey: app-id


### PR DESCRIPTION
## Summary\nBump chatops-lark image tag from  to .\n\n## Changes\n- Updated  image tag\n\n## Testing\n- Verified the YAML is valid\n- Image tag matches the requested version\n\n## Risk\n- Low risk: single image tag update for chatops-lark deployment