### PR TITLE
feat(apps/gcp/publisher,apps/prod2/publisher): bump images to v2026.7.19-5-gbdd4a4e and add schema_manager

### DIFF
--- a/apps/gcp/publisher/external-secrets/publisher-server-config.yaml
+++ b/apps/gcp/publisher/external-secrets/publisher-server-config.yaml
@@ -53,6 +53,10 @@ spec:
                   cluster_type: SHARED_POOL
                   base_image: us.gcr.io/pingcap-public/tidbx/tikv
                   github_repo: tidbcloud/cloud-storage-engine
+                schema_manager:
+                  cluster_type: SHARED_POOL
+                  base_image: us.gcr.io/pingcap-public/tidbx/tikv
+                  github_repo: tidbcloud/cloud-storage-engine
                 pd:
                   cluster_type: SHARED_POOL
                   base_image: us.gcr.io/pingcap-public/tidbx/pd

--- a/apps/gcp/publisher/releases/publisher.yaml
+++ b/apps/gcp/publisher/releases/publisher.yaml
@@ -25,7 +25,7 @@ spec:
     # Additional volumes on the output Deployment definition.
     image:
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/publisher versioning=semver
-      tag: v2026.6.21-25-g33ef990
+      tag: v2026.7.19-5-gbdd4a4e
     resources:
       limits:
         cpu: 500m

--- a/apps/gcp/publisher/releases/worker-tiup-prod.yaml
+++ b/apps/gcp/publisher/releases/worker-tiup-prod.yaml
@@ -25,7 +25,7 @@ spec:
     # Additional volumes on the output Deployment definition.
     image:
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/publisher-worker versioning=semver
-      tag: v2026.5.10-2-g5345963
+      tag: v2026.7.19-5-gbdd4a4e
     resources:
       requests:
         cpu: 250m

--- a/apps/gcp/publisher/releases/worker-tiup-staging.yaml
+++ b/apps/gcp/publisher/releases/worker-tiup-staging.yaml
@@ -25,7 +25,7 @@ spec:
     # Additional volumes on the output Deployment definition.
     image:
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/publisher-worker versioning=semver
-      tag: v2026.5.10-2-g5345963
+      tag: v2026.7.19-5-gbdd4a4e
     resources:
       requests:
         cpu: 250m

--- a/apps/prod2/publisher/external-secrets/publisher-server-config.yaml
+++ b/apps/prod2/publisher/external-secrets/publisher-server-config.yaml
@@ -53,6 +53,10 @@ spec:
                   cluster_type: SHARED_POOL
                   base_image: us.gcr.io/pingcap-public/tidbx/tikv
                   github_repo: tidbcloud/cloud-storage-engine
+                schema_manager:
+                  cluster_type: SHARED_POOL
+                  base_image: us.gcr.io/pingcap-public/tidbx/tikv
+                  github_repo: tidbcloud/cloud-storage-engine
                 pd:
                   cluster_type: SHARED_POOL
                   base_image: us.gcr.io/pingcap-public/tidbx/pd

--- a/apps/prod2/publisher/releases/publisher.yaml
+++ b/apps/prod2/publisher/releases/publisher.yaml
@@ -25,7 +25,7 @@ spec:
     # Additional volumes on the output Deployment definition.
     image:
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/publisher versioning=semver
-      tag: v2026.6.21-25-g33ef990
+      tag: v2026.7.19-5-gbdd4a4e
     resources:
       limits:
         cpu: 500m

--- a/apps/prod2/publisher/releases/worker-tiup-fileserver.yaml
+++ b/apps/prod2/publisher/releases/worker-tiup-fileserver.yaml
@@ -25,7 +25,7 @@ spec:
     # Additional volumes on the output Deployment definition.
     image:
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/publisher-worker versioning=semver
-      tag: v2026.3.15-3-g628a93d
+      tag: v2026.7.19-5-gbdd4a4e
     resources:
       limits:
         cpu: "1"

--- a/apps/prod2/publisher/releases/worker-tiup-prod.yaml
+++ b/apps/prod2/publisher/releases/worker-tiup-prod.yaml
@@ -25,7 +25,7 @@ spec:
     # Additional volumes on the output Deployment definition.
     image:
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/publisher-worker versioning=semver
-      tag: v2026.3.15-3-g628a93d
+      tag: v2026.7.19-5-gbdd4a4e
     resources:
       limits:
         cpu: "1"

--- a/apps/prod2/publisher/releases/worker-tiup-staging.yaml
+++ b/apps/prod2/publisher/releases/worker-tiup-staging.yaml
@@ -25,7 +25,7 @@ spec:
     # Additional volumes on the output Deployment definition.
     image:
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/publisher-worker versioning=semver
-      tag: v2026.3.15-3-g628a93d
+      tag: v2026.7.19-5-gbdd4a4e
     resources:
       limits:
         cpu: "1"


### PR DESCRIPTION
### Changes

1. **Bump publisher images** to the latest tag `v2026.7.19-5-gbdd4a4e`:
   - Publisher server (both gcp and prod2)
   - Publisher workers: tiup-prod, tiup-staging (gcp), fileserver (prod2)

2. **Add `schema_manager` component** under tidbcloud stages in publisher-server-config (both gcp and prod2):
   - `cluster_type`: SHARED_POOL
   - `base_image`: `us.gcr.io/pingcap-public/tidbx/tikv`
   - `github_repo`: `tidbcloud/cloud-storage-engine`