### PR TITLE
feat(apps/tencentcloud/cache): move brc from prod2 to tencentcloud with COS S3 storage

### DIFF
--- a/apps/prod2/cluster-policies/avoid-application-pods-run-on-arm64-nodes.yaml
+++ b/apps/prod2/cluster-policies/avoid-application-pods-run-on-arm64-nodes.yaml
@@ -11,7 +11,6 @@ spec:
             - Pod
           namespaces:
             - apps
-            - brc
             - buildbarn
             - cache
             - cs

--- a/apps/tencentcloud/cache/brc.yaml
+++ b/apps/tencentcloud/cache/brc.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cache-release
+spec:
+  targetNamespace: cache
+  interval: 5m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./apps/tencentcloud/cache/brc
+  prune: true
+  postBuild:
+    substitute:
+      COS_BUCKET: <bucket-name-appid>
+      COS_REGION: ap-beijing
+      COS_PREFIX: brc
+      COS_CREDENTIALS_JSON: tencentcloud_common_creds_json

--- a/apps/tencentcloud/cache/brc.yaml
+++ b/apps/tencentcloud/cache/brc.yaml
@@ -14,7 +14,7 @@ spec:
   prune: true
   postBuild:
     substitute:
-      COS_BUCKET: <bucket-name-appid>
+      COS_BUCKET: ee-brc-1453452848
       COS_REGION: ap-beijing
       COS_PREFIX: brc
       COS_CREDENTIALS_JSON: tencentcloud_common_creds_json

--- a/apps/tencentcloud/cache/brc/external-secret.yaml
+++ b/apps/tencentcloud/cache/brc/external-secret.yaml
@@ -1,0 +1,27 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: brc-cos-credentials
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: ee-gcp-sm
+    kind: ClusterSecretStore
+  target:
+    name: brc-cos-credentials
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        # AWS-style credentials file, consumed via s3.auth_method: credentials_file
+        # https://github.com/buchgr/bazel-remote#example-configuration-file
+        credentials: |
+          [brc]
+          aws_access_key_id = {{ .accessKey }}
+          aws_secret_access_key = {{ .accessSecret }}
+  dataFrom:
+    - extract:
+        # GCP Secret Manager JSON object with `accessKey` and `accessSecret`.
+        # e.g. jq -n '{access_key_id: $id, secret_access_key: $key}' | \
+        #      gcloud secrets create tencentcloud_brc_cos_credentials_json --data-file=-
+        key: "${COS_CREDENTIALS_JSON}"

--- a/apps/tencentcloud/cache/brc/kustomization.yaml
+++ b/apps/tencentcloud/cache/brc/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: cache
 resources:
+  - external-secret.yaml
   - pvc-cache.yaml
   - release.yaml

--- a/apps/tencentcloud/cache/brc/pvc-cache.yaml
+++ b/apps/tencentcloud/cache/brc/pvc-cache.yaml
@@ -7,6 +7,6 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1.1Ti
-  storageClassName: openebs-single-replica
+      storage: 100Gi
+  storageClassName: cbs
   volumeMode: Filesystem

--- a/apps/tencentcloud/cache/brc/release.yaml
+++ b/apps/tencentcloud/cache/brc/release.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: brc
@@ -28,26 +28,39 @@ spec:
       fsGroup: 1000
     nodeSelector:
       kubernetes.io/arch: amd64
+      compute-class: ee-application
     conf: |-
       # https://github.com/buchgr/bazel-remote#example-configuration-file
       dir: /data
-      max_size: 1000 # The maximum size of bazel-remote's disk cache in GiB.
+      max_size: 100 # The maximum size of bazel-remote's local disk cache in GiB.
       experimental_remote_asset_api: true
       access_log_level: all
       http_address: ":8080"
       grpc_address: ":9092"
       log_timezone: UTC
-      #s3_proxy:
-      #  endpoint: ks3-endpoint:9000
-      #  bucket: test-bucket
-      #  prefix: test-prefix
-      #  disable_ssl: true
-      #  bucket_lookup_type: auto
+      s3_proxy:
+        # Tencent COS only supports virtual-hosted-style addressing:
+        # https://<bucket>.cos.<region>.myqcloud.com
+        endpoint: cos.${COS_REGION}.myqcloud.com
+        bucket: ${COS_BUCKET}
+        prefix: ${COS_PREFIX}
+        region: ${COS_REGION}
+        auth_method: credentials_file
+        aws_shared_credentials_file: /etc/bazel-remote/credentials
+        aws_profile: brc
+        bucket_lookup_type: dns
+        max_idle_conns: 1024
     replicaCount: 1
     volumeMounts:
       - mountPath: /data
         name: brc-cache
