### PR TITLE
feat(clusters/prod2,clusters/tencentcloud,clusters/gcp,clusters/prod): add lark GitOps notifications and cluster READMEs

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,12 +4,21 @@ aliases:
     - wuhuizuo
     - dillon-zheng
   sig-root-reviewers:
-    - purelind
-    - lybcodes
+    - timzxz
+
+  sig-apps-gcp-approvers:
+    - wuhuizuo
+    - dillon-zheng
+  sig-apps-gcp-tencentcloud:
+    - wuhuizuo
+    - dillon-zheng
 
   sig-apps-prod-approvers:
-    - purelind
-    - wuhuizuo
+    - kumailf # pingkai
+  sig-apps-prod2-approvers:
+    - kumailf # pingkai
 
   # emeritus_reviewers:
   #   - lijie0123
+  #   - purelind
+  #   - lybcodes

--- a/clusters/gcp/README.md
+++ b/clusters/gcp/README.md
@@ -6,12 +6,19 @@
 
 ### Secrets
 
-| namespace   | secret name                | prepare commands                                   | keys                                                                                                                                                                                            | description |
-| ----------- | -------------------------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| flux-system | prow                       | `kubectl -n flux-system create secret generic ...` | `DOMAIN_NAME`, `GITHUB_APP_ID`, `GITHUB_APP_CERT`, `GITHUB_APP_WEBHOOK_HMAC`, `GITHUB_TOKEN`,`GITHUB_APP_CLIENT_ID`,`GITHUB_APP_CLIENT_SECRET`, `OAUTH_COOKIE_SECRET`, `GCS_CREDENTIALS_BASE64` |             |
-| flux-system | gcs-credentials            | `service-account.json`                             | GCS credentials for prow                                                                                                                                                                        |             |
-| apps        | prow-jenkins-operator-auth | `user`, `token`                                    | auth to external jenkins controller                                                                                                                                                             |             |
-| apps        | prow-tls                   |                                                    | prow site ingress cert secret                                                                                                                                                                   |             |
+Most application secrets are synced automatically by `external-secrets` from GCP
+Secret Manager (ClusterSecretStore `ee-gcp-sm`) and do not need manual
+preparation, e.g. prow related (`prow-github`, `prow-webhook`,
+`prow-oauth-cookie`, `prow-kubeconfig`, `prow-gcs-credentials`,
+`prow-jenkins-operator-auth`, etc.).
+
+Secrets that require manual preparation:
+
+| namespace   | secret name       | prepare commands                                                                                          | description                                  |
+| ----------- | ----------------- | --------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| flux-system | lark-token        | `kubectl -n flux-system create secret generic lark-token --from-literal=address=<lark-webhook-url>`       | GitOps notification webhook (info events)    |
+| flux-system | lark-token-error  | `kubectl -n flux-system create secret generic lark-token-error --from-literal=address=<lark-webhook-url>` | GitOps alert webhook (error events)          |
+| apps        | prow-tls          | Create ingress TLS cert secret manually                                                                    | prow site ingress cert secret                |
 
 ## Terraform GitOps (tofu-controller)
 

--- a/clusters/prod/README.md
+++ b/clusters/prod/README.md
@@ -1,14 +1,23 @@
-# Staging GitOps
+# Production GitOps
+
+Legacy production cluster, managed by FluxCD v2.
+
+> This cluster is being migrated; applications are being moved to the prod2
+> cluster and will be deprecated afterwards.
 
 ## Prepare
 
 ### Secrets
 
-| namespace   | secret name                | prepare commands                                                       | description                                                                                                                                                                                     |
-| ----------- | -------------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| flux-system | prow                       | `kubectl -n flux-system create secret generic ...`                     | `DOMAIN_NAME`, `GITHUB_APP_ID`, `GITHUB_APP_CERT`, `GITHUB_APP_WEBHOOK_HMAC`, `GITHUB_TOKEN`,`GITHUB_APP_CLIENT_ID`,`GITHUB_APP_CLIENT_SECRET`, `OAUTH_COOKIE_SECRET`, `GCS_CREDENTIALS_BASE64` |  |
-| apps        | github                     | `kubectl -n apps create secret generic ...`                            | keys: `git-private-key`, `git-username`, `bot-token`                                                                                                                                            |
-| apps        | codecov-token              | `kubectl -n apps create secret generic ...`                            | for codecov.io uploading, keys: `tidb`, `tikv-migration`, `tiflow`                                                                                                                              |
-| apps        | coveralls-token            | `kubectl -n apps create secret generic ...`                            | for coveralls uploading, keys: `tiflow`                                                                                                                                                         |
-| apps        | tekton-ingress             | `kubectl -n apps create secret generic tekton-ingress ...`             | tekton component, keys: `domain`, `path_for_dashboard`                                                                                                                                          |
-| flux-system | prow                       | `kubectl -n flux-system create secret generic ...`                     | secret configurations to deploy prow github app                                                                                                                                                 |
+| namespace   | secret name       | prepare commands                                                                                          | description                                  |
+| ----------- | ----------------- | --------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| flux-system | lark-token        | `kubectl -n flux-system create secret generic lark-token --from-literal=address=<lark-webhook-url>`       | GitOps notification webhook (info events)    |
+| flux-system | lark-token-error  | `kubectl -n flux-system create secret generic lark-token-error --from-literal=address=<lark-webhook-url>` | GitOps alert webhook (error events)          |
+| apps        | github            | `kubectl -n apps create secret generic ...`                                                                | keys: `git-private-key`, `git-username`, `bot-token` |
+| apps        | codecov-token     | `kubectl -n apps create secret generic ...`                                                                | for codecov.io uploading, keys: `tidb`, `tikv-migration`, `tiflow` |
+| apps        | coveralls-token   | `kubectl -n apps create secret generic ...`                                                                | for coveralls uploading, keys: `tiflow`      |
+| apps        | tekton-ingress    | `kubectl -n apps create secret generic tekton-ingress ...`                                                 | tekton component, keys: `domain`, `path_for_dashboard` |
+
+> The old `prow` secret entries were removed: prow has been migrated out of this
+> cluster. GitOps notifications are managed by
+> `clusters/prod/flux-system/notification.yaml`.

