### PR TITLE
feat(infrastructure): add unified ci-rwo storage class for gcp and tencentcloud

### DIFF
--- a/infrastructure/gcp/kustomization.yaml
+++ b/infrastructure/gcp/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - cleaners
   - terraform
   - compute-classes
+  - storage-classes

--- a/infrastructure/gcp/storage-classes/ci-rwo.yaml
+++ b/infrastructure/gcp/storage-classes/ci-rwo.yaml
@@ -1,0 +1,14 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ci-rwo
+  labels:
+    app.kubernetes.io/managed-by: fluxcd
+allowVolumeExpansion: true
+parameters:
+  provisioned-iops-on-create: "10000"
+  provisioned-throughput-on-create: 400Mi
+  type: hyperdisk-balanced
+provisioner: pd.csi.storage.gke.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/infrastructure/gcp/storage-classes/kustomization.yaml
+++ b/infrastructure/gcp/storage-classes/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ci-rwo.yaml

--- a/infrastructure/tencentcloud/kustomization.yaml
+++ b/infrastructure/tencentcloud/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - cleaners
   - gateways
   - operators
+  - storage-classes

--- a/infrastructure/tencentcloud/storage-classes/ci-rwo.yaml
+++ b/infrastructure/tencentcloud/storage-classes/ci-rwo.yaml
@@ -1,0 +1,12 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ci-rwo
+  labels:
+    app.kubernetes.io/managed-by: fluxcd
+allowVolumeExpansion: true
+parameters:
+  type: CLOUD_HSSD
+provisioner: com.tencent.cloud.csi.cbs
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/infrastructure/tencentcloud/storage-classes/kustomization.yaml
+++ b/infrastructure/tencentcloud/storage-classes/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ci-rwo.yaml


### PR DESCRIPTION
## What

Add a unified `ci-rwo` StorageClass to both the GCP and TencentCloud clusters, so CI manifests can reference a stable, cluster-agnostic storage class name.

- GCP: `infrastructure/gcp/storage-classes/ci-rwo.yaml` — copied from the existing `hyperdisk-rwo` (hyperdisk-balanced, 10000 IOPS / 400Mi provisioned), wired into `infrastructure/gcp/kustomization.yaml`
- TencentCloud: `infrastructure/tencentcloud/storage-classes/ci-rwo.yaml` — CBS (Tencent Cloud Block Storage) CSI driver with `CLOUD_HSSD` disk type, wired into `infrastructure/tencentcloud/kustomization.yaml`

## Why

GKE only ships `standard-rwo`/`standard`/`premium-rwo`/`dynamic-rwo` by default; `hyperdisk-rwo` is cluster-specific and absent on newly created clusters (verified with a fresh 1.35 cluster). Relying on cluster defaults or cluster-specific names makes CI configs drift across clusters. A unified `ci-rwo` name lets the CI repo reference one name everywhere while each cluster maps it to its best available disk type.

## Related

- Follow-up in PingCAP-QE/ci: replace `hyperdisk-rwo` references with `ci-rwo` and add a storage-class policy verification.
