### PR TITLE
feat(apps/tencentcloud/cluster-policies): add replace-quay-registry mutating policy to redirect quay.io images to tencentcloud mirror

### DIFF
--- a/apps/tencentcloud/cluster-policies/kustomization.yaml
+++ b/apps/tencentcloud/cluster-policies/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - replace-ghcr-registry.yaml
+  - replace-quay-registry.yaml
   - make-application-pods-run-on-low-cost-nodes.yaml

--- a/apps/tencentcloud/cluster-policies/replace-quay-registry.yaml
+++ b/apps/tencentcloud/cluster-policies/replace-quay-registry.yaml
@@ -1,0 +1,49 @@
+#yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/kyverno/refs/heads/main/config/crds/crds/policies.kyverno.io_mutatingpolicies.yaml
+apiVersion: policies.kyverno.io/v1
+kind: MutatingPolicy
+metadata:
+  name: replace-quay-registry
+spec:
+  evaluation:
+    admission:
+      enabled: true
+    mutateExisting:
+      enabled: false
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["pods"]
+  matchConditions:
+    - name: is-pod
+      expression: "object.kind == 'Pod'"
+    - name: no-image-pull-secrets
+      expression: "!has(object.spec.imagePullSecrets) || size(object.spec.imagePullSecrets) == 0"
+  mutations:
+    - patchType: JSONPatch
+      jsonPatch:
+        expression: |
+          has(object.spec.containers) ?
+          object.spec.containers.map(c,
+            c.image.startsWith("quay.io/") ?
+            JSONPatch{
+              op: "replace",
+              path: "/spec/containers/" + string(object.spec.containers.indexOf(c)) + "/image",
+              value: c.image.replace("quay.io/", "quay.tencentcloudcr.com/")
+            } : null
+          ).filter(p, p != null) :
+          []
+    - patchType: JSONPatch
+      jsonPatch:
+        expression: |
+          has(object.spec.initContainers) ?
+          object.spec.initContainers.map(c,
+            c.image.startsWith("quay.io/") ?
+            JSONPatch{
+              op: "replace",
+              path: "/spec/initContainers/" + string(object.spec.initContainers.indexOf(c)) + "/image",
+              value: c.image.replace("quay.io/", "quay.tencentcloudcr.com/")
+            } : null
+          ).filter(p, p != null) :
+          []


### PR DESCRIPTION
Add a Kyverno MutatingPolicy that replaces `quay.io/` with `quay.tencentcloudcr.com/` in container and initContainer images, similar to the existing `replace-ghcr-registry` policy.