### PR TITLE
feat(apps/tencentcloud/jenkins): add prod release instance parallel to staging

### DIFF
--- a/apps/tencentcloud/jenkins/pre/secret-jenkins-cache.yaml
+++ b/apps/tencentcloud/jenkins/pre/secret-jenkins-cache.yaml
@@ -17,6 +17,8 @@ spec:
         region: "{{ .region }}"
         bucket: "{{ .bucket }}"
         endpoint: '{{ replace (printf "https://%s." .bucket) "https://" .endpoint }}'
+        # strip scheme only, keep bucket name for COS virtual-hosted-style domain
+        endpoint-host: '{{ trimPrefix "http://" (trimPrefix "https://" .endpoint) }}'
         access-key: "{{ .accessKey }}"
         access-secret: "{{ .accessSecret }}"
   dataFrom:

--- a/apps/tencentcloud/jenkins/release/kustomization.yaml
+++ b/apps/tencentcloud/jenkins/release/kustomization.yaml
@@ -2,18 +2,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace-agent.yaml
-  # - release.yaml
-  # - http-routes.yaml
+  - prod/release.yaml
+  - prod/http-routes.yaml
   - staging/release.yaml
   - staging/http-routes.yaml
 secretGenerator:
   - name: jenkins-release-values
     files:
-      # - values1.yaml=values-controller.yaml
-      # - values2.yaml=values-controller-plugins.yaml
-      # - values3.yaml=values-JCasC.yaml
-      # - values4.yaml=values-rbac.yaml
-      # - values5.yaml=values-agent.yaml
+      - prod-values1.yaml=prod/values-controller.yaml
+      - prod-values2.yaml=prod/values-controller-plugins.yaml
+      - prod-values3.yaml=prod/values-JCasC.yaml
+      - prod-values4.yaml=prod/values-rbac.yaml
+      - prod-values5.yaml=prod/values-agent.yaml
       - staging-values1.yaml=staging/values-controller.yaml
       - staging-values2.yaml=staging/values-controller-plugins.yaml
       - staging-values3.yaml=staging/values-JCasC.yaml

--- a/apps/tencentcloud/jenkins/release/prod/http-routes.yaml
+++ b/apps/tencentcloud/jenkins/release/prod/http-routes.yaml
@@ -1,0 +1,20 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: controller
+  namespace: jenkins
+spec:
+  parentRefs:
+    - kind: Gateway
+      name: external-https
+      namespace: infra
+  hostnames:
+    - "${INGRESS_HOST}"
+  rules:
+    - backendRefs:
+        - name: jenkins
+          port: 8080
+      matches:
+        - path:
+            type: PathPrefix
+            value: "${INGRESS_PATH}"

--- a/apps/tencentcloud/jenkins/release/prod/release.yaml
+++ b/apps/tencentcloud/jenkins/release/prod/release.yaml
@@ -1,0 +1,64 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: jenkins
+spec:
+  chart:
+    spec:
+      chart: jenkins
+      version: 5.9.49
+      sourceRef:
+        kind: HelmRepository
+        name: jenkins
+        namespace: flux-system
+  dependsOn:
+    - name: cloudevents-server
+      namespace: cs
+  interval: 1h0m0s
+  timeout: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    crds: CreateReplace
+  test:
+    enable: true
+    ignoreFailures: false
+  valuesFrom:
+    - { kind: Secret, name: jenkins-release-values, valuesKey: prod-values1.yaml }
+    - { kind: Secret, name: jenkins-release-values, valuesKey: prod-values2.yaml }
+    - { kind: Secret, name: jenkins-release-values, valuesKey: prod-values3.yaml }
+    - { kind: Secret, name: jenkins-release-values, valuesKey: prod-values4.yaml }
+    - { kind: Secret, name: jenkins-release-values, valuesKey: prod-values5.yaml }
+  values:
+    agent:
+      namespace: "${AGENT_NAMESPACE}"
+
+    controller:
+      servicePort: 8080
+      targetPort: 8080
+      jenkinsUriPrefix: "${INGRESS_PATH}"
+      jenkinsUrl: "https://${INGRESS_HOST}${INGRESS_PATH}"
+      jenkinsAdminEmail: "${ADMIN_EMAIL}"
+
+    persistence:
+      enabled: true
+
+      # A manually managed Persistent Volume and Claim
+      # Requires persistence.enabled: true
+      # If defined, PVC must be created manually before volume will be bound
+      # existingClaim: jenkins
+
+      # jenkins data Persistent Volume Storage Class
+      # If defined, storageClassName: <storageClass>
+      # If set to "-", storageClassName: "", which disables dynamic provisioning
+      # If undefined (the default) or set to null, no storageClassName spec is
+      #   set, choosing the default provisioner.  (gp2 on AWS, standard on
+      #   GKE, AWS & OpenStack)
+      #
+      storageClass: "${PERSISTENCE_STORAGE_CLASS}"
+      size: "700Gi"
+
+    serviceAccount:
+      create: true

