### PR TITLE
fix(apps/tencentcloud,apps/gcp): add resource requests/limits for Kafka KafkaNodePools

### DIFF
--- a/apps/gcp/kafka/cluster.yaml
+++ b/apps/gcp/kafka/cluster.yaml
@@ -8,6 +8,13 @@ spec:
   replicas: 3
   roles:
     - controller
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
   storage:
     type: jbod
     volumes:
@@ -28,6 +35,13 @@ spec:
   replicas: 3
   roles:
     - broker
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 1000m
+      memory: 2Gi
   storage:
     type: jbod
     volumes:

--- a/apps/tencentcloud/kafka/cluster.yaml
+++ b/apps/tencentcloud/kafka/cluster.yaml
@@ -8,6 +8,13 @@ spec:
   replicas: 3
   roles:
     - controller
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
   storage:
     type: jbod
     volumes:
@@ -28,6 +35,13 @@ spec:
   replicas: 3
   roles:
     - broker
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 1000m
+      memory: 2Gi
   storage:
     type: jbod
     volumes:


### PR DESCRIPTION
## Problem

Kafka pods had BestEffort QoS (no resource requests/limits), allowing Karpenter to schedule them on undersized SA3.MEDIUM2 (2GB) nodes. This caused **System OOM** → java (Kafka) killed → container runtime down → kubelet stopped posting → node NotReady.

Confirmed on tencentcloud cluster node 10.0.7.13:
```
Warning  SystemOOM  System OOM encountered, victim process: java, pid: 78123
```

## Fix

Add `resources` to KafkaNodePool specs for both tencentcloud and gcp:

| NodePool | requests (cpu/mem) | limits (cpu/mem) |
|----------|--------------------|-------------------|
| controller-cd | 200m / 512Mi | 500m / 1Gi |
| broker-cd | 500m / 1Gi | 1000m / 2Gi |

With proper requests, Karpenter will provision appropriately-sized nodes and prevent OOM.