### PR TITLE
feat(terraform): add Terraform CR for Tencent Cloud tidb-cicd

### DIFF
--- a/infrastructure/gcp/terraform/kustomization.yaml
+++ b/infrastructure/gcp/terraform/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 namespace: flux-system
 resources:
   - gcp-pingcap-testing-account.yaml
+  - tencentcloud-tidb-cicd.yaml

--- a/infrastructure/gcp/terraform/tencentcloud-tidb-cicd.yaml
+++ b/infrastructure/gcp/terraform/tencentcloud-tidb-cicd.yaml
@@ -1,0 +1,30 @@
+# Reference: https://flux-iac.github.io/tofu-controller/
+# This Terraform CR manages resources in Tencent Cloud (ap-beijing).
+# Prerequisites:
+#   1. GCP Secret Manager key: tencentcloud_ci_terraform_creds
+#   2. ExternalSecret tencentcloud-terraform-creds in namespace prow-test-pods
+apiVersion: infra.contrib.fluxcd.io/v1alpha2
+kind: Terraform
+metadata:
+  name: tencentcloud-tidb-cicd
+spec:
+  approvePlan: auto
+  interval: 1h
+  retryInterval: 5m
+  destroyResourcesOnDeletion: true
+  sourceRef:
+    kind: GitRepository
+    name: ee-infra
+    namespace: flux-system
+  path: ./terraform/tencentcloud/tidb-cicd
+  env:
+    - name: TENCENTCLOUD_SECRET_ID
+      valueFrom:
+        secretKeyRef:
+          name: tencentcloud-terraform-creds
+          key: TENCENTCLOUD_SECRET_ID
+    - name: TENCENTCLOUD_SECRET_KEY
+      valueFrom:
+        secretKeyRef:
+          name: tencentcloud-terraform-creds
+          key: TENCENTCLOUD_SECRET_KEY


### PR DESCRIPTION
### Summary

Add a new Terraform CR `tencentcloud-tidb-cicd` to manage Tencent Cloud resources via tofu-controller, mirroring the existing GCP setup.

### Terraform CR

| Field | Value |
|---|---|
| Name | `tencentcloud-tidb-cicd` |
| Source | `ee-infra` GitRepository (`main` branch) |
| Path | `./terraform/tencentcloud/tidb-cicd` |
| Auth | `TENCENTCLOUD_SECRET_ID` / `TENCENTCLOUD_SECRET_KEY` from K8s Secret `tencentcloud-terraform-creds` (created in PR #2111) |
| Approval | Auto |
| State | Local (no remote backend) |