--- a/apps/tencentcloud/jenkins/release/prod/values-JCasC.yaml
+++ b/apps/tencentcloud/jenkins/release/prod/values-JCasC.yaml
@@ -1,0 +1,236 @@
+controller:
+  # 'name' is a name of an existing secret in same namespace as jenkins,
+  # 'keyName' is the name of one of the keys inside current secret.
+  # the 'name' and 'keyName' are concatenated with a '-' in between, so for example:
+  # an existing secret "secret-credentials" and a key inside it named "github-password" should be used in Jcasc as ${secret-credentials-github-password}
+  # 'name' and 'keyName' must be lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-',
+  # and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc')
+  additionalExistingSecrets:
+    # for login with google
+    - { name: google-oauth, keyName: client-id }
+    - { name: google-oauth, keyName: client-secret }
+
+    # for ci cache, no need create manually.
+    - { name: jenkins-cache, keyName: region }
+    - { name: jenkins-cache, keyName: bucket }
+    - { name: jenkins-cache, keyName: endpoint }
+    - { name: jenkins-cache, keyName: endpoint-host }
+    - { name: jenkins-cache, keyName: access-key }
+    - { name: jenkins-cache, keyName: access-secret }
+
+  additionalSecrets: []
+  #  - name: nameOfSecret
+  #    value: secretText
+
+  JCasC:
+    defaultConfig: true
+    # Ignored if authorizationStrategy is defined in controller.JCasC.configScripts
+    authorizationStrategy: |-
+      # loggedInUsersCanDoAnything:
+      #   allowAnonymousRead: true # allow users to read builds logs without logging in.
+      #
+      roleBased:
+        permissionTemplates:
+          - name: "read-build-template"
+            permissions:
+              - "Job/Cancel"
+              - "Job/Build"
+              - "Job/Read"
+          - name: "configure-template"
+            permissions:
+              - "Job/Cancel"
+              - "Job/Build"
+              - "Job/Read"
+              - "Job/Configure"
+        roles:
+          global:
+            # Full administrator
+            - name: "admin"
+              pattern: ".*"
+              permissions:
+                - "Overall/Read"
+                - "Overall/Administer"
+              entries:
+                - user: "wuhui.zuo@pingcap.com"
+                - user: "wei.zheng@pingcap.com"
+
+            # Reader
+            - name: "builder"
+              pattern: ".*"
+              permissions:
+                - "Overall/Read"
+                - "Job/Read"
+                - "Job/Build"
+                - "Job/Cancel"
+                - "Run/Read"
+                - "Run/Replay"
+                - "View/Read"
+                - "Metrics/Read"
+              entries:
+                - user: "lifu.wu@pingcap.com"
+                - user: "yebin.li@pingcap.com"
+
+            # Readonly
+            - name: "readonly"
+              pattern: ".*"
+              permissions:
+                - "Overall/Read"
+                - "Job/Read"
+                - "Run/Read"
+                - "View/Read"
+              entries:
+                - user: anonymous
+                - group: authenticated
+
+    # for security.
+    security:
+      globalJobDslSecurityConfiguration:
+        useScriptSecurity: false
+      gitHostKeyVerificationConfiguration:
+        sshHostKeyVerificationStrategy: "noHostKeyVerificationStrategy"
+
+    securityRealm: |-
+      # local:
+      #   allowsSignup: false
+      #   enableCaptcha: false
+      #   users:
+      #   - id: "${chart-admin-username}"
+      #     name: "Jenkins Admin"
+      #     password: "${chart-admin-password}"
+      googleOAuth2:
+        clientId: "${google-oauth-client-id}"
+        clientSecret: "${google-oauth-client-secret}"
+        domain: "pingcap.com"
+
+    # REF Doc: https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/README.md
+    #
+    # Notable: if you want delete some key, first please delete the conetnt but keep the key.
+    #   after deployed, then create other commit and push to delete the key.
+    configScripts:
+      #  welcome-message: |
+      #    jenkins:
+      #      systemMessage: Welcome to our CI\CD server.  This Jenkins is configured and managed 'as code'.
+      # Ignored if securityRealm is defined in controller.JCasC.configScripts and
+      # ignored if controller.enableXmlConfig=true as controller.securityRealm takes precedence
+      # securityRealm: |
+      #   jenkins:
+      #     securityRealm:
+      #       googleOAuth2:
+      #         # will read from key `client-id` from secret `google-oauth2`
+      #         clientId: "${google-oauth2-client-id}"
+      #         # will read from key `client-secret` from secret `google-oauth2`
+      #         clientSecret: "${google-oauth2-client-secret}"
+
+      # for jobs.
+      jobs-dsl: |
+        jobs:
+          - script: |
+              job('seed') {
+                description('''
+                    Jenkins jobs As Code
+                    No need to configure job on Jenkins Web UI anymore.
+                ''')
+                logRotator {
+                    daysToKeep(7)
+                }
+                parameters {
+                    // Ref: https://docs.prow.k8s.io/docs/jobs/#job-environment-variables
+                    stringParam("BUILD_ID", "", "Build ID")
+                    stringParam("PROW_JOB_ID", "", "Prow job ID")
+                    stringParam(
+                      "JOB_SPEC",
+                      '{"type":"postsubmit","refs":{"org":"PingCAP-QE","repo":"ci","repo_link":"https://github.com/PingCAP-QE/ci","base_ref":"main","base_sha":"main"}}',
+                      "Prow job spec struct data"
+                    )
+                }
+                scm {
+                  git {
+                    remote {
+                      url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                      cloneOptions {
+                        depth(1)
+                        shallow(true)
+                        timeout(5)
+                      }
+                    }
+                  }
+                }
+                steps {
+                  jobDsl {
+                    targets('jobs/**/*.groovy')
+                    failOnMissingPlugin(false)
+                    ignoreMissingFiles(true)
+                    ignoreExisting(false)
+                    removedJobAction('DELETE')
+                    removedConfigFilesAction('DELETE')
+                    removedViewAction('DELETE')
+                    lookupStrategy('SEED_JOB')
+                    sandbox(false)
+                  }
+                }
+              }
+
+      # global environment variables for all agents.
+      global-env: |
+        jenkins:
+          globalNodeProperties:
+            - envVars:
+                env:
+                  - key: "GOPROXY"
+                    value: "http://goproxy.cache.svc,direct"
+
+      pipeline-cache: |
+        unclassified:
+          pipeline-cache:
+            region: ${jenkins-cache-region}
+            bucket: ${jenkins-cache-bucket}
+            endpoint: ${jenkins-cache-endpoint}
+            username: ${jenkins-cache-access-key}
+            password: ${jenkins-cache-access-secret}
+            threshold: 400000 # limit to 400GiB
+      cdevents: |
+        unclassified:
+          cDEventsGlobalConfig:
+            httpSinkUrl: "http://cloudevents-server.cs.svc/events"
+            sinkType: "http"
+      # for global shared libraries
+      global-library: |
+        unclassified:
+          globalLibraries:
+            libraries:
+              - name: "tisys"
+                retriever:
+                  modernSCM:
+                    scm:
+                      gitSource:
+                        remote: "https://github.com/pingcap-qe/ci.git"
+                    libraryPath: "libraries/tisys"
+                defaultVersion: "main"
+                implicit: true
+                allowVersionOverride: true
+                includeInChangesets: false
+                cachingConfiguration:
+                  refreshTimeMinutes: 60
+                  includedVersionsStr: "main"
+                  excludedVersionsStr: "feature/ fix/ bugfix/"
+
+      artifact-manager-s3: |
+        unclassified:
+          artifactManager:
+            artifactManagerFactories:
+              - jclouds:
+                  provider: s3
+        aws:
+          awsCredentials:
+            credentialsId: jenkins-artifact-s3-auth
+          s3:
+            container: ${jenkins-cache-bucket}
+            prefix: "jenkins-artifacts/"
+            # artifact-manager-s3 validates customEndpoint as host[:port].
+            customEndpoint: ${jenkins-cache-endpoint-host}
+            customSigningRegion: ${jenkins-cache-region}
+            usePathStyleUrl: false
+            disableSessionToken: true

