### PR TITLE
fix(infrastructure/gcp/terraform): add ExternalSecret for tencentcloud-terraform-creds in flux-system

### DIFF
--- a/infrastructure/gcp/terraform/kustomization.yaml
+++ b/infrastructure/gcp/terraform/kustomization.yaml
@@ -4,3 +4,4 @@ namespace: flux-system
 resources:
   - gcp-pingcap-testing-account.yaml
   - tencentcloud-tidb-cicd.yaml
+  - tencentcloud-tidb-cicd-creds.yaml

--- a/infrastructure/gcp/terraform/tencentcloud-tidb-cicd-creds.yaml
+++ b/infrastructure/gcp/terraform/tencentcloud-tidb-cicd-creds.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: tencentcloud-terraform-creds
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: ee-gcp-sm
+  target:
+    name: tencentcloud-terraform-creds
+  data:
+    - remoteRef:
+        key: tencentcloud_ci_terraform_creds
+        property: TENCENTCLOUD_SECRET_ID
+      secretKey: TENCENTCLOUD_SECRET_ID
+    - remoteRef:
+        key: tencentcloud_ci_terraform_creds
+        property: TENCENTCLOUD_SECRET_KEY
+      secretKey: TENCENTCLOUD_SECRET_KEY


### PR DESCRIPTION
## Problem

Terraform runner pod `tencentcloud-tidb-cicd-tf-runner` in `flux-system` namespace fails to start:

> Error: secret "tencentcloud-terraform-creds" not found

The ExternalSecret only existed in `prow-test-pods` namespace, but the Terraform CR's `runnerPodTemplate.spec.env` references it from `flux-system`.

## Solution

Add an `ExternalSecret` for `tencentcloud-terraform-creds` in the `flux-system` namespace under the terraform kustomization.