### PR TITLE
feat(apps/gcp/dl): switch to Ko-built image, enable workload identity for GCS ADC

### DIFF
--- a/apps/gcp/dl/release.yaml
+++ b/apps/gcp/dl/release.yaml
@@ -35,9 +35,12 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/dl
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/dl versioning=docker
-      tag: v2026.6.14-13-gade3d63
+      tag: v2026.6.28-4-g1306453
     server:
-      args: [--ks3-config=/config/ks3.yaml, --oci-config=/config/oci.yaml]
+      args:
+        - --domain=0.0.0.0:80
+        - --ks3-config=/config/ks3.yaml
+        - --oci-config=/config/oci.yaml
       volumes:
         - name: config
           secret:
@@ -46,6 +49,8 @@ spec:
         - name: config
           mountPath: /config
     serviceAccount:
-      create: false
+      create: true
+      annotations:
+        iam.gke.io/gcp-service-account: hotfix-binaries-reader@pingcap-testing-account.iam.gserviceaccount.com
     httpRoute:
       enabled: false


### PR DESCRIPTION
## Summary

- Update image tag to `v2026.6.28-4-g1306453` (Ko-built, supports GCS)
- Add `--domain=0.0.0.0:80` arg for container port binding
- Enable `serviceAccount` with GCP workload identity annotation (`hotfix-binaries-reader@pingcap-testing-account.iam.gserviceaccount.com`)
- GCS access uses ADC — no `--gcs-config` flag needed

GCP service account `hotfix-binaries-reader` must have `storage.objects.get` permission on the target bucket.