### PR TITLE
refactor(secrets): migrate github secrets to use shared GCP SM keys

### DIFF
--- a/apps/gcp/jenkins/beta/pre.yaml
+++ b/apps/gcp/jenkins/beta/pre.yaml
@@ -16,7 +16,6 @@ spec:
     substitute:
       GOOGLE_OAUTH_JSON: prod2_jenkins_beta_google_oauth_json
       JENKINS_CACHE_S3_JSON: gcp_jenkins_cache_s3_json
-      GITHUB_SECRET_JSON: prod2_jenkins_beta_github_json
       CODECOV_TOKENS_JSON: prod2_jenkins_beta_codecov_tokens_json
       HARBOR_CREDENTIALS_JSON: prod2_jenkins_beta_harbor_credentials_json
       DOCS_CN_S3_JSON: prod2_jenkins_beta_docs_cn_s3_json

--- a/apps/gcp/jenkins/beta/pre/secret-github.yaml
+++ b/apps/gcp/jenkins/beta/pre/secret-github.yaml
@@ -10,11 +10,17 @@ spec:
   target:
     name: github
     creationPolicy: Owner
-  dataFrom:
-    - extract:
-        # json object include keys:
-        # - git-private-key
-        # - git-username
-        # - bot-token
-        # - pr-diff-token
-        key: "${GITHUB_SECRET_JSON}"
+  data:
+    - secretKey: git-username
+      remoteRef:
+        key: github-bot-username
+    - secretKey: bot-token
+      remoteRef:
+        key: github-bot-token
+    - secretKey: pr-diff-token
+      remoteRef:
+        key: github-bot-token
+    - secretKey: git-private-key
+      remoteRef:
+        key: github-bot-ssh-rsa-json
+        property: ssh-privatekey

--- a/apps/gcp/tekton/configs/secrets/github-pat-secret.yaml
+++ b/apps/gcp/tekton/configs/secrets/github-pat-secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: github-pat-secret
+spec:
+  secretStoreRef:
+    name: ee-gcp-sm
+    kind: ClusterSecretStore
+  target:
+    name: github-pat-secret
+    template:
+      type: kubernetes.io/basic-auth
+      metadata:
+        annotations:
+          tekton.dev/git-0: https://github.com
+  data:
+    - secretKey: username
+      remoteRef:
+        key: github-bot-username
+    - secretKey: password
+      remoteRef:
+        key: github-bot-token
+  refreshInterval: 1h

--- a/apps/gcp/tekton/configs/secrets/github-ssh-secret.yaml
+++ b/apps/gcp/tekton/configs/secrets/github-ssh-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: github-ssh-secret
+spec:
+  secretStoreRef:
+    name: ee-gcp-sm
+    kind: ClusterSecretStore
+  target:
+    name: github-ssh-secret
+    template:
+      type: kubernetes.io/ssh-auth
+      metadata:
+        annotations:
+          tekton.dev/git-0: github.com
+  dataFrom:
+    - extract:
+        # json object contains keys: `ssh-privatekey`, `ssh-publickey`.
+        key: github-bot-ssh-rsa-json
+  refreshInterval: 1h

--- a/apps/gcp/tekton/configs/secrets/kustomization.yaml
+++ b/apps/gcp/tekton/configs/secrets/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - github.yaml
+  - github-pat-secret.yaml
+  - github-ssh-secret.yaml
   - image-delivery-notify-config-tidbx.yaml
   - image-delivery-ops-config-tidbx.yaml
   - image-release-cred.yaml

--- a/apps/prod2/jenkins/beta/pre.yaml
+++ b/apps/prod2/jenkins/beta/pre.yaml
@@ -16,7 +16,6 @@ spec:
     substitute:
       GOOGLE_OAUTH_JSON: prod2_jenkins_beta_google_oauth_json
       JENKINS_CACHE_S3_JSON: prod2_jenkins_beta_ks3_json
-      GITHUB_SECRET_JSON: prod2_jenkins_beta_github_json
       CODECOV_TOKENS_JSON: prod2_jenkins_beta_codecov_tokens_json
       HARBOR_CREDENTIALS_JSON: prod2_jenkins_beta_harbor_credentials_json
       DOCS_CN_S3_JSON: prod2_jenkins_beta_docs_cn_s3_json

--- a/apps/prod2/jenkins/beta/pre/secret-github.yaml
+++ b/apps/prod2/jenkins/beta/pre/secret-github.yaml
@@ -10,11 +10,17 @@ spec:
   target:
     name: github
     creationPolicy: Owner
-  dataFrom:
-    - extract:
-        # json object include keys:
-        # - git-private-key
-        # - git-username
-        # - bot-token
-        # - pr-diff-token
-        key: "${GITHUB_SECRET_JSON}"
+  data:
+    - secretKey: git-username
+      remoteRef:
+        key: github-bot-username
+    - secretKey: bot-token
+      remoteRef:
+        key: github-bot-token
+    - secretKey: pr-diff-token
+      remoteRef:
+        key: github-bot-token
+    - secretKey: git-private-key
+      remoteRef:
+        key: github-bot-ssh-rsa-json
+        property: ssh-privatekey


### PR DESCRIPTION
### Summary

Unify `github-ssh-secret`, `github-pat-secret` (Tekton) and Jenkins `github` secret to sync from shared GCP Secret Manager keys (`github-bot-username`, `github-bot-token`, `github-bot-ssh-rsa-json`), consistent with prod2 cluster.

### Changes

| File | Change |
|------|--------|
| `apps/gcp/tekton/configs/secrets/github-ssh-secret.yaml` | **New** — ExternalSecret syncing from `github-bot-ssh-rsa-json` |
| `apps/gcp/tekton/configs/secrets/github-pat-secret.yaml` | **New** — ExternalSecret syncing from `github-bot-username`/`github-bot-token` |
| `apps/gcp/tekton/configs/secrets/kustomization.yaml` | Add both new files to resources |
| `apps/gcp/jenkins/beta/pre/secret-github.yaml` | Switch from combined JSON to individual keys, drop `GITHUB_SECRET_JSON` |
| `apps/prod2/jenkins/beta/pre/secret-github.yaml` | Same as above |
| `apps/gcp/jenkins/beta/pre.yaml` | Remove unused `GITHUB_SECRET_JSON` variable |
| `apps/prod2/jenkins/beta/pre.yaml` | Remove unused `GITHUB_SECRET_JSON` variable |

### Data Mapping

```
GCP SM key                          → K8s secret key
────────────────────────────────────────────────────────
github-bot-username                  → git-username (Jenkins)
github-bot-token                     → bot-token, pr-diff-token (Jenkins)
github-bot-ssh-rsa-json[ssh-privatekey] → git-private-key (Jenkins)
github-bot-username                  → username (Tekton PAT)
github-bot-token                     → password (Tekton PAT)
github-bot-ssh-rsa-json              → ssh-privatekey, ssh-publickey (Tekton SSH)
```

### Notes

- `github-bot-ssh-rsa-json`, `github-bot-username`, `github-bot-token` already exist in GCP Secret Manager
- `ee-gcp-sm` ClusterSecretStore is ready on the GCP cluster
- Jenkins `pr-diff-token` uses the same value as `bot-token` (matches current behavior)