### PR TITLE
chore(apps/gcp/cost-insight): bump jobs image for storage batch token refresh

### DIFF
--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -31,7 +31,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.5-3-g5887e97
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.5-5-g15b244e
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -127,7 +127,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcs-cache-last-seen
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.5-3-g5887e97
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.5-5-g15b244e
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -193,7 +193,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-delete-cas
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.5-3-g5887e97
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.5-5-g15b244e
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -280,7 +280,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.5-3-g5887e97
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.5-5-g15b244e
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -359,7 +359,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.5-3-g5887e97
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.5-5-g15b244e
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -449,7 +449,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.5-3-g5887e97
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.5-5-g15b244e
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh


### PR DESCRIPTION
## Summary
- Rebased on `upstream/main@3647a349` and preserved the cost-insight CronJob cleanup from PingCAP-QE/ee-ops#2097.
- Bump the remaining 6 `apps/gcp/cost-insight` CronJob images to `ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.5-5-g15b244e`.
- Image comes from ee-apps release run https://github.com/PingCAP-QE/ee-apps/actions/runs/28842909629 (`15b244e9c47c321a319ac4d11abbef6fc6eef9ab`, PR PingCAP-QE/ee-apps#566).

## Validation
- `python - <<'PY' ... yaml.safe_load_all('apps/gcp/cost-insight/cronjobs.yaml') ... PY` parsed 6 YAML documents.
- `kubectl kustomize apps/gcp/cost-insight >/tmp/ee-ops-cost-insight-kustomize.yaml` rendered successfully; all 6 rendered images use `v2026.7.5-5-g15b244e`.
- `./scripts/validate_k8s_yaml.sh` currently fails before reaching this app on existing `charts/prow/templates/tests/test-connection.yaml` YAML parse error.