--- a/apps/tencentcloud/jenkins/release/prod/values-agent.yaml
+++ b/apps/tencentcloud/jenkins/release/prod/values-agent.yaml
@@ -1,0 +1,23 @@
+# please see: https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/VALUES_SUMMARY.md
+agent:
+  maxRequestsPerHostStr: "400" # need to restart controller after updated it.
+  containerCap: 400
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      cpu: 200m
+      memory: 512Mi
+  envVars:
+    - name: JAVA_OPTS
+      value: "-Xms128m -Xmx224m -XX:MaxDirectMemorySize=32m -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Djenkins.agent.protocol=false"
+  garbageCollection:
+    enabled: true
+    timeout: 300
+    namespaces: |-
+      jenkins-pd
+      jenkins-tiflow
+      jenkins-tidb
+      jenkins-tiflash
+      jenkins-tikv

--- a/apps/tencentcloud/jenkins/release/prod/values-controller-plugins.yaml
+++ b/apps/tencentcloud/jenkins/release/prod/values-controller-plugins.yaml
@@ -1,0 +1,69 @@
+# please see: https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/VALUES_SUMMARY.md
+controller:
+  overwritePlugins: true
+  installLatestPlugins: true
+
+  # Override the default list to use our own custom plugin
+  # Ref: https://artifacthub.io/packages/helm/jenkinsci/jenkins?modal=values&path=controller.installPlugins
+  installPlugins:
+    - kubernetes:4437.vd64141124d8f-fork.3:https://github.com/wuhuizuo/jenkins-kubernetes-plugin/releases/download/4437.vd64141124d8f-fork.3/kubernetes.hpi
+    - workflow-aggregator:608.v67378e9d3db_1
+    - git:5.10.1
+    - configuration-as-code:2114.v67a_a_18696b_8f
+
+  # List of plugins to install in addition to those listed in controller.installPlugins
+  additionalPlugins:
+    # Ref: https://github.com/jenkinsci/plugin-installation-manager-tool#plugin-input-format
+    # but without outer `plugin` key.
+    - artifact-manager-s3:986.v7c9a_d15576b_b_
+    - build-failure-analyzer::https://github.com/PingCAP-QE/build-failure-analyzer-plugin/releases/download/v2.4.2-jobname/build-failure-analyzer.hpi
+    - cdevents::https://github.com/dillon-zheng/cdevents-plugin/releases/download/cdevents-1-40-pingcap-1/cdevents-1-40-pingcap-1.hpi
+    - generic-webhook-trigger:2.4.2
+    - google-login:109.v022b_cf87b_e5b_
+    - http_request:1.25
+    - jenkins-pipeline-cache:0.2.0:https://github.com/j3t/jenkins-pipeline-cache-plugin/releases/download/0.2.0/jenkins-pipeline-cache-0.2.0.hpi
+    - job-dsl:3654.vdf58f53e2d15
+    - kubernetes-credentials-provider:1.303.vdfcf47fb_b_fef
+    - lockable-resources:1539.v4db_b_fc1cc115
+    - pipeline-graph-view:980.vb_db_0b_e5f683c
+    - pipeline-utility-steps:3.810.va_7672d206740
+    - prometheus:856.vc9e3d6e4b_b_9e
+    - role-strategy:898.vc050ed2424ca_
+    - ssh-agent:413.v1fd573533a_ec
+
+  initializeOnce: false
+
+  # for plugin build-failure-analyzer
+  #   Exporting to prometheus
+  #   Ref: https://github.com/jenkinsci/build-failure-analyzer-plugin/blob/master/docs/metrics.md
+  prometheus:
+    metricRelabelings:
+      # add label: category
+      - sourceLabels: [__name__]
+        regex: jenkins_bfa_category_(.*)
+        targetLabel: category
+      - sourceLabels: [__name__]
+        regex: jenkins_bfa_job_category:_:.*:_:(.*)
+        targetLabel: category
+
+      # add label: cause
+      - sourceLabels: [__name__]
+        regex: jenkins_bfa_cause_(.*)
+        targetLabel: cause
+      - sourceLabels: [__name__]
+        regex: jenkins_bfa_job_cause:_:.*:_:(.*)
+        targetLabel: cause
+
+      # add label: jobname
+      - sourceLabels: [__name__]
+        regex: jenkins_bfa_job_category:_:(.*):_:.*
+        targetLabel: jobname
+      - sourceLabels: [__name__]
+        regex: jenkins_bfa_job_cause:_:(.*):_:.*
+        targetLabel: jobname
+
+      # aggerate to uniq metric: jenkins_bfa
+      - sourceLabels: [__name__]
+        regex: jenkins_bfa_(.*)_(.*)
+        replacement: jenkins_bfa
+        targetLabel: __name__

