### PR TITLE
feat(cost-insight): enable daily GCS cache cascade cleanup

### DIFF
--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -31,7 +31,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-14-g4b0ea63
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-28-ge2c9b20
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -127,7 +127,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcs-cache-last-seen
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-14-g4b0ea63
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-28-ge2c9b20
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -194,7 +194,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcs-cache-ac-references
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-14-g4b0ea63
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-28-ge2c9b20
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -258,7 +258,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-dry-run
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-14-g4b0ea63
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-28-ge2c9b20
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -332,7 +332,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-delete-cas
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-14-g4b0ea63
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-28-ge2c9b20
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -413,7 +413,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-14-g4b0ea63
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-28-ge2c9b20
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -492,7 +492,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-14-g4b0ea63
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-28-ge2c9b20
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -582,7 +582,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-14-g4b0ea63
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-28-ge2c9b20
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh


### PR DESCRIPTION
Supersedes #2064 because that PR head got stuck on an older commit and stopped reflecting the branch tip.

## Summary

Enable the daily AC-driven CAS cleanup CronJob after manual v3 canary validation, roll out the `ci-dashboard` image built from `ee-apps#525`, and bump `cost-insight-jobs` to include the BigQuery cleanup staging quota fix from `ee-apps#529`.

Changes:
- Unsuspend `cost-insight-cleanup-gcs-cache-delete-cas`.
- Raise AC seed hard cap from the canary value `500` to `5,000,000`.
- Raise CAS delete hard cap from `500` to `1,000,000`, so the job is not effectively limited to 500 CAS objects per day while still keeping a safety cap.
- Increase the cleanup job deadline and resources for the larger daily run.
- Bump `ci-dashboard` image tag to `v2026.6.21-22-g7e11485` from the successful `ee-apps` workflow run `28140431255` for `ee-apps#525`.
- Bump all `cost-insight-jobs` CronJobs to `v2026.6.21-28-ge2c9b20` from the successful `ee-apps` workflow run `28214995791` for `ee-apps#529`.

## Notes

The last large manual canary selected `493,404` AC objects and `107,446` CAS objects, and ran for about `2h22m`.

A `5,000,000` AC cap is intentionally a hard upper bound, not an expected daily volume. If the job reaches the cap, it can run much longer than the canary, so this PR also increases `activeDeadlineSeconds` to `12h` and raises CPU/memory requests and limits.

The CAS cap is set to `1,000,000` as a separate hard guard. Leaving it at `500` would make the daily cleanup ineffective even when many eligible CAS objects are discovered from the selected AC set.

For the app image bumps, the release tags are taken from successful push workflow outputs, not inferred from merge time:
- `ci-dashboard` workflow run: `28140431255`
- `ci-dashboard` image tag: `v2026.6.21-22-g7e11485`
- `cost-insight` workflow run: `28214995791`
- `cost-insight-jobs` image tag: `v2026.6.21-28-ge2c9b20`

## Validation

- `git diff --check`
- `kubectl kustomize apps/gcp/cost-insight`
- `kubectl kustomize apps/gcp/ci-dashboard`
- Verified the rendered delete CronJob keeps `suspend: false`, AC cap `5000000`, CAS cap `1000000`, and `activeDeadlineSeconds: 43200`.
- Verified all rendered `cost-insight` CronJobs use `ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.21-28-ge2c9b20`.
- Verified the rendered `ci-dashboard` HelmRelease uses image tag `v2026.6.21-22-g7e11485`.
