### PR TITLE
feat(apps/tencentcloud/jenkins): inject GOPROXY global env var for build agents

### DIFF
--- a/apps/tencentcloud/jenkins/release/staging/values-JCasC.yaml
+++ b/apps/tencentcloud/jenkins/release/staging/values-JCasC.yaml
@@ -183,7 +183,7 @@ controller:
             - envVars:
                 env:
                   - key: "GOPROXY"
-                    value: "http://goproxy.cache.svc"
+                    value: "http://goproxy.cache.svc,direct"
 
       pipeline-cache: |
         unclassified:

--- a/apps/tencentcloud/jenkins/release/staging/values-JCasC.yaml
+++ b/apps/tencentcloud/jenkins/release/staging/values-JCasC.yaml
@@ -176,6 +176,15 @@ controller:
                 }
               }
 
+      # global environment variables for all agents.
+      global-env: |
+        jenkins:
+          globalNodeProperties:
+            - envVars:
+                env:
+                  - key: "GOPROXY"
+                    value: "http://goproxy.cache.svc"
+
       pipeline-cache: |
         unclassified:
           pipeline-cache:


### PR DESCRIPTION
## What's changed

Inject `GOPROXY` as a global environment variable on all Jenkins agents via JCasC `globalNodeProperties` (env-vars plugin), pointing to the in-cluster goproxy service `http://goproxy.cache.svc` in the tencentcloud cluster.

Files:
- `apps/tencentcloud/jenkins/release/staging/values-JCasC.yaml` (staging, live)
- `apps/tencentcloud/jenkins/release/values-JCasC.yaml` (production, will be enabled with the release migration)

Depends on the goproxy service added in #2159.