+      - mountPath: /etc/bazel-remote/credentials
+        name: brc-cos-credentials
+        subPath: credentials
     volumes:
       - name: brc-cache
         persistentVolumeClaim:
           claimName: brc-cache
+      - name: brc-cos-credentials
+        secret:
+          secretName: brc-cos-credentials

--- a/apps/tencentcloud/cache/kustomization.yaml
+++ b/apps/tencentcloud/cache/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: cache
 resources:
   - namespace.yaml
-  - git-cdn
-  - goproxy
-  - greenhouse
-  - ats
+  - brc.yaml

--- a/apps/tencentcloud/cache/namespace.yaml
+++ b/apps/tencentcloud/cache/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cache

--- a/apps/tencentcloud/jenkins/pre.yaml
+++ b/apps/tencentcloud/jenkins/pre.yaml
@@ -16,4 +16,5 @@ spec:
     substitute:
       GOOGLE_OAUTH_JSON: tencentcloud_jenkins_google_oauth_json
       JENKINS_CACHE_S3_JSON: tencentcloud_jenkins_cache_s3_json
-      JENKINS_ARTIFACT_S3_S3_JSON: tencentcloud_jenkins_artifact_s3_json
+      JENKINS_ARTIFACT_S3_JSON: tencentcloud_jenkins_artifact_s3_json
+      S3_CREDENTIALS_JSON: tencentcloud_common_creds_json

--- a/apps/tencentcloud/jenkins/pre/credential-jenkins-artifact-s3-auth.yaml
+++ b/apps/tencentcloud/jenkins/pre/credential-jenkins-artifact-s3-auth.yaml
@@ -23,4 +23,4 @@ spec:
         secretKey: "{{ .accessSecret }}"
   dataFrom:
     - extract:
-        key: "${JENKINS_ARTIFACT_S3_S3_JSON}"
+        key: "${S3_CREDENTIALS_JSON}" # json object containing keys: `accessKey` and `accessSecret`

--- a/apps/tencentcloud/jenkins/pre/secret-jenkins-artifact-s3.yaml
+++ b/apps/tencentcloud/jenkins/pre/secret-jenkins-artifact-s3.yaml
@@ -20,4 +20,4 @@ spec:
         endpoint-host: '{{ trimPrefix "http://" (trimPrefix "https://" .endpoint) }}'
   dataFrom:
     - extract:
-        key: "${JENKINS_ARTIFACT_S3_S3_JSON}" # json object
+        key: "${JENKINS_ARTIFACT_S3_JSON}" # json object containing keys: `region`, `bucket`, and `endpoint`

--- a/apps/tencentcloud/jenkins/pre/secret-jenkins-cache.yaml
+++ b/apps/tencentcloud/jenkins/pre/secret-jenkins-cache.yaml
@@ -21,4 +21,6 @@ spec:
         access-secret: "{{ .accessSecret }}"
   dataFrom:
     - extract:
-        key: "${JENKINS_CACHE_S3_JSON}" # json object
+        key: "${JENKINS_CACHE_S3_JSON}" # json object containing keys: `region`, `bucket`, and `endpoint`
+    - extract:
+        key: "${S3_CREDENTIALS_JSON}" # json object containing keys: `accessKey` and `accessSecret`

--- a/apps/tencentcloud/kustomization.yaml
+++ b/apps/tencentcloud/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - cache
   - cluster-policies
   - kafka
   - cloudevents-server


### PR DESCRIPTION
Move brc (bazel-remote) from prod2 to tencentcloud:

- Deploy in the `cache` namespace under `apps/tencentcloud/cache/brc`
- Local LRU cache PVC 100Gi with `cbs` storage class (was 1.1Ti openebs on prod2)
- Blobs stored in Tencent COS via bazel-remote `s3_proxy` (virtual-hosted addressing, `bucket_lookup_type: dns`)
- COS bucket/region injected via Flux `postBuild.substitute` in `apps/tencentcloud/cache/brc.yaml`
  - `COS_BUCKET` / `COS_REGION` / `COS_PREFIX` still placeholders, need actual values
  - `COS_CREDENTIALS_JSON`: `tencentcloud_brc_cos_credentials_json` (create this secret in GCP Secret Manager with `access_key_id`/`secret_access_key`)
- Credentials file mounted from ExternalSecret (GCP SM), auth via `auth_method: credentials_file`
- Node selection: `compute-class: ee-application` (ee-application nodepool) + amd64
- Removed brc from prod2

Note: prod2 ats remap `/brc -> greenhouse.cache.svc.cluster.local` still points to prod2.