### PR TITLE
chore(apps/prod2,apps/gcp): update publisher image tag to v2026.6.21-25-g33ef990

### DIFF
--- a/apps/gcp/publisher/releases/publisher.yaml
+++ b/apps/gcp/publisher/releases/publisher.yaml
@@ -25,7 +25,7 @@ spec:
     # Additional volumes on the output Deployment definition.
     image:
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/publisher versioning=semver
-      tag: v2026.6.21-17-gf2b6f8a
+      tag: v2026.6.21-25-g33ef990
     resources:
       limits:
         cpu: 500m

--- a/apps/prod2/publisher/releases/publisher.yaml
+++ b/apps/prod2/publisher/releases/publisher.yaml
@@ -25,7 +25,7 @@ spec:
     # Additional volumes on the output Deployment definition.
     image:
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/publisher versioning=semver
-      tag: v2026.6.21-17-gf2b6f8a
+      tag: v2026.6.21-25-g33ef990
     resources:
       limits:
         cpu: 500m


### PR DESCRIPTION
## Summary

Update publisher image tag to include the v26.3.* version normalization fix for tidbcloud ops platform.

## Changes

- Updated image tag from  to 
- Files modified:
  - 
  - 

## Related

- Ref: https://github.com/PingCAP-QE/ee-apps/pull/527 (version normalization fix)

## Testing

- Verified image tag exists in ghcr.io
- Changes are minimal (only image tag update)