--- a/apps/tencentcloud/jenkins/release/prod/values-controller.yaml
+++ b/apps/tencentcloud/jenkins/release/prod/values-controller.yaml
@@ -1,0 +1,69 @@
+# please see: https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/VALUES.md
+controller:
+  podLabels:
+    env: cicd
+    team: eq
+    author: wuhuizuo
+
+  containerPort: 8080
+
+  image:
+    registry: "docker.io"
+    repository: "jenkins/jenkins"
+    tag: "2.568.2-jdk21"
+  resources:
+    requests:
+      cpu: "12"
+      memory: 48Gi
+    limits:
+      cpu: "12"
+      memory: 48Gi
+
+  # https://docs.cloudbees.com/docs/admin-resources/latest/jvm-troubleshooting/
+  # Set min/max heap here if needed with:
+  javaOpts: >-
+    -XX:+UseContainerSupport -XX:InitialRAMPercentage=20.0
+    -XX:MaxRAMPercentage=70.0 -XX:+UseG1GC -XX:+AlwaysPreTouch
+    -XX:+UseStringDeduplication -XX:+ParallelRefProcEnabled
+    -XX:+DisableExplicitGC -XX:+UnlockExperimentalVMOptions
+    -XX:+UnlockDiagnosticVMOptions -XX:+HeapDumpOnOutOfMemoryError
+    -Xlog:gc*=info,gc+heap=debug,gc+ref*=debug,gc+ergo*=trace,gc+age*=trace:file=/var/jenkins_home/logs/gc-%t.log:utctime,pid,level,tags:filecount=2,filesize=100M
+    -Dio.jenkins.plugins.artifact_manager_jclouds.s3.S3BlobStoreConfig.deleteArtifacts=true
+    -Dio.jenkins.plugins.artifact_manager_jclouds.s3.S3BlobStoreConfig.deleteStashes=true
+
+  # Optionally specify additional init-containers
+  customInitContainers:
+    - name: init-create-logs-dir
+      image: "alpine:3.23.3"
+      imagePullPolicy: Always
+      command: ["mkdir", "-p", "/var/jenkins_home/logs"]
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        runAsGroup: 1000
+        runAsUser: 1000
+      volumeMounts:
+        - mountPath: /var/jenkins_home
+          name: jenkins-home
+
+  # jenkinsOpts: ""
+  # If you are using the ingress definitions provided by this chart via the `controller.ingress` block the configured hostname will be the ingress hostname starting with `https://` or `http://` depending on the `tls` configuration.
+  # The Protocol can be overwritten by specifying `controller.jenkinsUrlProtocol`.
+  # jenkinsUrlProtocol: "https"
+  # If you are not using the provided ingress you can specify `controller.jenkinsUrl` to change the url definition.
+  # jenkinsUrl: ""
+  # If you set this prefix and use ingress controller then you might want to set the ingress path below
+
+  hostAliases:
+    - ip: "193.112.193.79"
+      hostnames:
+        - "accounts.google.com"
+
+  ingress:
+    enabled: false
+
+  # Expose Prometheus metrics
+  prometheus:
+    # If enabled, add the prometheus plugin to the list of plugins to install
+    # https://plugins.jenkins.io/prometheus
+    enabled: false

