### PR TITLE
feat(apps/prod2/publisher,apps/gcp/publisher): add data_migration component to tidbcloud ops config

### DIFF
--- a/apps/gcp/publisher/external-secrets/publisher-server-config.yaml
+++ b/apps/gcp/publisher/external-secrets/publisher-server-config.yaml
@@ -113,6 +113,10 @@ spec:
                   cluster_type: SHARED_POOL
                   base_image: us.gcr.io/pingcap-public/tidbx/br
                   github_repo: pingcap/tidb
+                data_migration:
+                  cluster_type: SHARED_POOL
+                  base_image: us.gcr.io/pingcap-public/tidbx/dm
+                  github_repo: pingcap/tiflow
             dev:
               api_base_url: "{{ .ops_dev_api_base_url }}"
               api_key: "{{ .ops_dev_api_key }}"

--- a/apps/prod2/publisher/external-secrets/publisher-server-config.yaml
+++ b/apps/prod2/publisher/external-secrets/publisher-server-config.yaml
@@ -113,6 +113,10 @@ spec:
                   cluster_type: SHARED_POOL
                   base_image: us.gcr.io/pingcap-public/tidbx/br
                   github_repo: pingcap/tidb
+                data_migration:
+                  cluster_type: SHARED_POOL
+                  base_image: us.gcr.io/pingcap-public/tidbx/dm
+                  github_repo: pingcap/tiflow
             dev:
               api_base_url: "{{ .ops_dev_api_base_url }}"
               api_key: "{{ .ops_dev_api_key }}"


### PR DESCRIPTION
## Summary

Add `data_migration` component to the publisher service's tidbcloud ops configuration in both prod2 and gcp cluster configs.

## Changes

- Added `data_migration` component to `&tidbcloud_components` anchor in `apps/prod2/publisher/external-secrets/publisher-server-config.yaml`
- Added `data_migration` component to `&tidbcloud_components` anchor in `apps/gcp/publisher/external-secrets/publisher-server-config.yaml`
- The component is automatically inherited by the `dev` stage via the `*tidbcloud_components` reference

## Testing

YAML validation passes - anchor/reference structure remains intact.

## Risk

Low. Configuration-only change within an existing YAML anchor.