### PR TITLE
fix(apps/tencentcloud/cluster-policies): add default resource requests for containers without resources via Kyverno

### DIFF
--- a/apps/tencentcloud/cluster-policies/make-application-pods-run-on-low-cost-nodes.yaml
+++ b/apps/tencentcloud/cluster-policies/make-application-pods-run-on-low-cost-nodes.yaml
@@ -37,3 +37,23 @@ spec:
               value: {"compute-class": "ee-application"}
             }
           ]
+    - patchType: JSONPatch
+      jsonPatch:
+        expression: |
+          object.spec.containers.map(c, i,
+            has(c.resources) && has(c.resources.requests) && has(c.resources.requests.cpu) ?
+            null :
+            (
+              has(c.resources) ?
+              JSONPatch{
+                op: "add",
+                path: sprintf("/spec/containers/%d/resources/requests", [i]),
+                value: {"cpu": "100m", "memory": "200Mi"}
+              } :
+              JSONPatch{
+                op: "add",
+                path: sprintf("/spec/containers/%d/resources", [i]),
+                value: {"requests": {"cpu": "100m", "memory": "200Mi"}}
+              }
+            )
+          ).filter(p, p != null)

--- a/apps/tencentcloud/cluster-policies/make-application-pods-run-on-low-cost-nodes.yaml
+++ b/apps/tencentcloud/cluster-policies/make-application-pods-run-on-low-cost-nodes.yaml
@@ -41,19 +41,11 @@ spec:
       jsonPatch:
         expression: |
           object.spec.containers.map(c, i,
-            has(c.resources) && has(c.resources.requests) && has(c.resources.requests.cpu) ?
+            has(c.resources) ?
             null :
-            (
-              has(c.resources) ?
-              JSONPatch{
-                op: "add",
-                path: sprintf("/spec/containers/%d/resources/requests", [i]),
-                value: {"cpu": "100m", "memory": "200Mi"}
-              } :
-              JSONPatch{
-                op: "add",
-                path: sprintf("/spec/containers/%d/resources", [i]),
-                value: {"requests": {"cpu": "100m", "memory": "200Mi"}}
-              }
-            )
+            JSONPatch{
+              op: "add",
+              path: sprintf("/spec/containers/%d/resources", [i]),
+              value: {"requests": {"cpu": "100m", "memory": "200Mi"}}
+            }
           ).filter(p, p != null)


### PR DESCRIPTION
## Problem

9 Tekton-pipelines deployments run as BestEffort (no resource requests/limits). They are created by Tekton Operator via `TektonInstallerSet`, outside of Flux Kustomization control, so Flux patches cannot reach them.

## Fix

Add a Kyverno `MutatingPolicy` mutation that sets default resource requests for containers that have no resources configured. This applies at pod admission time (CREATE/UPDATE) for all namespaces in the existing policy scope (tekton-pipelines, kafka, etc.).

### How it works

For each container in a pod that has no `resources` at all, the mutation injects:
```yaml
resources:
  requests:
    cpu: 100m
    memory: 200Mi
```

Containers that already have resources (even partial) are not affected.

### Note

Existing pods will NOT be retroactively mutated (`mutateExisting: false`). They will get resources on next recreate (e.g., deployment rollout or operator reconciliation).