### PR TITLE
fix(apps/tencentcloud/cache/brc): use aws_credentials_file for COS s3 auth

### DIFF
--- a/apps/tencentcloud/cache/brc/external-secret.yaml
+++ b/apps/tencentcloud/cache/brc/external-secret.yaml
@@ -13,7 +13,7 @@ spec:
     template:
       type: Opaque
       data:
-        # AWS-style credentials file, consumed via s3.auth_method: credentials_file
+        # AWS-style credentials file, consumed via s3.auth_method: aws_credentials_file
         # https://github.com/buchgr/bazel-remote#example-configuration-file
         credentials: |
           [brc]

--- a/apps/tencentcloud/cache/brc/release.yaml
+++ b/apps/tencentcloud/cache/brc/release.yaml
@@ -45,7 +45,7 @@ spec:
         bucket: ${COS_BUCKET}
         prefix: ${COS_PREFIX}
         region: ${COS_REGION}
-        auth_method: credentials_file
+        auth_method: aws_credentials_file
         aws_shared_credentials_file: /etc/bazel-remote/credentials
         aws_profile: brc
         bucket_lookup_type: dns


### PR DESCRIPTION
Fix bazel-remote (brc) crash loop in tencentcloud cluster: container fails with `invalid s3.auth_method: credentials_file` because v2.6.1 only accepts `iam_role`, `access_key`, `aws_credentials_file` (per cache/s3proxy/auth_methods.go). `credentials_file` in README example is wrong.

```
kubectl logs -n cache <brc-pod> | tail
# invalid s3.auth_method: credentials_file
```

Change auth_method to the valid `aws_credentials_file` value; no image upgrade needed.