### PR TITLE
perf(apps/prod2/tirelease): enable gzip compression via Envoy Gateway

### DIFF
--- a/apps/prod2/tirelease/httproute.yaml
+++ b/apps/prod2/tirelease/httproute.yaml
@@ -63,3 +63,18 @@ spec:
       backendRefs:
         - name: tirelease
           port: 80
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: tirelease-gzip
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: tirelease-internal
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: tirelease-external
+  compressor:
+    - type: Gzip


### PR DESCRIPTION
## What

tirelease lost gzip response compression after migrating from nginx ingress to Envoy Gateway (Gateway API HTTPRoute), making page/API response transfers slower.

Adds a `BackendTrafficPolicy` in `apps/prod2/tirelease` that enables gzip response compression via Envoy Gateway's `compressor` for the `tirelease-internal` and `tirelease-external` HTTPRoutes (the webhook route is excluded).

## Why

nginx ingress enabled gzip via its own configuration, which is not inherited by Envoy Gateway. The equivalent capability requires the Gateway API extension CRD `gateway.envoyproxy.io/v1alpha1 BackendTrafficPolicy`.

## Test

- YAML validated with `yq e 'true'`
- After rollout, verify with: `curl -H "Accept-Encoding: gzip" -I https://tirelease.pingcap.net/` (expect `Content-Encoding: gzip` in response headers)