### PR TITLE
fix(apps/gcp/jenkins): grant jenkins-staging SA agent scheduling rbac

### DIFF
--- a/apps/gcp/jenkins/beta/post/_base/rbac.yaml
+++ b/apps/gcp/jenkins/beta/post/_base/rbac.yaml
@@ -40,3 +40,6 @@ subjects:
   - kind: ServiceAccount
     name: jenkins
     namespace: ${CONTROLLER_NAMESPACE}
+  - kind: ServiceAccount
+    name: jenkins-staging
+    namespace: ${CONTROLLER_NAMESPACE}


### PR DESCRIPTION
## Problem

The GCP staging Jenkins controller fails to launch agents with:

```
pods is forbidden: User "system:serviceaccount:jenkins:jenkins-staging" cannot list resource "pods" in API group "" in the namespace "jenkins-tidb"
```

## Cause

The staging Jenkins controller (HelmRelease `jenkins-staging`, `serviceAccount.create: true`) runs as the `jenkins-staging` service account. However the `jenkins-schedule-agents` RoleBinding shared across agent namespaces (pd/ticdc/tidb/tiflash/tikv) only bound the `jenkins` SA, so `jenkins-staging` lacked permission to list/create pods in the agent namespaces.

## Fix

Add `jenkins-staging` as a subject to the `jenkins-schedule-agents` RoleBinding in `apps/gcp/jenkins/beta/post/_base/rbac.yaml`. Since `_base` is shared by all agent namespaces, the binding applies everywhere after Flux reconciles.