### PR TITLE
feat(infrastructure/tencentcloud): add EnvoyProxy config with security group for public gateway

### DIFF
--- a/clusters/tencentcloud/01-infrastructure.yaml
+++ b/clusters/tencentcloud/01-infrastructure.yaml
@@ -13,3 +13,6 @@ spec:
     name: flux-system
   path: ./infrastructure/tencentcloud
   prune: true
+  postBuild:
+    substitute:
+      security_group_id: sg-ijmyqquv

--- a/infrastructure/tencentcloud/gateways/config/envoy-proxy-public.yaml
+++ b/infrastructure/tencentcloud/gateways/config/envoy-proxy-public.yaml
@@ -1,0 +1,12 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: external-https-proxy
+  namespace: infra
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyService:
+        annotations:
+          service.cloud.tencent.com/security-group-id: "${security_group_id}"

--- a/infrastructure/tencentcloud/gateways/config/gateway-public.yaml
+++ b/infrastructure/tencentcloud/gateways/config/gateway-public.yaml
@@ -3,6 +3,11 @@ kind: Gateway
 metadata:
   name: external-https
 spec:
+  infrastructure:
+    parametersRef:
+      group: gateway.envoyproxy.io
+      kind: EnvoyProxy
+      name: external-https-proxy
   gatewayClassName: envoy-gateway
   listeners:
     - name: wildcard-pingcap-net-https

--- a/infrastructure/tencentcloud/gateways/config/kustomization.yaml
+++ b/infrastructure/tencentcloud/gateways/config/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - gatewayclass.yaml
   - gateway-public.yaml
+  - envoy-proxy-public.yaml


### PR DESCRIPTION
Add EnvoyProxy configuration with security group injection for public gateway.

**Changes:**
- `clusters/tencentcloud/01-infrastructure.yaml`: add `postBuild.substitute` for `security_group_id`
- `infrastructure/tencentcloud/gateways/config/envoy-proxy-public.yaml`: new EnvoyProxy resource with security group annotation via variable substitution
- `infrastructure/tencentcloud/gateways/config/gateway-public.yaml`: reference EnvoyProxy in Gateway spec
- `infrastructure/tencentcloud/gateways/config/kustomization.yaml`: register new resource