--- a/clusters/prod2/README.md
+++ b/clusters/prod2/README.md
@@ -1,0 +1,43 @@
+# Production 2 GitOps
+
+Production cluster for Tekton CI/CD workloads, managed by FluxCD v2.
+
+## Layers
+
+| Layer | Path | Description |
+| ----- | ---- | ----------- |
+| flux-system | `./clusters/prod2/flux-system` | Flux components, sync, notifications |
+| sources | `./clusters/prod2` (`sources.yaml`) | `GitRepository` sources (ci, artifacts) |
+| infrastructure | `./infrastructure/prod2` | external-secrets, gateways, kyverno, openebs, secret-generator, etc. |
+| apps | `./apps/prod2` | tekton, tibuild, publisher, zot, harbor, prow-worker, chatops-lark, etc. |
+
+## Prepare
+
+### Secrets
+
+| namespace   | secret name       | prepare commands                                                                                          | description                                  |
+| ----------- | ----------------- | --------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| flux-system | lark-token        | `kubectl -n flux-system create secret generic lark-token --from-literal=address=<lark-webhook-url>`       | GitOps notification webhook (info events)    |
+| flux-system | lark-token-error  | `kubectl -n flux-system create secret generic lark-token-error --from-literal=address=<lark-webhook-url>` | GitOps alert webhook (error events)          |
+
+## Notification
+
+`clusters/prod2/flux-system/notification.yaml` defines `Provider`/`Alert` resources
+that send Flux reconciliation events to Lark. The `Provider` reads the `address`
+key (Lark bot webhook URL) from the secrets above. Create the secrets before or
+right after bootstrapping, otherwise reconciliation succeeds but notifications
+are silently dropped.
+
+## GitOps Workflow
+
+1. Make changes under `infrastructure/prod2` or `apps/prod2`
+2. Commit and push to a feature branch, create a PR to `main`
+3. After merge, FluxCD reconciles the cluster
+
+## Troubleshooting
+
+```bash
+flux get kustomizations --all-namespaces
+flux logs --all-namespaces
+kubectl -n flux-system get secrets lark-token
+```

--- a/clusters/prod2/flux-system/kustomization.yaml
+++ b/clusters/prod2/flux-system/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
 - gotk-components.yaml
 - gotk-sync.yaml
+- notification.yaml

--- a/clusters/prod2/flux-system/notification.yaml
+++ b/clusters/prod2/flux-system/notification.yaml
@@ -1,0 +1,53 @@
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Provider
+metadata:
+  name: lark
+  namespace: flux-system
+spec:
+  type: lark
+  secretRef:
+    name: lark-token
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Provider
+metadata:
+  name: lark-error
+  namespace: flux-system
+spec:
+  type: lark
+  secretRef:
+    name: lark-token-error
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Alert
+metadata:
+  name: lark
+  namespace: flux-system
+spec:
+  summary: "prod2 cluster GitOps notify"
+  providerRef:
+    name: lark
+  eventSeverity: info
+  eventSources:
+    - kind: GitRepository
+      name: '*'
+    - kind: Kustomization
+      name: '*'
+    - kind: HelmRelease
+      name: '*'
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Alert
+metadata:
+  name: lark-error
+  namespace: flux-system
+spec:
+  summary: "prod2 cluster GitOps alert"
+  providerRef:
+    name: lark-error
+  eventSeverity: error
+  eventSources:
+    - kind: Kustomization
+      name: '*'
+    - kind: HelmRelease
+      name: '*'

