### PR TITLE
chore(apps/gcp/cost-insight): reduce cas cleanup retention

### DIFF
--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -224,7 +224,7 @@ spec:
                 - name: COST_INSIGHT_GCS_CACHE_AC_RETENTION_DAYS
                   value: "10"
                 - name: COST_INSIGHT_GCS_CACHE_CAS_RETENTION_DAYS
-                  value: "13"
+                  value: "12"
                 - name: COST_INSIGHT_GCS_CACHE_SAFETY_BUFFER_DAYS
                   value: "1"
                 - name: COST_INSIGHT_GCS_CACHE_CLEANUP_MAX_DELETE_OBJECTS


### PR DESCRIPTION
## Summary
- reduce `COST_INSIGHT_GCS_CACHE_CAS_RETENTION_DAYS` from 13 to 12 for the CAS cleanup CronJob
- keep `COST_INSIGHT_GCS_CACHE_SAFETY_BUFFER_DAYS=1`, so the effective CAS cold threshold becomes about 13 days

## Test
- `yq e '.kind' apps/gcp/cost-insight/cronjobs.yaml >/dev/null`