### PR TITLE
chore(cost-insight): modify run CAS cleanup timing

### DIFF
--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -171,8 +171,8 @@ metadata:
     app.kubernetes.io/name: cost-insight-cleanup-gcs-cache-delete-cas
     app.kubernetes.io/part-of: cost-insight
 spec:
-  # Interpreted with timeZone below: daily 22:20 Asia/Shanghai.
-  schedule: "20 22 * * *"
+  # Interpreted with timeZone below: daily 17:10 Asia/Shanghai.
+  schedule: "10 17 * * *"
   timeZone: Asia/Shanghai
   suspend: false
   concurrencyPolicy: Forbid


### PR DESCRIPTION
## Summary
 move cost-insight CAS cleanup CronJob from 22:20 to 17:10 Asia/Shanghai

Test\n- yq e '.kind' apps/gcp/cost-insight/cronjobs.yaml >/dev/null