### PR TITLE
feat(apps/gcp/jenkins,apps/prod/jenkins,apps/prod2/jenkins): use shallow clone for ci repo in JCasC config

### DIFF
--- a/apps/gcp/jenkins/beta/release/staging/values-JCasC.yaml
+++ b/apps/gcp/jenkins/beta/release/staging/values-JCasC.yaml
@@ -274,9 +274,16 @@ controller:
                 scm {
                   git {
                     remote {
-                      github('PingCAP-QE/ci', 'https')
+                      url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                      cloneOptions {
+                        depth(1)
+                        shallow(true)
+                        timeout(5)
+                      }
+                    }
                   }
                 }
                 steps {

--- a/apps/gcp/jenkins/beta/release/values-JCasC.yaml
+++ b/apps/gcp/jenkins/beta/release/values-JCasC.yaml
@@ -274,9 +274,16 @@ controller:
                 scm {
                   git {
                     remote {
-                      github('PingCAP-QE/ci', 'https')
+                      url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                      cloneOptions {
+                        depth(1)
+                        shallow(true)
+                        timeout(5)
+                      }
+                    }
                   }
                 }
                 steps {

--- a/apps/prod/jenkins/release/values-JCasC.yaml
+++ b/apps/prod/jenkins/release/values-JCasC.yaml
@@ -235,9 +235,16 @@ controller:
                 scm {
                   git {
                     remote {
-                      github('PingCAP-QE/ci', 'https')
+                      url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                      cloneOptions {
+                        depth(1)
+                        shallow(true)
+                        timeout(5)
+                      }
+                    }
                   }
                 }
                 triggers {

--- a/apps/prod2/jenkins/beta/release/values-JCasC.yaml
+++ b/apps/prod2/jenkins/beta/release/values-JCasC.yaml
@@ -288,9 +288,16 @@ controller:
                 scm {
                   git {
                     remote {
-                      github('PingCAP-QE/ci', 'https')
+                      url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                      cloneOptions {
+                        depth(1)
+                        shallow(true)
+                        timeout(5)
+                      }
+                    }
                   }
                 }
                 triggers {


### PR DESCRIPTION
Update Jenkins JCasC configs to use `url()` instead of `github()` for the ci repo SCM git remote, and add shallow clone options (depth=1, shallow=true, timeout=5) to improve checkout performance.