### PR TITLE
feat(apps/prod2/prow-worker): add ExternalSecrets for job parameters and credentials

### DIFF
--- a/apps/prod2/prow-worker/kustomization.yaml
+++ b/apps/prod2/prow-worker/kustomization.yaml
@@ -4,3 +4,4 @@ namespace: prow-test-pods
 resources:
   - namespace.yaml
   - rbac.yaml
+  - secrets

--- a/apps/prod2/prow-worker/secrets/ci-job-params-mono.yaml
+++ b/apps/prod2/prow-worker/secrets/ci-job-params-mono.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ci-job-params-mono
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: ee-gcp-sm
+    kind: ClusterSecretStore
+  target:
+    name: ci-job-params-mono
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        # json object is a flatten object that contains all params that are needed for prow jobs.
+        # If you want add/update a new secret param, please update the json object in the secret store.
+        key: gcp_prow_ci_job_params_flattened

--- a/apps/prod2/prow-worker/secrets/ci-smtp.yaml
+++ b/apps/prod2/prow-worker/secrets/ci-smtp.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ci-smtp
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: ee-gcp-sm
+    kind: ClusterSecretStore
+  target:
+    name: ci-smtp
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        # json object contains keys: `smtp-host`, `smtp-port`, `smtp-user`, `smtp-password`.
+        key: gcp_ci_smtp_config_json

--- a/apps/prod2/prow-worker/secrets/codecov-token.yaml
+++ b/apps/prod2/prow-worker/secrets/codecov-token.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: codecov-tokens
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: ee-gcp-sm
+    kind: ClusterSecretStore
+  target:
+    name: codecov-tokens
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        # JSON object contains keys for each project in format <ORG>-<REPO>
+        # Example: {"tikv-tikv": "token1", ...}
+        key: gcp_codecov_tokens_json

--- a/apps/prod2/prow-worker/secrets/docs-cn.yaml
+++ b/apps/prod2/prow-worker/secrets/docs-cn.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: docs-cn
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: ee-gcp-sm
+    kind: ClusterSecretStore
+  target:
+    name: docs-cn
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: "${DOCS_CN_S3_JSON}" # json object

--- a/apps/prod2/prow-worker/secrets/gcs-credentials.yaml
+++ b/apps/prod2/prow-worker/secrets/gcs-credentials.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gcs-credentials
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: ee-gcp-sm
+    kind: ClusterSecretStore
+  target:
+    name: gcs-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: service-account.json
+      remoteRef:
+        # Name of the secret in GCP Secret Manager that holds the service account JSON
+        key: gcp_gcs_sa_json

--- a/apps/prod2/prow-worker/secrets/github-token.yaml
+++ b/apps/prod2/prow-worker/secrets/github-token.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: github-token
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: ee-gcp-sm
+    kind: ClusterSecretStore
+  target:
+    name: github-token
+    creationPolicy: Owner
+  data:
+    - secretKey: token
+      remoteRef:
+        # Name of the secret in GCP Secret Manager that holds the github private token
+        key: github-bot-token

--- a/apps/prod2/prow-worker/secrets/kustomization.yaml
+++ b/apps/prod2/prow-worker/secrets/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ci-job-params-mono.yaml
+  - ci-smtp.yaml
+  - gcs-credentials.yaml
+  - github-token.yaml
+  - codecov-token.yaml
+  - docs-cn.yaml


### PR DESCRIPTION
Add ExternalSecret resources to pull CI job params, SMTP config, GCS
credentials, GitHub token, codecov tokens, and docs-cn secrets from
GCP Secret Manager via the ee-gcp-sm ClusterSecretStore.
