### PR TITLE
chore(cost-insight): bump jobs image

### DIFF
--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -31,7 +31,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-10-g946744d
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -127,7 +127,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcs-cache-last-seen
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-10-g946744d
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -194,7 +194,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcs-cache-ac-references
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-10-g946744d
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -258,7 +258,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-dry-run
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-10-g946744d
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -332,7 +332,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-delete-cas
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-10-g946744d
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -413,7 +413,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-10-g946744d
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -492,7 +492,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-10-g946744d
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -582,7 +582,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-10-g946744d
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh

--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -31,7 +31,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-5-g99a8c89
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_arm64
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -127,7 +127,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcs-cache-last-seen
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-5-g99a8c89
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_arm64
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -194,7 +194,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcs-cache-ac-references
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-5-g99a8c89
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_arm64
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -258,7 +258,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-dry-run
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-5-g99a8c89
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_arm64
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -332,7 +332,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-delete-cas
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-5-g99a8c89
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_arm64
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -413,7 +413,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-5-g99a8c89
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_arm64
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -492,7 +492,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-5-g99a8c89
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_arm64
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -582,7 +582,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-5-g99a8c89
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_arm64
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh

--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -31,7 +31,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_amd64
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -127,7 +127,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcs-cache-last-seen
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_amd64
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -194,7 +194,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcs-cache-ac-references
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_amd64
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -258,7 +258,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-dry-run
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_amd64
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -332,7 +332,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-delete-cas
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_amd64
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -413,7 +413,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_amd64
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -492,7 +492,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_amd64
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -582,7 +582,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_amd64
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh

--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -31,7 +31,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_arm64
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_amd64
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -127,7 +127,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcs-cache-last-seen
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_arm64
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_amd64
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -194,7 +194,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcs-cache-ac-references
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_arm64
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_amd64
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -258,7 +258,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-dry-run
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_arm64
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_amd64
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -332,7 +332,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-delete-cas
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_arm64
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_amd64
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -413,7 +413,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_arm64
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_amd64
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -492,7 +492,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_arm64
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_amd64
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -582,7 +582,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_arm64
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-9-gc8dc928_linux_amd64
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh


### PR DESCRIPTION
## Summary
- Bump cost-insight jobs image to ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-10-g946744d
- Source ee-apps release: https://github.com/PingCAP-QE/ee-apps/actions/runs/28572254338
- Keep CronJob schedules and suspend flags unchanged; this PR does not enable the formal AC reference CronJob.

## Validation
- gh run view 28572254338 confirms release success and head SHA 946744d6c02d68475cfe104578c69057d9d494c9
- registry manifest for the no-suffix tag is multi-arch: linux/amd64 sha256:90313753535163a002bd72d00b801351f765e08b26c566efe23583b0ebc227b8, linux/arm64 sha256:f75c95f0c5b16d71027b50d58ba265af3b537b62679132e56f5efd5685db2bf0
- git diff --check
- rg verified only image tags changed; sync-gcs-cache-ac-references remains suspend: true
- ad-hoc bootstrap validation with this image:
  - shards 12-15 completed after retrying shard 12 once; all parse_error_count=0
  - shards 16-19 completed after retrying shard 19 once; all parse_error_count=0
  - state table now has shards 0-19 indexed_through populated

## Rollout note
The new shard logs work and per-shard throughput is around 10-11 minutes. Parallel one-shard Jobs are viable but current code still does per-Job table ensure and missing-AC reconcile DML, which can hit BigQuery table update/concurrent update limits. Avoid large fan-out until that is fixed or keep small waves with manual retry.

Note: local pre-commit command is unavailable in this environment.