### PR TITLE
feat(infrastructure/tencentcloud): add pod cleaners for OOMKilled and NotReady pods

### DIFF
--- a/infrastructure/tencentcloud/cleaners/kustomization.yaml
+++ b/infrastructure/tencentcloud/cleaners/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: infra
 resources:
-  - namespace.yaml
-  - kyverno/
-  - node-pools/
-  - cleaners/
+  - pod-cleaner

--- a/infrastructure/tencentcloud/cleaners/pod-cleaner/cronjob-notready-cleaner.yaml
+++ b/infrastructure/tencentcloud/cleaners/pod-cleaner/cronjob-notready-cleaner.yaml
@@ -1,0 +1,37 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: notready-pod-cleaner
+spec:
+  schedule: "0 * * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: pod-cleaner
+          containers:
+            - name: kubectl-container
+              image: bitnami/kubectl:latest
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  #!/usr/bin/env bash
+                  set -eo pipefail
+
+                  echo "Starting cleanup of NotReady pods with ready container count > 0 and age > 3 hours..."
+                  kubectl get pods -A -o json | jq -r '
+                    .items[] |
+                    select(
+                      (.status.conditions[] | select(.type=="Ready" and .status=="False")) and
+                      (.status.containerStatuses[]? | select(.ready == true)) and
+                      (.metadata.creationTimestamp | fromdateiso8601 < (now - 10800))
+                    ) |
+                    .metadata.namespace + " " + .metadata.name
+                  ' | while read -r ns name; do
+                    echo "Deleting pod $ns/$name due to NotReady status with ready containers and age > 3 hours"
+                    kubectl delete pod "$name" -n "$ns" --wait=false
+                  done
+                  echo "Cleanup complete."
+          restartPolicy: OnFailure

--- a/infrastructure/tencentcloud/cleaners/pod-cleaner/cronjob-oom-cleaner.yaml
+++ b/infrastructure/tencentcloud/cleaners/pod-cleaner/cronjob-oom-cleaner.yaml
@@ -1,0 +1,29 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: oomkilled-pod-cleaner
+spec:
+  schedule: "*/10 * * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: pod-cleaner
+          containers:
+            - name: kubectl-container
+              image: bitnami/kubectl:latest
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  #!/usr/bin/env bash
+                  set -eo pipefail
+
+                  echo "Starting cleanup of OOMKilled pods..."
+                  kubectl get pods -A -o json | jq -r '.items[] | select(.status.containerStatuses[]?.lastState.terminated.reason=="OOMKilled" or .status.containerStatuses[]?.state.terminated.reason=="OOMKilled") | .metadata.namespace + " " + .metadata.name' | while read -r ns name; do
+                    echo "Deleting pod $ns/$name due to OOMKilled status"
+                    kubectl delete pod "$name" -n "$ns" --wait=false
+                  done
+                  echo "Cleanup complete."
+          restartPolicy: OnFailure

--- a/infrastructure/tencentcloud/cleaners/pod-cleaner/kustomization.yaml
+++ b/infrastructure/tencentcloud/cleaners/pod-cleaner/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rbac.yaml
+  - cronjob-oom-cleaner.yaml
+  - cronjob-notready-cleaner.yaml

--- a/infrastructure/tencentcloud/cleaners/pod-cleaner/rbac.yaml
+++ b/infrastructure/tencentcloud/cleaners/pod-cleaner/rbac.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pod-cleaner
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pod-cleaner-role
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: pod-cleaner-binding
+subjects:
+  - kind: ServiceAccount
+    name: pod-cleaner
+roleRef:
+  kind: ClusterRole
+  name: pod-cleaner-role
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Add pod cleaner CronJobs to automatically clean up:

- **OOMKilled pods**: Runs every 10 minutes, deletes pods with OOMKilled termination reason
- **NotReady pods**: Runs hourly, deletes pods that are NotReady but have ready containers and are older than 3 hours

Includes RBAC (ServiceAccount, ClusterRole, ClusterRoleBinding) for pod cleanup permissions.