### PR TITLE
fix(apps/gcp/cost-insight): raise CAS cleanup caps

### DIFF
--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -332,7 +332,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-delete-cas
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-22-g0e99626
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-23-g579b709
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh

--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -341,7 +341,8 @@ spec:
                 - |
                   cost-insight cleanup-gcs-cache \
                     --mode delete \
-                    --execute-kind cas-from-index
+                    --execute-kind cas-from-index \
+                    --max-delete-objects 5000000
               env:
                 - name: PYTHONUNBUFFERED
                   value: "1"
@@ -367,6 +368,8 @@ spec:
                   value: "1"
                 - name: COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_OBJECTS
                   value: "5000000"
+                - name: COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_CAS_BYTES
+                  value: "54975581388800"
                 - name: COST_INSIGHT_GCS_CACHE_CLEANUP_AC_DELETE_BATCH_SIZE
                   value: "500000"
                 - name: COST_INSIGHT_GCS_CACHE_CLEANUP_MANIFEST_BUCKET


### PR DESCRIPTION
## Summary
- pass `--max-delete-objects 5000000` to the CAS cleanup CronJob so cas-from-index uses the intended object cap
- set `COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_CAS_BYTES=54975581388800` (50 TiB)

## Validation
- `python - <<PY ... yaml.safe_load_all(apps/gcp/cost-insight/cronjobs.yaml) ... PY`
- `kubectl kustomize apps/gcp/cost-insight`
