### PR TITLE
feat(prow): add terraform-plan-reader SA and Tencent Cloud creds

### DIFF
--- a/apps/gcp/prow/post/job-ns/rbac.yaml
+++ b/apps/gcp/prow/post/job-ns/rbac.yaml
@@ -38,3 +38,10 @@ metadata:
   name: tidbx-puller
   annotations:
     iam.gke.io/gcp-service-account: tidbx-gar-reader@pingcap-testing-account.iam.gserviceaccount.com
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: terraform-plan-reader
+  annotations:
+    iam.gke.io/gcp-service-account: terraform-plan-reader@pingcap-testing-account.iam.gserviceaccount.com

--- a/apps/gcp/prow/post/job-ns/secrets/kustomization.yaml
+++ b/apps/gcp/prow/post/job-ns/secrets/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - github-token.yaml
   - codecov-token.yaml
   - docs-cn.yaml
+  - tencentcloud-terraform-creds.yaml

--- a/apps/gcp/prow/post/job-ns/secrets/tencentcloud-terraform-creds.yaml
+++ b/apps/gcp/prow/post/job-ns/secrets/tencentcloud-terraform-creds.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: tencentcloud-terraform-creds
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: ee-gcp-sm
+    kind: ClusterSecretStore
+  target:
+    name: tencentcloud-terraform-creds
+    creationPolicy: Owner
+  data:
+    - secretKey: TENCENTCLOUD_SECRET_ID
+      remoteRef:
+        # GCP Secret Manager key name: tencentcloud_ci_terraform_creds
+        # The value must be a JSON object: {"TENCENTCLOUD_SECRET_ID": "...", "TENCENTCLOUD_SECRET_KEY": "..."}
+        key: tencentcloud_ci_terraform_creds
+        property: TENCENTCLOUD_SECRET_ID
+    - secretKey: TENCENTCLOUD_SECRET_KEY
+      remoteRef:
+        key: tencentcloud_ci_terraform_creds
+        property: TENCENTCLOUD_SECRET_KEY


### PR DESCRIPTION
### Summary

Two changes to support CI terraform plan for `ee-infra`:

### 1. K8s SA `terraform-plan-reader`

Adds a new ServiceAccount `prow-test-pods/terraform-plan-reader` with Workload Identity bound to `terraform-plan-reader@pingcap-testing-account.iam.gserviceaccount.com`. This allows CI Prow jobs to read GCP resources for `terraform plan`.

### 2. ExternalSecret `tencentcloud-terraform-creds`

Creates a K8s Secret `tencentcloud-terraform-creds` from GCP Secret Manager key `tencentcloud_ci_terraform_creds`. Contains `TENCENTCLOUD_SECRET_ID` and `TENCENTCLOUD_SECRET_KEY` for use by the Tencent Cloud terraform plan job.

**Prerequisite:** Create the GCP Secret Manager secret before this PR is applied:

```bash
echo -n '{TENCENTCLOUD_SECRET_ID:your-id,TENCENTCLOUD_SECRET_KEY:your-key}' |   gcloud secrets create tencentcloud_ci_terraform_creds     --project=pingcap-testing-account     --data-file=-
```