### PR TITLE
chore(cost-insight): bump jobs image for GCS cache catch-up

### DIFF
--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -31,7 +31,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-10-g946744d
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.5-1-g0057031
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -127,7 +127,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcs-cache-last-seen
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-10-g946744d
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.5-1-g0057031
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -194,7 +194,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcs-cache-ac-references
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-10-g946744d
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.5-1-g0057031
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -258,7 +258,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-dry-run
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-10-g946744d
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.5-1-g0057031
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -332,7 +332,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-delete-cas
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-23-g579b709
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.5-1-g0057031
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -416,7 +416,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-10-g946744d
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.5-1-g0057031
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -495,7 +495,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-10-g946744d
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.5-1-g0057031
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -585,7 +585,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.6.28-10-g946744d
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.5-1-g0057031
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh


### PR DESCRIPTION
## Summary
- bump all GCP cost-insight CronJobs to ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.5-1-g0057031
- deploy ee-apps change from PingCAP-QE/ee-apps#562 for safer parallel GCS cache catch-up

## Source
- ee-apps workflow: https://github.com/PingCAP-QE/ee-apps/actions/runs/28741244592
- image manifest verified: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.5-1-g0057031

## Tests
- docker buildx imagetools inspect ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.5-1-g0057031
- kubectl kustomize apps/gcp/cost-insight