### PR TITLE
fix(apps/tencentcloud/cloudevents-server): add missing lark segment in ExternalSecret rewrite target

### DIFF
--- a/apps/tencentcloud/cloudevents-server/external-secret.yaml
+++ b/apps/tencentcloud/cloudevents-server/external-secret.yaml
@@ -72,4 +72,4 @@ spec:
       rewrite:
         - regexp:
             source: "(.*)"
-            target: "tekton_notify_$1"
+            target: "tekton_notify_lark_$1"


### PR DESCRIPTION
## Problem

ExternalSecret `cloudevents-server-config` rewrite target was `tekton_notify_$1`, producing keys like `tekton_notify_app_id`. But the template references `tekton_notify_lark_app_id` (with `_lark_` segment). This caused template execution failure and the Kubernetes Secret was never created, blocking the cloudevents-server pod from starting.

## Fix

Change rewrite target from `tekton_notify_$1` to `tekton_notify_lark_$1` to match template expectations.