### PR TITLE
chore(apps/prod2/tibuild): deploy PR1 (#531) image for paramPluginGitRef extension

### DIFF
--- a/apps/prod2/tibuild/v1/deployment.yaml
+++ b/apps/prod2/tibuild/v1/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app: tibuild
     spec:
       containers:
-        - image: ghcr.io/pingcap-qe/ee-apps/tibuild:v2026.6.14-7-g63e8534
+        - image: ghcr.io/pingcap-qe/ee-apps/tibuild:v2026.6.21-29-g7948db8
           imagePullPolicy: Always
           name: tibuild
           ports:

--- a/apps/prod2/tibuild/v2/release.yaml
+++ b/apps/prod2/tibuild/v2/release.yaml
@@ -37,7 +37,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/exp-tibuild-v2
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/exp-tibuild-v2 versioning=semver
-      tag: v2026.6.21-16-gd6cdfe2
+      tag: v2026.6.21-29-g7948db8
     server:
       debug: false
       config:


### PR DESCRIPTION
## Summary

Update tibuild v1 and v2 image tags to deploy the changes from [ee-apps#531](https://github.com/PingCAP-QE/ee-apps/pull/531).

## Changes

- `apps/prod2/tibuild/v1/deployment.yaml`: Update image tag from `v2026.6.14-7-g63e8534` → `v2026.6.21-29-g7948db8`
- `apps/prod2/tibuild/v2/release.yaml`: Update image tag from `v2026.6.21-16-gd6cdfe2` → `v2026.6.21-29-g7948db8`

## Background

ee-apps PR #531 added `paramPluginGitRef` CloudEvent extension in both v1 and v2 tibuild services. The CI built and pushed the Docker images (`tibuild:v2026.6.21-29-g7948db8` and `exp-tibuild-v2:v2026.6.21-29-g7948db8`). This PR updates the GitOps manifests to point to these new images, so FluxCD deploys them to the prod2 cluster.

## Verification

- CI run #353 (commit 7948db8) succeeded
- Images built and pushed to ghcr.io:
  - `ghcr.io/pingcap-qe/ee-apps/tibuild:v2026.6.21-29-g7948db8`
  - `ghcr.io/pingcap-qe/ee-apps/exp-tibuild-v2:v2026.6.21-29-g7948db8`

## References

- [ee-apps#531](https://github.com/PingCAP-QE/ee-apps/pull/531)
- Refs: FLA-225