### PR TITLE
feat(apps/prod2,apps/gcp): add data_migration component to publisher config

### DIFF
--- a/apps/gcp/publisher/external-secrets/publisher-server-config.yaml
+++ b/apps/gcp/publisher/external-secrets/publisher-server-config.yaml
@@ -81,6 +81,10 @@ spec:
                   cluster_type: SHARED_POOL
                   base_image: us.gcr.io/pingcap-public/tidbx/tikv
                   github_repo: tidbcloud/cloud-storage-engine
+                data_migration:
+                  cluster_type: SHARED_POOL
+                  base_image: us.gcr.io/pingcap-public/tidbx/dm
+                  github_repo: pingcap/tiflow
                 tidb:
                   cluster_type: SHARED_POOL
                   base_image: us.gcr.io/pingcap-public/tidbx/tidb

--- a/apps/prod2/publisher/external-secrets/publisher-server-config.yaml
+++ b/apps/prod2/publisher/external-secrets/publisher-server-config.yaml
@@ -81,6 +81,10 @@ spec:
                   cluster_type: SHARED_POOL
                   base_image: us.gcr.io/pingcap-public/tidbx/tikv
                   github_repo: tidbcloud/cloud-storage-engine
+                data_migration:
+                  cluster_type: SHARED_POOL
+                  base_image: us.gcr.io/pingcap-public/tidbx/dm
+                  github_repo: pingcap/tiflow
                 tidb:
                   cluster_type: SHARED_POOL
                   base_image: us.gcr.io/pingcap-public/tidbx/tidb


### PR DESCRIPTION
## Summary

Add `data_migration` component to publisher tidbcloud ops config for both prod2 and gcp clusters.

## Changes

- Added `data_migration` component to `apps/prod2/publisher/external-secrets/publisher-server-config.yaml`
- Added `data_migration` component to `apps/gcp/publisher/external-secrets/publisher-server-config.yaml`

Component definition: `cluster_type: SHARED_POOL`, `base_image: us.gcr.io/pingcap-public/tidbx/dm`, `github_repo: pingcap/tiflow`

## Testing

Validated with `yq` — YAML structure matches existing component pattern.

## Risk

Low. Config-only change, follows existing component pattern. Revert by reverting this PR.