### PR TITLE
feat(apps/gcp/dl,apps/prod2/dl): update dl image tag to v2026.6.28-20-g343ff73

### DIFF
--- a/apps/gcp/dl/release.yaml
+++ b/apps/gcp/dl/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/dl
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/dl versioning=docker
-      tag: v2026.6.28-14-g16bd374
+      tag: v2026.6.28-20-g343ff73
     server:
       args:
         - --domain=0.0.0.0:80

--- a/apps/prod2/dl/release.yaml
+++ b/apps/prod2/dl/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/dl
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/dl versioning=docker
-      tag: v2026.6.14-13-gade3d63
+      tag: v2026.6.28-20-g343ff73
     server:
       args: [--ks3-config=/config/ks3.yaml, --oci-config=/config/oci.yaml]
       volumes:


### PR DESCRIPTION
Update DL image tag to `v2026.6.28-20-g343ff73`, which includes features from ee-apps@ade3d63.

Changes:
- `apps/gcp/dl/release.yaml`: `v2026.6.28-14-g16bd374` → `v2026.6.28-20-g343ff73`
- `apps/prod2/dl/release.yaml`: `v2026.6.14-13-gade3d63` → `v2026.6.28-20-g343ff73`