### PR TITLE
chore(cost-insight): raise AC cleanup cap

### DIFF
--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -231,7 +231,7 @@ spec:
                 - name: COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_OBJECTS
                   value: "10000000"
                 - name: COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_AC_OBJECTS
-                  value: "100000"
+                  value: "3000000"
                 - name: COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_CAS_BYTES
                   value: "54975581388800"
                 - name: COST_INSIGHT_GCS_CACHE_CLEANUP_AC_DELETE_BATCH_SIZE


### PR DESCRIPTION
## Summary\n- raise cost-insight CAS cleanup AC cap from 100k to 3,000k\n\n## Test\n- yq e '.kind' apps/gcp/cost-insight/cronjobs.yaml >/dev/null