### PR TITLE
fix(infrastructure/tencentcloud/node-pools): use instance-family and drop ee-application

### DIFF
--- a/infrastructure/tencentcloud/node-pools/ci-worker.yaml
+++ b/infrastructure/tencentcloud/node-pools/ci-worker.yaml
@@ -18,12 +18,11 @@ spec:
           operator: In
           values:
             - amd64
-            - arm64
         - key: karpenter.sh/capacity-type
           operator: In
           values:
             - on-demand
-        - key: node.kubernetes.io/instance-type
+        - key: karpenter.k8s.tke/instance-family
           operator: In
           values:
             - C6

--- a/infrastructure/tencentcloud/node-pools/kustomization.yaml
+++ b/infrastructure/tencentcloud/node-pools/kustomization.yaml
@@ -2,4 +2,3 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ci-worker.yaml
-  - ee-application.yaml


### PR DESCRIPTION
## What
- ci-worker NodePool: replace `node.kubernetes.io/instance-type` (bare family names, invalid for tke-karpenter) with `karpenter.k8s.tke/instance-family` per official tke-karpenter docs; remove `arm64` since the provider currently only supports `amd64`.
- node-pools kustomization: stop including `ee-application` (its TKEMachineNodeClass does not exist on cluster, leaving the NodePool NotReady).

## Why
Testing showed Karpenter could not provision nodes for ci-worker: `NoCompatibleInstanceTypes` — requirements filtered out all instance types. The bare-family `instance-type` values and the unsupported `arm64` arch were the cause.

## Reference
- tke-karpenter docs (arch only amd64, use instance-family): https://www.tencentcloud.com/document/product/457/64855
- GitHub provider: https://github.com/TencentCloud/karpenter-provider-tke

## Note
Cluster-side `ee-application` NodePool remains as-is (only removed from GitOps include, not deleted). ci-worker was tested end-to-end before this change revealed the config bug.