### PR TITLE
feat(infrastructure/tencentcloud): add strimzi kafka operator

### DIFF
--- a/infrastructure/tencentcloud/operators/kafka/kustomization.yaml
+++ b/infrastructure/tencentcloud/operators/kafka/kustomization.yaml
@@ -2,9 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
-  - kyverno
-  - external-secrets
-  - node-pools
-  - cleaners
-  - gateways
-  - operators
+  - operator-release.yaml

--- a/infrastructure/tencentcloud/operators/kafka/namespace.yaml
+++ b/infrastructure/tencentcloud/operators/kafka/namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kafka-operator
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kafka

--- a/infrastructure/tencentcloud/operators/kafka/operator-release.yaml
+++ b/infrastructure/tencentcloud/operators/kafka/operator-release.yaml
@@ -1,0 +1,21 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: strimzi-kafka-operator
+  namespace: kafka-operator
+spec:
+  chart:
+    spec:
+      chart: strimzi-kafka-operator
+      version: 0.49.0
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: strimzi
+        namespace: flux-system
+  interval: 5m0s
+  values:
+    replicas: 2
+    watchAnyNamespace: true
+    nodeSelector:
+      compute-class: ee-application

--- a/infrastructure/tencentcloud/operators/kustomization.yaml
+++ b/infrastructure/tencentcloud/operators/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kafka


### PR DESCRIPTION
Add Strimzi Kafka operator to the tencentcloud cluster, mirroring the setup from infrastructure/gcp.

**Changes:**
- Add `infrastructure/tencentcloud/operators/` directory with kafka operator HelmRelease
- Creates `kafka-operator` and `kafka` namespaces
- Installs strimzi-kafka-operator v0.49.0 with 2 replicas and watchAnyNamespace enabled
- Wire `operators` into the tencentcloud infrastructure kustomization