### PR TITLE
fix(infrastructure/gcp/terraform): replace spec.env with spec.runnerPodTemplate for env injection

### DIFF
--- a/infrastructure/gcp/terraform/tencentcloud-tidb-cicd.yaml
+++ b/infrastructure/gcp/terraform/tencentcloud-tidb-cicd.yaml
@@ -17,14 +17,16 @@ spec:
     name: ee-infra
     namespace: flux-system
   path: ./terraform/tencentcloud/tidb-cicd
-  env:
-    - name: TENCENTCLOUD_SECRET_ID
-      valueFrom:
-        secretKeyRef:
-          name: tencentcloud-terraform-creds
-          key: TENCENTCLOUD_SECRET_ID
-    - name: TENCENTCLOUD_SECRET_KEY
-      valueFrom:
-        secretKeyRef:
-          name: tencentcloud-terraform-creds
-          key: TENCENTCLOUD_SECRET_KEY
+  runnerPodTemplate:
+    spec:
+      env:
+        - name: TENCENTCLOUD_SECRET_ID
+          valueFrom:
+            secretKeyRef:
+              name: tencentcloud-terraform-creds
+              key: TENCENTCLOUD_SECRET_ID
+        - name: TENCENTCLOUD_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: tencentcloud-terraform-creds
+              key: TENCENTCLOUD_SECRET_KEY


### PR DESCRIPTION
## Problem

`flux get kustomizations -A --status-selector ready=false` shows `infrastructure` kustomization is not ready:

> Terraform/flux-system/tencentcloud-tidb-cicd dry-run failed: failed to create typed patch object: .spec.env: field not declared in schema

`spec.env` is not a valid field in the Terraform CRD (`infra.contrib.fluxcd.io/v1alpha2`). The CRD schema only supports `spec.runnerPodTemplate` for injecting environment variables into the runner pod.

## Solution

Move the env vars from `spec.env` to `spec.runnerPodTemplate.spec.containers[0].env`.

## Verification

- [ ] After merge, run `flux reconcile kustomization flux-system --with-source` to sync
- [ ] The `apps` kustomization dependency error will resolve automatically once `infrastructure` is healthy