### PR TITLE
chore(apps/gcp/dl,apps/prod2/dl): update dl image tag to v2026.6.28-14-g16bd374

### DIFF
--- a/apps/gcp/dl/release.yaml
+++ b/apps/gcp/dl/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/dl
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/dl versioning=docker
-      tag: v2026.6.28-4-g1306453
+      tag: v2026.6.28-14-g16bd374
     server:
       args:
         - --domain=0.0.0.0:80

--- a/apps/prod2/dl/release.yaml
+++ b/apps/prod2/dl/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/dl
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/dl versioning=docker
-      tag: v2026.6.14-13-gade3d63
+      tag: v2026.6.28-14-g16bd374
     server:
       args: [--ks3-config=/config/ks3.yaml, --oci-config=/config/oci.yaml]
       volumes:


### PR DESCRIPTION
## Summary

Update dl service deployment image tag to include HEAD support (head-object Goa method for KS3 and GCS, PR PingCAP-QE/ee-apps#543).

## Changes

- apps/prod2/dl/release.yaml: tag v2026.6.14-13-gade3d63 -> v2026.6.28-14-g16bd374
- apps/gcp/dl/release.yaml: tag v2026.6.28-4-g1306453 -> v2026.6.28-14-g16bd374

## Testing

- Image already built and pushed by ee-apps release workflow (sha 16bd374)
- Manifest validation via FluxCD will apply automatically after merge

## Risk

Low. Only image tag change; no structural or configuration changes.