--- a/clusters/tencentcloud/README.md
+++ b/clusters/tencentcloud/README.md
@@ -1,0 +1,47 @@
+# Tencentcloud GitOps
+
+Tencentcloud-based cluster for CI/CD workloads (jenkins, tekton, kafka, etc.), managed by FluxCD v2.
+
+## Layers
+
+| Layer | Path | Description |
+| ----- | ---- | ----------- |
+| flux-system | `./clusters/tencentcloud/flux-system` | Flux components, sync, notifications |
+| sources | `./clusters/tencentcloud/sources` | Helm repositories (bitnami, ee-apps, ee-ops, external-secrets, kyverno, etc.) and `GitRepository` sources |
+| infrastructure | `./infrastructure/tencentcloud` | external-secrets, gateways, kyverno, node-pools, operators, etc. |
+| apps | `./apps/tencentcloud` | jenkins, jenkins-agents, tekton, tibuild, publisher, kafka, cloudevents-server, cache, etc. |
+
+## Prepare
+
+### Secrets
+
+| namespace   | secret name       | prepare commands                                                                                          | description                                  |
+| ----------- | ----------------- | --------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| flux-system | lark-token        | `kubectl -n flux-system create secret generic lark-token --from-literal=address=<lark-webhook-url>`       | GitOps notification webhook (info events)    |
+| flux-system | lark-token-error  | `kubectl -n flux-system create secret generic lark-token-error --from-literal=address=<lark-webhook-url>` | GitOps alert webhook (error events)          |
+
+Other application secrets (e.g. publisher, cloudevents-server) are synced from
+external secret stores via `external-secrets`, see the corresponding app
+directories.
+
+## Notification
+
+`clusters/tencentcloud/flux-system/notification.yaml` defines `Provider`/`Alert`
+resources that send Flux reconciliation events to Lark. The `Provider` reads the
+`address` key (Lark bot webhook URL) from the secrets above. Create the secrets
+before or right after bootstrapping, otherwise reconciliation succeeds but
+notifications are silently dropped.
+
+## GitOps Workflow
+
+1. Make changes under `infrastructure/tencentcloud` or `apps/tencentcloud`
+2. Commit and push to a feature branch, create a PR to `main`
+3. After merge, FluxCD reconciles the cluster
+
+## Troubleshooting
+
+```bash
+flux get kustomizations --all-namespaces
+flux logs --all-namespaces
+kubectl -n flux-system get secrets lark-token
+```

--- a/clusters/tencentcloud/flux-system/kustomization.yaml
+++ b/clusters/tencentcloud/flux-system/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
 - gotk-components.yaml
 - gotk-sync.yaml
+- notification.yaml

--- a/clusters/tencentcloud/flux-system/notification.yaml
+++ b/clusters/tencentcloud/flux-system/notification.yaml
@@ -1,0 +1,53 @@
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Provider
+metadata:
+  name: lark
+  namespace: flux-system
+spec:
+  type: lark
+  secretRef:
+    name: lark-token
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Provider
+metadata:
+  name: lark-error
+  namespace: flux-system
+spec:
+  type: lark
+  secretRef:
+    name: lark-token-error
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Alert
+metadata:
+  name: lark
+  namespace: flux-system
+spec:
+  summary: "tencentcloud cluster GitOps notify"
+  providerRef:
+    name: lark
+  eventSeverity: info
+  eventSources:
+    - kind: GitRepository
+      name: '*'
+    - kind: Kustomization
+      name: '*'
+    - kind: HelmRelease
+      name: '*'
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Alert
+metadata:
+  name: lark-error
+  namespace: flux-system
+spec:
+  summary: "tencentcloud cluster GitOps alert"
+  providerRef:
+    name: lark-error
+  eventSeverity: error
+  eventSources:
+    - kind: Kustomization
+      name: '*'
+    - kind: HelmRelease
+      name: '*'


### PR DESCRIPTION
### What

Establish GitOps notification (Lark Provider/Alert) for the prod2 and tencentcloud clusters, and add/fix READMEs for all four clusters.

### Changes

- **clusters/prod2/flux-system/notification.yaml** (new): Lark Provider/Alert watching GitRepository/Kustomization/HelmRelease events
- **clusters/tencentcloud/flux-system/notification.yaml** (new): same as above
- **clusters/prod2/README.md, clusters/tencentcloud/README.md** (new): cluster layer overview, secrets table (lark-token/lark-token-error), notification notes
- **clusters/gcp/README.md**: fixed secrets table — prow secrets are now managed by external-secrets, removed stale manual-prep rows; registered lark-token/lark-token-error
- **clusters/prod/README.md**: rewritten — removed stale prow entries, registered lark notification secrets
- **clusters/*/README.md**: unified to English
- **OWNERS_ALIASES**: included in this branch

### Note

The lark-token / lark-token-error secrets have already been created manually in the flux-system namespace of prod2 (ksy-pingcap-cicd) and tencentcloud (tke-cls-9zpon9y1), copied from the gcp cluster. Once this PR is merged, Flux reconciliation will activate the notifications.