### PR TITLE
feat(tke): enable Karpenter CR management for tidb-cicd

### DIFF
--- a/infrastructure/gcp/terraform/tencentcloud-tidb-cicd.yaml
+++ b/infrastructure/gcp/terraform/tencentcloud-tidb-cicd.yaml
@@ -12,6 +12,9 @@ spec:
     name: ee-infra
     namespace: flux-system
   path: ./terraform/tencentcloud/tidb-cicd
+  vars:
+    - name: manage_karpenter_cr
+      value: "true"
   runnerPodTemplate:
     spec:
       env:


### PR DESCRIPTION
Pass `manage_karpenter_cr=true` to the Terraform module so that `TKEMachineNodeClass` is created after the TKE cluster exists in state.

ee-infra PR #121 added the variable (default `false`) and the `kubernetes_manifest` resource. This PR enables it.