### PR TITLE
chore(infrastructure/tencentcloud/kyverno): grant background controller pod delete RBAC

### DIFF
--- a/infrastructure/tencentcloud/kyverno/release.yaml
+++ b/infrastructure/tencentcloud/kyverno/release.yaml
@@ -37,6 +37,13 @@ spec:
         enabled: true
         minReplicas: 1
         maxReplicas: 2
+      # For DeletingPolicy to delete pods (e.g. cleanup of orphan Jenkins agent pods).
+      rbac:
+        clusterRole:
+          extraResources:
+            - apiGroups: [""]
+              resources: ["pods"]
+              verbs: ["get", "list", "watch", "delete"]
     cleanupController:
       image:
         registry: ghcr.nju.edu.cn


### PR DESCRIPTION
## Summary

Grant the Kyverno background controller permission to delete pods, required by `DeletingPolicy` targeting pods (e.g. cleanup of orphan Jenkins agent pods).

The default `kyverno:background-controller` ClusterRole has no pods permissions (verified in cluster).

### Changes

- `infrastructure/tencentcloud/kyverno/release.yaml`: add `backgroundController.rbac.clusterRole.extraResources` with `get/list/watch/delete` on pods (official chart values path, chart 3.8.2 = app v1.18.2)