### PR TITLE
fix(apps/gcp/dl): add GCPBackendPolicy to increase backend timeout

### DIFF
--- a/apps/gcp/dl/backend-policy.yaml
+++ b/apps/gcp/dl/backend-policy.yaml
@@ -1,0 +1,11 @@
+apiVersion: networking.gke.io/v1
+kind: GCPBackendPolicy
+metadata:
+  name: dl-backend-policy
+spec:
+  default:
+    timeoutSec: 3600
+  targetRef:
+    group: ""
+    kind: Service
+    name: dl

--- a/apps/gcp/dl/http-route.yaml
+++ b/apps/gcp/dl/http-route.yaml
@@ -20,12 +20,8 @@ spec:
             path:
               type: ReplacePrefixMatch
               replacePrefixMatch: /
-      # Large artifact downloads are streamed for minutes. The GCP external
-      # HTTP(S) load balancer (GKE Gateway) has a 30s backend timeout, which
-      # applies to data-packet intervals, not total download duration. As long
-      # as the dl service streams data continuously, downloads won't be cut off.
-      # If long pauses between chunks cause timeouts, configure timeout via
-      # a GCPBackendPolicy on the dl Service instead.
+      # Large artifact downloads are streamed for minutes. The GCPBackendPolicy
+      # (backend-policy.yaml) overrides the default 30s backend timeout to 1h.
       backendRefs:
         - name: dl
           port: 80

--- a/apps/gcp/dl/kustomization.yaml
+++ b/apps/gcp/dl/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: dl
 resources:
   - namespace.yaml
   - external-secrets
+  - backend-policy.yaml
   - health-check-policy.yaml
   - http-route.yaml
   - release.yaml


### PR DESCRIPTION
## Problem

Large artifact downloads via `prow.tidb.net/dl` fail at ~30% progress. The same service works fine via `internal2-do.pingcap.net/dl` (prod2 cluster).

**Root cause:** The GKE external HTTP(S) load balancer (`gke-l7-global-external-managed`) has a default 30s backend timeout. When the dl service pauses >30s between data chunks (e.g. pulling from OCI storage), the LB severs the connection.

## Fix

Add a `GCPBackendPolicy` targeting the dl Service to override the backend timeout to 3600s (1h).

This matches the behavior on prod2, where Envoy Gateway has `timeouts.request: 0s` (disabled).

## Verification

- `GCPBackendPolicy` status: `Attached: True`
- Gateway re-synced after policy was applied
- Test download completed successfully at 100% (189MB, 1m47s), previously failing at ~30%