### PR TITLE
chore(apps/gcp/cost-insight): set CAS retention to 13 days

### DIFF
--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -225,7 +225,7 @@ spec:
                 - name: COST_INSIGHT_GCS_CACHE_AC_RETENTION_DAYS
                   value: "10"
                 - name: COST_INSIGHT_GCS_CACHE_CAS_RETENTION_DAYS
-                  value: "15"
+                  value: "13"
                 - name: COST_INSIGHT_GCS_CACHE_SAFETY_BUFFER_DAYS
                   value: "1"
                 - name: COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_OBJECTS


### PR DESCRIPTION
## Summary
- change cost-insight CAS cleanup retention from 15 days to 13 days\n\n## Test
- yq e '.kind' apps/gcp/cost-insight/cronjobs.yaml >/dev/null