### PR TITLE
chore(apps/gcp/cost-insight): let cleanup ac cap use env

### DIFF
--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -203,8 +203,7 @@ spec:
                   cost-insight cleanup-gcs-cache \
                     --mode delete \
                     --execute-kind cas-from-index \
-                    --max-delete-objects 10000000 \
-                    --max-delete-ac-objects 100000
+                    --max-delete-objects 10000000
               env:
                 - name: PYTHONUNBUFFERED
                   value: "1"


### PR DESCRIPTION
## Summary
- remove the `--max-delete-ac-objects` CLI override from the CAS cleanup CronJob
- let `COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_AC_OBJECTS=3000000` from #2118 control the AC cleanup cap

## Test
- `yq e '.kind' apps/gcp/cost-insight/cronjobs.yaml >/dev/null`