### PR TITLE
feat(apps/gcp/jenkins/staging): pin kubernetes fork 4437.vd64141124d8f-fork.3 for diagnostic logging

### DIFF
--- a/apps/gcp/jenkins/beta/release/staging/values-controller-plugins.yaml
+++ b/apps/gcp/jenkins/beta/release/staging/values-controller-plugins.yaml
@@ -6,7 +6,7 @@ controller:
   # Override the default list to use our own custom plugin
   # Ref: https://artifacthub.io/packages/helm/jenkinsci/jenkins?modal=values&path=controller.installPlugins
   installPlugins:
-    - kubernetes:4437.vd64141124d8f:https://github.com/wuhuizuo/jenkins-kubernetes-plugin/releases/download/4437.vd64141124d8f/kubernetes-4437.vd64141124d8f.hpi
+    - kubernetes:4437.vd64141124d8f-fork.2:https://github.com/wuhuizuo/jenkins-kubernetes-plugin/releases/download/4437.vd64141124d8f-fork.2/kubernetes.hpi
     - workflow-aggregator:608.v67378e9d3db_1
     - git:5.10.1
     - configuration-as-code:2077.v41f1011a_5110

--- a/apps/gcp/jenkins/beta/release/staging/values-controller-plugins.yaml
+++ b/apps/gcp/jenkins/beta/release/staging/values-controller-plugins.yaml
@@ -6,7 +6,7 @@ controller:
   # Override the default list to use our own custom plugin
   # Ref: https://artifacthub.io/packages/helm/jenkinsci/jenkins?modal=values&path=controller.installPlugins
   installPlugins:
-    - kubernetes:4437.vd64141124d8f-fork.2:https://github.com/wuhuizuo/jenkins-kubernetes-plugin/releases/download/4437.vd64141124d8f-fork.2/kubernetes.hpi
+    - kubernetes:4437.vd64141124d8f-fork.3:https://github.com/wuhuizuo/jenkins-kubernetes-plugin/releases/download/4437.vd64141124d8f-fork.3/kubernetes.hpi
     - workflow-aggregator:608.v67378e9d3db_1
     - git:5.10.1
     - configuration-as-code:2077.v41f1011a_5110


### PR DESCRIPTION
Bump kubernetes plugin fork to include CPS closure fix for declarative agent retries.

**Root cause**: KubernetesDeclarativeAgentScript used an intermediate  variable inside podTemplate. CPS failed to properly re-execute this closure on retry — the agent retry provisioned a fresh pod and re-ran SCM checkout, but the body produced no stages, resulting in terminal ABORTED.

**Fix**: Inline the retry + node + checkout body directly (matching LabelScript pattern). Eliminates the intermediate closure variable.

**Fork**: https://github.com/wuhuizuo/jenkins-kubernetes-plugin/releases/tag/4437.vd64141124d8f-fork.2