### PR TITLE
feat(gcp/jenkins): use credentials-binding fork hpi (offline-agent cleanup fix)

### DIFF
--- a/apps/gcp/jenkins/beta/release/staging/values-controller-plugins.yaml
+++ b/apps/gcp/jenkins/beta/release/staging/values-controller-plugins.yaml
@@ -18,6 +18,10 @@ controller:
     - artifact-manager-s3:973.v6a_51253e896b_
     - build-failure-analyzer::https://github.com/PingCAP-QE/build-failure-analyzer-plugin/releases/download/v2.4.2-jobname/build-failure-analyzer.hpi
     - cdevents::https://github.com/dillon-zheng/cdevents-plugin/releases/download/cdevents-1-40-pingcap-1/cdevents-1-40-pingcap-1.hpi
+    # PingCAP fork: skip withCredentials cleanup when the agent is offline, so a lost agent
+    # (e.g. preempted Kubernetes pod) under `retry` no longer fails the build on cleanup.
+    # Ref: jenkinsci/credentials-binding-plugin#530 (fixes #531)
+    - credentials-binding:725.ve52b_2328a_fde-fork.2:https://github.com/wuhuizuo/credentials-binding-plugin/releases/download/725.ve52b_2328a_fde-fork.2/credentials-binding-725.ve52b_2328a_fde-fork.2.hpi
     - generic-webhook-trigger:2.4.1
     - google-login:109.v022b_cf87b_e5b_
     - http_request:1.25

--- a/apps/gcp/jenkins/beta/release/values-controller-plugins.yaml
+++ b/apps/gcp/jenkins/beta/release/values-controller-plugins.yaml
@@ -18,6 +18,10 @@ controller:
     - artifact-manager-s3:973.v6a_51253e896b_
     - build-failure-analyzer::https://github.com/PingCAP-QE/build-failure-analyzer-plugin/releases/download/v2.4.2-jobname/build-failure-analyzer.hpi
     - cdevents::https://github.com/dillon-zheng/cdevents-plugin/releases/download/cdevents-1-40-pingcap-1/cdevents-1-40-pingcap-1.hpi
+    # PingCAP fork: skip withCredentials cleanup when the agent is offline, so a lost agent
+    # (e.g. preempted Kubernetes pod) under `retry` no longer fails the build on cleanup.
+    # Ref: jenkinsci/credentials-binding-plugin#530 (fixes #531)
+    - credentials-binding:725.ve52b_2328a_fde-fork.2:https://github.com/wuhuizuo/credentials-binding-plugin/releases/download/725.ve52b_2328a_fde-fork.2/credentials-binding-725.ve52b_2328a_fde-fork.2.hpi
     - generic-webhook-trigger:2.4.1
     - google-login:109.v022b_cf87b_e5b_
     - http_request:1.25


### PR DESCRIPTION
### What

Switch the GCP Jenkins controllers (prod `release` and `staging`) to the PingCAP fork of the
`credentials-binding` plugin: `725.ve52b_2328a_fde-fork.2`.

Added to `controller.additionalPlugins` in:
- `apps/gcp/jenkins/beta/release/values-controller-plugins.yaml`
- `apps/gcp/jenkins/beta/release/staging/values-controller-plugins.yaml`

### Why

Upstream `credentials-binding` fails a build when a `withCredentials` block's deferred cleanup
runs on an agent that is already gone: it resolves the (missing) workspace `FilePath` and
re-throws `AgentOfflineException`. On our GCP agents (preemptible / node loss) this turns a
recoverable agent loss into a failure and, under `retry`, can become the terminal build result —
so the retried attempt is defeated (observed on `pull_unit_test_next_gen`).

The fork skips the cleanup when the agent is offline (the temporary secret files vanished with
the workspace). Fork is `725.ve52b_2328a_fde` + the one patch; upstream PR/issue below.

- Fork release: https://github.com/wuhuizuo/credentials-binding-plugin/releases/tag/725.ve52b_2328a_fde-fork.2
- Upstream: jenkinsci/credentials-binding-plugin#530 (fixes jenkinsci/credentials-binding-plugin#531)

### Notes

- Same mechanism already used here for the `kubernetes` and `build-failure-analyzer` forks.
- The release `.hpi` asset is public (verified downloadable).
- Rolls out on the next reconcile; revert by removing the two added lines.
