### PR TITLE
feat(apps/tencentcloud/cache): add goproxy with goproxy.cn upstream

### DIFF
--- a/apps/tencentcloud/cache/goproxy/deployment.yaml
+++ b/apps/tencentcloud/cache/goproxy/deployment.yaml
@@ -6,7 +6,7 @@ spec:
   selector:
     matchLabels:
       app: goproxy
-  replicas: 2
+  replicas: 1
   template:
     metadata:
       labels:
@@ -45,4 +45,5 @@ spec:
           mountPath: /opt/cache
       volumes:
       - name: data
-        emptyDir: {}
+        persistentVolumeClaim:
+          claimName: goproxy-cache

--- a/apps/tencentcloud/cache/goproxy/deployment.yaml
+++ b/apps/tencentcloud/cache/goproxy/deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: goproxy
+spec:
+  selector:
+    matchLabels:
+      app: goproxy
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: goproxy
+    spec:
+      containers:
+      - name: goproxy
+        image: goproxy/goproxy:latest
+        imagePullPolicy: IfNotPresent
+        args:
+          - "-listen=0.0.0.0:8080"
+          - "-cacheDir=/opt/cache"
+          - "-proxy=https://goproxy.cn"
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        resources:
+          requests:
+            cpu: "500m"
+            memory: 512Mi
+          limits:
+            cpu: "2"
+            memory: 2Gi
+        ports:
+        - containerPort: 8080
+          name: http
+        volumeMounts:
+        - name: data
+          mountPath: /opt/cache
+      volumes:
+      - name: data
+        emptyDir: {}

--- a/apps/tencentcloud/cache/goproxy/kustomization.yaml
+++ b/apps/tencentcloud/cache/goproxy/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: cache
 resources:
+  - pvc.yaml
   - deployment.yaml
   - svc.yaml

--- a/apps/tencentcloud/cache/goproxy/kustomization.yaml
+++ b/apps/tencentcloud/cache/goproxy/kustomization.yaml
@@ -2,6 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: cache
 resources:
-  - namespace.yaml
-  - brc.yaml
-  - goproxy
+  - deployment.yaml
+  - svc.yaml

--- a/apps/tencentcloud/cache/goproxy/pvc.yaml
+++ b/apps/tencentcloud/cache/goproxy/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: goproxy-cache
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: cbs
+  volumeMode: Filesystem

--- a/apps/tencentcloud/cache/goproxy/svc.yaml
+++ b/apps/tencentcloud/cache/goproxy/svc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: goproxy
+spec:
+  selector:
+    app: goproxy
+  ports:
+  - port: 80
+    targetPort: http


### PR DESCRIPTION
## What's changed

Add a goproxy (Go module proxy) in the tencentcloud cluster cache namespace:

- `apps/tencentcloud/cache/goproxy/deployment.yaml`: `goproxy/goproxy:latest`, upstream `https://goproxy.cn`, 2 replicas, resources 500m/512Mi requests and 2cpu/2Gi limits
- `apps/tencentcloud/cache/goproxy/svc.yaml`: ClusterIP service `goproxy.cache.svc` on port 80
- Wire into `apps/tencentcloud/cache/kustomization.yaml`

The in-cluster service `http://goproxy.cache.svc` will be consumed by Jenkins agents (GOPROXY env injection to follow in a separate PR).