--- a/apps/tencentcloud/jenkins/release/prod/values-rbac.yaml
+++ b/apps/tencentcloud/jenkins/release/prod/values-rbac.yaml
@@ -1,0 +1,2 @@
+rbac:
+  readSecrets: true


### PR DESCRIPTION
## Summary

Add a production (official) Jenkins instance in the tencentcloud cluster, managed in `apps/tencentcloud/jenkins/release/prod/`, running in parallel with the existing staging instance.

### Changes

- **New `release/prod/` directory**: official Jenkins HelmRelease (`jenkins`, chart `5.9.49`, port 8080, PVC 700Gi, path `/jenkins`) with HTTPRoute `controller` and 5 values files.
- **Official vs staging differences** (as requested):
  - Server specs: controller 12C/48Gi (staging 3C/12Gi), agent containerCap 400 (staging 10), PVC 700Gi (staging 10Gi)
  - Service path: `/jenkins` (staging `/jenkins-staging`)
  - Artifact storage uses `jenkins-cache` bucket
- **`release/kustomization.yaml`**: enable both prod and staging; values secret keys `prod-values1..5` vs `staging-values1..5`
- **`pre/secret-jenkins-cache.yaml`**: add `endpoint-host` key (required by prod JCasC artifact-manager-s3 config)