### PR TITLE
revert: feat(tke): enable Karpenter CR management for tidb-cicd

### DIFF
--- a/infrastructure/gcp/terraform/tencentcloud-tidb-cicd.yaml
+++ b/infrastructure/gcp/terraform/tencentcloud-tidb-cicd.yaml
@@ -12,9 +12,6 @@ spec:
     name: ee-infra
     namespace: flux-system
   path: ./terraform/tencentcloud/tidb-cicd
-  vars:
-    - name: manage_karpenter_cr
-      value: "true"
   runnerPodTemplate:
     spec:
       env:


### PR DESCRIPTION
Revert `manage_karpenter_cr=true` since ee-infra PR #124 removes the variable entirely and replaces it with automatic cluster detection via data source.