### PR TITLE
chore(apps/gcp): pause insight db workloads for migration

### DIFF
--- a/apps/gcp/ci-dashboard/cronjobs.yaml
+++ b/apps/gcp/ci-dashboard/cronjobs.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   schedule: "5 * * * *"
   timeZone: Asia/Shanghai
-  suspend: false
+  suspend: true
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 1800
   successfulJobsHistoryLimit: 5
@@ -57,7 +57,7 @@ metadata:
 spec:
   schedule: "15 * * * *"
   timeZone: Asia/Shanghai
-  suspend: false
+  suspend: true
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 1800
   successfulJobsHistoryLimit: 5
@@ -105,7 +105,7 @@ metadata:
 spec:
   schedule: "20,50 * * * *"
   timeZone: Asia/Shanghai
-  suspend: false
+  suspend: true
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 1800
   successfulJobsHistoryLimit: 5
@@ -157,7 +157,7 @@ metadata:
 spec:
   schedule: "0 */4 * * *"
   timeZone: Asia/Shanghai
-  suspend: false
+  suspend: true
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 1800
   successfulJobsHistoryLimit: 5
@@ -212,7 +212,7 @@ metadata:
 spec:
   schedule: "5,25,45 * * * *"
   timeZone: Asia/Shanghai
-  suspend: false
+  suspend: true
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 1800
   successfulJobsHistoryLimit: 3
@@ -270,7 +270,7 @@ metadata:
 spec:
   schedule: "15,35,55 * * * *"
   timeZone: Asia/Shanghai
-  suspend: false
+  suspend: true
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 1800
   successfulJobsHistoryLimit: 3
@@ -324,7 +324,7 @@ metadata:
 spec:
   schedule: "10 9 * * *"
   timeZone: Asia/Shanghai
-  suspend: false
+  suspend: true
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 600
   successfulJobsHistoryLimit: 3

--- a/apps/gcp/ci-dashboard/jenkins-worker.yaml
+++ b/apps/gcp/ci-dashboard/jenkins-worker.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/part-of: ci-dashboard
     ci-dashboard.pingcap.com/instance: jenkins-worker
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: ci-dashboard-jenkins-worker

--- a/apps/gcp/ci-dashboard/pod-watcher.yaml
+++ b/apps/gcp/ci-dashboard/pod-watcher.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: ci-dashboard-pod-watcher
     app.kubernetes.io/part-of: ci-dashboard
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: ci-dashboard-pod-watcher

--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -29,7 +29,7 @@ spec:
     enable: true
     ignoreFailures: false
   values:
-    replicaCount: 1
+    replicaCount: 0
     nodeSelector:
       kubernetes.io/arch: amd64
     image:

--- a/apps/gcp/cloudevents-server/release.yaml
+++ b/apps/gcp/cloudevents-server/release.yaml
@@ -27,7 +27,7 @@ spec:
     enable: true
     ignoreFailures: false
   values:
-    replicaCount: 1
+    replicaCount: 0
     resources:
       requests:
         cpu: "100m"

--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -10,7 +10,7 @@ spec:
   # Interpreted with timeZone below: 21:10 Asia/Shanghai, intentionally outside BJ work time.
   schedule: "10 21 * * *"
   timeZone: Asia/Shanghai
-  suspend: false
+  suspend: true
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 1800
   successfulJobsHistoryLimit: 5
@@ -106,7 +106,7 @@ spec:
   # Interpreted with timeZone below: 21:20 Asia/Shanghai, after the other daily cost jobs.
   schedule: "20 21 * * *"
   timeZone: Asia/Shanghai
-  suspend: false
+  suspend: true
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 1800
   successfulJobsHistoryLimit: 5
@@ -393,7 +393,7 @@ spec:
   # Interpreted with timeZone below: Monday 22:10 Asia/Shanghai.
   schedule: "10 22 * * 1"
   timeZone: Asia/Shanghai
-  suspend: false
+  suspend: true
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 1800
   successfulJobsHistoryLimit: 5
@@ -473,7 +473,7 @@ spec:
   # Interpreted with timeZone below: 21:40 Asia/Shanghai, after the GCP summary job.
   schedule: "40 21 * * *"
   timeZone: Asia/Shanghai
-  suspend: false
+  suspend: true
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 1800
   successfulJobsHistoryLimit: 5
@@ -563,7 +563,7 @@ spec:
   # Interpreted with timeZone below: Monday 23:10 Asia/Shanghai, after the GCP unmatched job.
   schedule: "10 23 * * 1"
   timeZone: Asia/Shanghai
-  suspend: false
+  suspend: true
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 1800
   successfulJobsHistoryLimit: 5

--- a/apps/gcp/roster/cronjob.yaml
+++ b/apps/gcp/roster/cronjob.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   schedule: "0 3 * * *"
   timeZone: Asia/Shanghai
-  suspend: false
+  suspend: true
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 1800
   successfulJobsHistoryLimit: 3
@@ -60,7 +60,7 @@ metadata:
 spec:
   schedule: "10 10 * * 1"
   timeZone: Asia/Shanghai
-  suspend: false
+  suspend: true
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 1800
   successfulJobsHistoryLimit: 3


### PR DESCRIPTION
## Summary
- suspend CI dashboard, cost insight, and roster CronJobs that can touch the insight DB
- scale CI dashboard web, Jenkins worker, pod watcher, and cloudevents-server to zero replicas

## Verification
- kubectl kustomize apps/gcp/ci-dashboard
- kubectl kustomize apps/gcp/cost-insight
- kubectl kustomize apps/gcp/roster
- kubectl kustomize apps/gcp/cloudevents-server
- git diff --check

Note: ./scripts/validate_k8s_yaml.sh currently fails on existing charts/prow/templates/tests/test-connection.yaml Helm template parsing, unrelated to this PR.