### PR TITLE
chore(dashboard): update ee-apps release tags

### DIFF
--- a/apps/gcp/ci-dashboard/release.yaml
+++ b/apps/gcp/ci-dashboard/release.yaml
@@ -35,7 +35,7 @@ spec:
     image:
       repository: ghcr.io/pingcap-qe/ee-apps/ci-dashboard
       # renovate: datasource=docker depName=ghcr.io/pingcap-qe/ee-apps/ci-dashboard versioning=semver
-      tag: v2026.7.19-6-ge88ded8
+      tag: v2026.7.26-1-geabc587
     resources:
       requests:
         cpu: "2"

--- a/apps/gcp/cost-insight/cronjobs.yaml
+++ b/apps/gcp/cost-insight/cronjobs.yaml
@@ -31,7 +31,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.19-4-g4bf26ea
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.26-1-geabc587
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -127,7 +127,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcs-cache-last-seen
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.19-4-g4bf26ea
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.26-1-geabc587
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -193,7 +193,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: cleanup-gcs-cache-delete-cas
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.19-4-g4bf26ea
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.26-1-geabc587
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -279,7 +279,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-gcp-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.19-4-g4bf26ea
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.26-1-geabc587
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -358,7 +358,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-billing-summary
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.19-4-g4bf26ea
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.26-1-geabc587
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
@@ -448,7 +448,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: sync-aws-unmatched-resources
-              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.19-4-g4bf26ea
+              image: ghcr.io/pingcap-qe/ee-apps/cost-insight-jobs:v2026.7.26-1-geabc587
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh


### PR DESCRIPTION
Bump ee-ops manifests to the ee-apps release image from run 30231571322.\n\n- ci-dashboard: v2026.7.26-1-geabc587\n- cost-insight jobs: v2026.7.26-1-geabc587